### PR TITLE
codegen: Prevent yanked version from being selected as candidate for latest or omitted version

### DIFF
--- a/tools/codegen/Cargo.toml
+++ b/tools/codegen/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 anyhow = "1"
 fs-err = "2"
-semver = "1"
+semver = { version = "1", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"


### PR DESCRIPTION
Implement the first one in https://github.com/taiki-e/install-action/issues/178#issuecomment-1663273376

> I think it is possible to fetch the crates.io API during manifest generation to prevent the yanked version from being selected as a candidate for the latest or omitted version. This is not likely to very help this case, where the problem was resolved very quickly on the nextest side, since it is not reflected until the manifest update is released, but it would be helpful if the fix is not released quickly. It will also make the way described below more efficient.

