### PR TITLE
Pass --locked to cargo-binstall

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -583,5 +583,5 @@ if [[ ${#unsupported_tools[@]} -gt 0 ]]; then
     # By default, cargo-binstall enforce downloads over secure transports only.
     # As a result, http will be disabled, and it will also set
     # min tls version to be 1.2
-    cargo binstall --force --no-confirm "${unsupported_tools[@]}"
+    cargo binstall --force --no-confirm --locked "${unsupported_tools[@]}"
 fi


### PR DESCRIPTION
So that if taiki-e/install-action fallback to cargo-install, it will use the lockfile instead of latest version for every dep to ensure the compilation succeeds.