### PR TITLE
Bump `cargo-binstall` to v0.16.0

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -80,7 +80,7 @@ host_triple() {
 }
 install_cargo_binstall() {
     # https://github.com/cargo-bins/cargo-binstall/releases
-    binstall_version="0.14.0"
+    binstall_version="0.16.0"
     install_binstall='1'
     if [[ -f "${cargo_bin}/cargo-binstall${exe}" ]]; then
         if [[ "$(cargo binstall -V)" == "cargo-binstall ${binstall_version}" ]]; then


### PR DESCRIPTION
Here's the release log: https://github.com/cargo-bins/cargo-binstall/releases/tag/v0.16.0