### PR TITLE
Add support for `mdbook`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
       - main
       - dev
   schedule:
-    - cron: "0 0 * * *"
+    - cron: '0 0 * * *'
   workflow_dispatch:
 
 defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,13 +27,13 @@ jobs:
           - ubuntu-20.04
         tool:
           # Note: Specifying the version of valgrind and wasm-pack is not supported.
-          - cargo-hack,cargo-llvm-cov,cargo-minimal-versions,parse-changelog,cross,nextest,shellcheck,shfmt,valgrind,wasm-pack,wasmtime
-          - cargo-hack@0.5.12,cargo-llvm-cov@0.2.4,cargo-minimal-versions@0.1.3,parse-changelog@0.4.7,cross@0.2.1,nextest@0.9.11,shellcheck@0.8.0,shfmt@3.4.3,wasmtime@0.35.1
+          - cargo-hack,cargo-llvm-cov,cargo-minimal-versions,parse-changelog,cross,nextest,shellcheck,shfmt,valgrind,wasm-pack,wasmtime,mdbook
+          - cargo-hack@0.5.12,cargo-llvm-cov@0.2.4,cargo-minimal-versions@0.1.3,parse-changelog@0.4.7,cross@0.2.1,nextest@0.9.11,shellcheck@0.8.0,shfmt@3.4.3,wasmtime@0.35.1,mdbook@0.4.17
           # Nextest supports basic version ranges as well
           - nextest@0.9
         include:
           - os: macos-10.15
-            tool: cargo-hack,cargo-llvm-cov,cargo-minimal-versions,parse-changelog,cross,nextest,shellcheck,shfmt,wasm-pack,wasmtime
+            tool: cargo-hack,cargo-llvm-cov,cargo-minimal-versions,parse-changelog,cross,nextest,shellcheck,shfmt,wasm-pack,wasmtime,mdbook
           - os: windows-2019
             tool: cargo-hack,cargo-llvm-cov,cargo-minimal-versions,parse-changelog,cross,nextest
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
       - main
       - dev
   schedule:
-    - cron: '0 0 * * *'
+    - cron: "0 0 * * *"
   workflow_dispatch:
 
 defaults:
@@ -23,7 +23,6 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-18.04
           - ubuntu-20.04
         tool:
           # Note: Specifying the version of valgrind and wasm-pack is not supported.
@@ -32,6 +31,12 @@ jobs:
           # Nextest supports basic version ranges as well
           - nextest@0.9
         include:
+          # Note: mdBook binary is incompatible with ubuntu 18.04,
+          # see https://github.com/rust-lang/mdBook/issues/1779
+          - os: ubuntu-18.04
+            tool: cargo-hack,cargo-llvm-cov,cargo-minimal-versions,parse-changelog,cross,nextest,shellcheck,shfmt,valgrind,wasm-pack,wasmtime
+          - os: ubuntu-18.04
+            tool: cargo-hack@0.5.12,cargo-llvm-cov@0.2.4,cargo-minimal-versions@0.1.3,parse-changelog@0.4.7,cross@0.2.1,nextest@0.9.11,shellcheck@0.8.0,shfmt@3.4.3,wasmtime@0.35.1
           - os: macos-10.15
             tool: cargo-hack,cargo-llvm-cov,cargo-minimal-versions,parse-changelog,cross,nextest,shellcheck,shfmt,wasm-pack,wasmtime,mdbook
           - os: windows-2019

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ https://spdx.org/licenses
 | [**valgrind**](https://valgrind.org) | `/snap/bin` | [snap](https://snapcraft.io/install/valgrind/ubuntu) | Linux | [GPL-2.0-or-later](https://valgrind.org/docs/manual/license.gpl.html) |
 | [**wasm-pack**](https://github.com/rustwasm/wasm-pack) | `~/.cargo/bin` | [GitHub Releases](https://github.com/rustwasm/wasm-pack/releases) | Linux, macOS | [Apache-2.0](https://github.com/rustwasm/wasm-pack/blob/HEAD/LICENSE-APACHE) OR [MIT](https://github.com/rustwasm/wasm-pack/blob/HEAD/LICENSE-MIT) |
 | [**wasmtime**](https://github.com/bytecodealliance/wasmtime) | `~/.cargo/bin` | [GitHub Releases](https://github.com/bytecodealliance/wasmtime/releases) | Linux, macOS | [Apache-2.0 WITH LLVM-exception](https://github.com/bytecodealliance/wasmtime/blob/HEAD/LICENSE) |
+| [**mdbook**](https://github.com/rust-lang/mdBook) | `~/.cargo/bin` | [GitHub Releases](https://github.com/rust-lang/mdBook/releases) | Linux, macOS | [MPL-2.0](https://github.com/rust-lang/mdBook/blob/master/LICENSE) |
 
 <!-- TODO:
 | [**cmake**](https://cmake.org) | | [GitHub Releases](https://github.com/Kitware/CMake/releases) | Linux, macOS, Windows | [BSD-3-Clause](https://github.com/Kitware/CMake/blob/HEAD/Copyright.txt) |

--- a/main.sh
+++ b/main.sh
@@ -194,6 +194,25 @@ for tool in "${tools[@]}"; do
             retry curl --proto '=https' --tlsv1.2 -fsSL --retry 10 --retry-connrefused "${url}" \
                 | tar xJf - --strip-components 1 -C ${CARGO_HOME:-~/.cargo}/bin "wasmtime-v${version}-${target}/wasmtime"
             ;;
+        mdbook)
+            # https://github.com/rust-lang/mdBook/releases
+            latest_version="0.4.17"
+            repo="rust-lang/mdBook"
+            case "${OSTYPE}" in
+                linux*) target="x86_64-unknown-linux-gnu" ;;
+                darwin*) target="x86_64-apple-darwin" ;;
+                # TODO: mdbook has windows binaries, but they use `.zip` and not `.tar.gz`.
+                cygwin* | msys*) bail "${tool} for windows is not supported yet by this action" ;;
+                *) bail "unsupported OSTYPE '${OSTYPE}' for ${tool}" ;;
+            esac
+            case "${version}" in
+                latest) version="${latest_version}" ;;
+            esac
+            url="https://github.com/${repo}/releases/download/v${version}/${tool}-v${version}-${target}.tar.gz"
+            # shellcheck disable=SC2086
+            retry curl --proto '=https' --tlsv1.2 -fsSL --retry 10 --retry-connrefused "${url}" \
+                | tar xzf - -C ${CARGO_HOME:-~/.cargo}/bin
+            ;;
         *) bail "unsupported tool '${tool}'" ;;
     esac
 

--- a/tools/publish.sh
+++ b/tools/publish.sh
@@ -88,6 +88,7 @@ tools=(
     valgrind
     wasm-pack
     wasmtime
+    mdbook
 )
 
 (


### PR DESCRIPTION
It would be nice to support `mdbook` here, and seems simple as it has prebuilt binaries on github releases: https://github.com/rust-lang/mdBook/releases. I'm hoping that `mdbook` meets whatever threshold you want for usefulness. (At the very least, it's part of the `rust-lang` org, so it should be reasonably trustworthy)

I tried to follow the patterns used for the others, but have not really tested it beyond ensuring that if I run the lines individually that they seem to work. So I'm hoping that the CI handles this for me 🤞.

Also, this just adds Linux/macOS, since Windows support seems like a hassle (or, I'm not quite good enough at `sh` to know a clean way to do it, nor do I have a windows box to check against).

P.S. Thanks for this action, it's really cool.