### PR TITLE
for nextest action, use version in URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,9 @@ jobs:
         tool:
           # Note: Specifying the version of valgrind and wasm-pack is not supported.
           - cargo-hack,cargo-llvm-cov,cargo-minimal-versions,parse-changelog,cross,nextest,shellcheck,shfmt,valgrind,wasm-pack,wasmtime
-          - cargo-hack@0.5.12,cargo-llvm-cov@0.2.4,cargo-minimal-versions@0.1.3,parse-changelog@0.4.7,cross@0.2.1,shellcheck@0.8.0,shfmt@3.4.3,wasmtime@0.35.1
+          - cargo-hack@0.5.12,cargo-llvm-cov@0.2.4,cargo-minimal-versions@0.1.3,parse-changelog@0.4.7,cross@0.2.1,nextest@0.9.11,shellcheck@0.8.0,shfmt@3.4.3,wasmtime@0.35.1
+          # Nextest supports basic version ranges as well
+          - nextest@0.9
         include:
           - os: macos-10.15
             tool: cargo-hack,cargo-llvm-cov,cargo-minimal-versions,parse-changelog,cross,nextest,shellcheck,shfmt,wasm-pack,wasmtime

--- a/main.sh
+++ b/main.sh
@@ -102,14 +102,10 @@ for tool in "${tools[@]}"; do
         nextest)
             # https://nexte.st/book/pre-built-binaries.html
             case "${OSTYPE}" in
-                linux*) url="https://get.nexte.st/latest/linux" ;;
-                darwin*) url="https://get.nexte.st/latest/mac" ;;
-                cygwin* | msys*) url="https://get.nexte.st/latest/windows-tar" ;;
+                linux*) url="https://get.nexte.st/${version}/linux" ;;
+                darwin*) url="https://get.nexte.st/${version}/mac" ;;
+                cygwin* | msys*) url="https://get.nexte.st/${version}/windows-tar" ;;
                 *) bail "unsupported OSTYPE '${OSTYPE}' for ${tool}" ;;
-            esac
-            case "${version}" in
-                latest) ;;
-                *) warn "specifying the version of ${tool} is not supported yet by this action" ;;
             esac
             # shellcheck disable=SC2086
             retry curl --proto '=https' --tlsv1.2 -fsSL --retry 10 --retry-connrefused "${url}" \


### PR DESCRIPTION
Thanks for adding support for this

Nextest lets you specify the version in its URL. It also supports basic version ranges (e.g. 0.9, or later 1).

After this lands I'm going to point folks to this action as the recommended way to install nextest in GHA. Thanks again!