### PR TITLE
Fetch crates.io API during installation and install older version if latest version is yanked

### DIFF
--- a/manifests/cargo-careful.json
+++ b/manifests/cargo-careful.json
@@ -18,6 +18,7 @@
     "version": "0.3.4"
   },
   "0.3.4": {
+    "previous_stable_version": "0.3.3",
     "x86_64_linux_musl": {
       "checksum": "a9cfc7775546bd646a9e9252527c5caa56c429d854c6d8664ab4d63ed87827bd"
     },

--- a/manifests/cargo-deny.json
+++ b/manifests/cargo-deny.json
@@ -25,6 +25,7 @@
     "version": "0.14.1"
   },
   "0.14.1": {
+    "previous_stable_version": "0.14.0",
     "x86_64_linux_musl": {
       "checksum": "913928cabbf80d2a237de6ffe47bdcba49434f8f08f9680f8a3a27b4ebc30832"
     },
@@ -39,6 +40,7 @@
     }
   },
   "0.14.0": {
+    "previous_stable_version": "0.13.9",
     "x86_64_linux_musl": {
       "checksum": "85dee04c86104c84f83b344f29ba3f9e0b57b64da011c478e1e4a677cd59baa0"
     },
@@ -56,6 +58,7 @@
     "version": "0.13.9"
   },
   "0.13.9": {
+    "previous_stable_version": "0.13.8",
     "x86_64_linux_musl": {
       "checksum": "77f6b3feab12afc82638cd4c6197c983d249d1afa4180a6b9c933efbf8bff427"
     },
@@ -70,6 +73,7 @@
     }
   },
   "0.13.8": {
+    "previous_stable_version": "0.13.7",
     "x86_64_linux_musl": {
       "checksum": "95b2b7eacc1e93b918969e8d9f25dad49ce079511401308b548f5fceeafeb896"
     },
@@ -84,6 +88,7 @@
     }
   },
   "0.13.7": {
+    "previous_stable_version": "0.13.6",
     "x86_64_linux_musl": {
       "checksum": "0e20f4302c1054a3f1a8e0e22eb15cfa3173c0e2dcbb62cfe7d6fe40dc27abd9"
     },
@@ -98,6 +103,7 @@
     }
   },
   "0.13.6": {
+    "previous_stable_version": "0.13.5",
     "x86_64_linux_musl": {
       "checksum": "400142c52fa30b5718bd260c27937c66709bc3d1d7dcf152131e00c625be67ce"
     },
@@ -112,6 +118,7 @@
     }
   },
   "0.13.5": {
+    "previous_stable_version": "0.13.4",
     "x86_64_linux_musl": {
       "checksum": "339014366d1ea1137fe425b35b7c0fb3b3c8a54f9bfb2b470f52cbb1a7904e17"
     },
@@ -126,6 +133,7 @@
     }
   },
   "0.13.4": {
+    "previous_stable_version": "0.13.3",
     "x86_64_linux_musl": {
       "checksum": "85a1a30f9d337bff504b6530c2328e01a96484d48494c9dec8352516229bfd1d"
     },
@@ -140,6 +148,7 @@
     }
   },
   "0.13.3": {
+    "previous_stable_version": "0.13.2",
     "x86_64_linux_musl": {
       "checksum": "54988b975f7b914e6178031fa55ebb59dc1f25008c7b3ddebc4494456d538f18"
     },
@@ -154,6 +163,7 @@
     }
   },
   "0.13.2": {
+    "previous_stable_version": "0.13.1",
     "x86_64_linux_musl": {
       "checksum": "cbdd95a6d5b2e308d0189210e02152153bf2181b045c73058e4db842ae02162d"
     },
@@ -168,6 +178,7 @@
     }
   },
   "0.13.1": {
+    "previous_stable_version": "0.13.0",
     "x86_64_linux_musl": {
       "checksum": "55fd1cea05b91f53e373352f168d8bd4ed8523bde70aa5e60a039c589e491eac"
     },
@@ -182,6 +193,7 @@
     }
   },
   "0.13.0": {
+    "previous_stable_version": "0.12.2",
     "x86_64_linux_musl": {
       "checksum": "bb9139a7c9d01bd5de3c389563edc20bf562decdb54dd1bf57e5370a25400938"
     },
@@ -199,6 +211,7 @@
     "version": "0.12.2"
   },
   "0.12.2": {
+    "previous_stable_version": "0.12.1",
     "x86_64_linux_musl": {
       "checksum": "2f5d9da751bfe291495e51937c74473850e101c26e52c3ab667b0d1a5d5e8d65"
     },
@@ -213,6 +226,7 @@
     }
   },
   "0.12.1": {
+    "previous_stable_version": "0.12.0",
     "x86_64_linux_musl": {
       "checksum": "fd6b38cf813bd112916f01e7b13169a03c29b46fe044e9360f84c0adbc301bed"
     },
@@ -227,6 +241,7 @@
     }
   },
   "0.12.0": {
+    "previous_stable_version": "0.11.4",
     "x86_64_linux_musl": {
       "checksum": "38eb55610be0408996e2f36b24aadaaa0ec8fc27ddbeab137774dc3c78d42267"
     },
@@ -244,6 +259,7 @@
     "version": "0.11.4"
   },
   "0.11.4": {
+    "previous_stable_version": "0.11.3",
     "x86_64_linux_musl": {
       "checksum": "868d7b4ff4e0aa900896626fddc5dbbb0df84c5a61beb1a3e1dd5b8457d3b413"
     },
@@ -258,6 +274,7 @@
     }
   },
   "0.11.3": {
+    "previous_stable_version": "0.11.2",
     "x86_64_linux_musl": {
       "checksum": "ffed77d73b5f76b6a7b200a939b6215bde55b0e59ab3294ad8518ddb01c49f09"
     },
@@ -272,6 +289,7 @@
     }
   },
   "0.11.2": {
+    "previous_stable_version": "0.11.1",
     "x86_64_linux_musl": {
       "checksum": "125b7df67dd25a4a3d9c012c036030d62d022a0b73a83b79c3f6fdc0d464288c"
     },
@@ -286,6 +304,7 @@
     }
   },
   "0.11.1": {
+    "previous_stable_version": "0.11.0",
     "x86_64_linux_musl": {
       "checksum": "caefe6e981ebe842af69a0338a3e1fe80bc3bb0be6199720a039429477778f70"
     },
@@ -300,6 +319,7 @@
     }
   },
   "0.11.0": {
+    "previous_stable_version": "0.10.3",
     "x86_64_linux_musl": {
       "checksum": "bdac664b436fd8501b3bea5461bbf8566086ab0cf5555d83178c3209a848f9f8"
     },
@@ -317,6 +337,7 @@
     "version": "0.10.3"
   },
   "0.10.3": {
+    "previous_stable_version": "0.10.2",
     "x86_64_linux_musl": {
       "checksum": "ac31f6dc5d8379568b047ed7718bf283db76e5895283c534f1ab348533c4f0c9"
     },
@@ -331,6 +352,7 @@
     }
   },
   "0.10.2": {
+    "previous_stable_version": "0.10.1",
     "x86_64_linux_musl": {
       "checksum": "9c27bb092ad67c7ca86c8585801e9fe48f2b273d5730b9f1188d3720aa4e4642"
     },
@@ -345,6 +367,7 @@
     }
   },
   "0.10.1": {
+    "previous_stable_version": "0.10.0",
     "x86_64_linux_musl": {
       "checksum": "66d60ca20e0bcfcfcb55ac157853f92526c268445f5f673c2aa2345a8e09ece4"
     },
@@ -359,6 +382,7 @@
     }
   },
   "0.10.0": {
+    "previous_stable_version": "0.9.1",
     "x86_64_linux_musl": {
       "checksum": "77d50bea7f20961dccb7133e61a3e2d75411870c1c377f56f6b01f6e9e1139ef"
     },
@@ -376,6 +400,7 @@
     "version": "0.9.1"
   },
   "0.9.1": {
+    "previous_stable_version": "0.9.0",
     "x86_64_linux_musl": {
       "checksum": "a2dc10ca868120f67b232d6687c60dda50f285508886b0aff26a80e9cfab524e"
     },
@@ -390,6 +415,7 @@
     }
   },
   "0.9.0": {
+    "previous_stable_version": "0.8.9",
     "x86_64_linux_musl": {
       "checksum": "f52840198cdc9d62875f475ecfdf92feba94de12442c71f77c3a9d5681bf269d"
     },
@@ -404,6 +430,7 @@
     "version": "0.8.9"
   },
   "0.8.9": {
+    "previous_stable_version": "0.8.8",
     "x86_64_linux_musl": {
       "checksum": "d618d65652765872e8a4448f16e706fafeb47e9fc021dc059eed52a0f5aba6f4"
     },
@@ -415,6 +442,7 @@
     }
   },
   "0.8.8": {
+    "previous_stable_version": "0.8.7",
     "x86_64_linux_musl": {
       "checksum": "1b3a2c8caabfc60c59f2e93361574dd583374ff73bf9b866d5680156c2cb3783"
     },
@@ -426,6 +454,7 @@
     }
   },
   "0.8.7": {
+    "previous_stable_version": "0.8.5",
     "x86_64_linux_musl": {
       "checksum": "38186e163b1428aa2bd6c2a2000de280f5f401d653a461f278b2856ac86340a1"
     },
@@ -437,6 +466,7 @@
     }
   },
   "0.8.5": {
+    "previous_stable_version": "0.8.4",
     "x86_64_linux_musl": {
       "checksum": "87f4f80d313ce5115862ca4f73cdefad085df71d99522a3d4a6de6dd3d4f787d"
     },
@@ -448,6 +478,7 @@
     }
   },
   "0.8.4": {
+    "previous_stable_version": "0.8.3",
     "x86_64_linux_musl": {
       "checksum": "aa1cab0ab3687b05dd76fa003e0134171704b0019626ef6d70f1c0dbd5524be1"
     },
@@ -459,6 +490,7 @@
     }
   },
   "0.8.3": {
+    "previous_stable_version": "0.8.2",
     "x86_64_linux_musl": {
       "checksum": "a0a54ae2a7003565de31fd1d434ef969f05f36e51975275430feda88612158c3"
     },
@@ -470,6 +502,7 @@
     }
   },
   "0.8.2": {
+    "previous_stable_version": "0.8.1",
     "x86_64_linux_musl": {
       "checksum": "8258c8bc6d6a1b9e45daab7edb4ec2f876c201e2f5263f09f0f6d81a0de98fa8"
     },
@@ -481,6 +514,7 @@
     }
   },
   "0.8.1": {
+    "previous_stable_version": "0.8.0",
     "x86_64_linux_musl": {
       "checksum": "f4e17311f684d8908460c3267afae40156b3c76e0acf54416b21915a7431eb8a"
     },
@@ -492,6 +526,7 @@
     }
   },
   "0.8.0": {
+    "previous_stable_version": "0.7.3",
     "x86_64_linux_musl": {
       "checksum": "82865e614a278b17cde1e171ce03bb2e97f4039b0f3098c9daa4d303dc738dcb"
     },
@@ -506,6 +541,7 @@
     "version": "0.7.3"
   },
   "0.7.3": {
+    "previous_stable_version": "0.7.2",
     "x86_64_linux_musl": {
       "checksum": "5456fed7c90f8658c085fac6a602f495fbb6107b62c9f8f54e90cad4ea33a61b"
     },
@@ -517,6 +553,7 @@
     }
   },
   "0.7.2": {
+    "previous_stable_version": "0.7.1",
     "x86_64_linux_musl": {
       "checksum": "0a3c009e0e6776da40ad0bbf362ed08d048e21e6275b04bc8163f5cbc5b6f3c9"
     },
@@ -528,6 +565,7 @@
     }
   },
   "0.7.1": {
+    "previous_stable_version": "0.7.0",
     "x86_64_linux_musl": {
       "checksum": "a1a6e388f101fc1063e2b70bcf631f7d3e736a46bbdf58a1078a847504d2e484"
     },
@@ -539,6 +577,7 @@
     }
   },
   "0.7.0": {
+    "previous_stable_version": "0.6.8",
     "x86_64_linux_musl": {
       "checksum": "5c9a61652c167ab41f1ef137450dfa2d690c110b1d464be145b50849ed43ae4a"
     },
@@ -553,6 +592,7 @@
     "version": "0.6.8"
   },
   "0.6.8": {
+    "previous_stable_version": "0.6.7",
     "x86_64_linux_musl": {
       "checksum": "c68bc8346f0da424beff7c49f63b3383a2828c5fbe6c4be72a34e7a8c4eeb69e"
     },
@@ -564,6 +604,7 @@
     }
   },
   "0.6.7": {
+    "previous_stable_version": "0.6.6",
     "x86_64_linux_musl": {
       "checksum": "09ca45edf08d2973f11a82ee646c6a06043a573a7b3b790ee3d810776c58d694"
     },
@@ -575,6 +616,7 @@
     }
   },
   "0.6.6": {
+    "previous_stable_version": "0.6.5",
     "x86_64_linux_musl": {
       "checksum": "41e2e71b7b07cd68e1275d694b1646c0c2873e40f4f809f29d88467b6a1e3c21"
     },
@@ -586,6 +628,7 @@
     }
   },
   "0.6.5": {
+    "previous_stable_version": "0.6.4",
     "x86_64_linux_musl": {
       "checksum": "c4f49b651d45f83e38b335941a204ddcae6506efef392820352f85cf989b517e"
     },
@@ -594,6 +637,7 @@
     }
   },
   "0.6.4": {
+    "previous_stable_version": "0.6.3",
     "x86_64_linux_musl": {
       "checksum": "6ca1e7630895506785a6a454d054a18b2183b4b101f67e6fd4f069bc78d2ae79"
     },
@@ -605,6 +649,7 @@
     }
   },
   "0.6.3": {
+    "previous_stable_version": "0.6.2",
     "x86_64_linux_musl": {
       "checksum": "75f18d80816403b5cd011886f98af1ae5bea43b1a3143e1ffdc4ef7ddfdaa568"
     },
@@ -616,6 +661,7 @@
     }
   },
   "0.6.2": {
+    "previous_stable_version": "0.6.1",
     "x86_64_linux_musl": {
       "checksum": "6d83095e51090b204c8ebbc270621c97614c49d1042289d418421ec586ef3114"
     },
@@ -627,6 +673,7 @@
     }
   },
   "0.6.1": {
+    "previous_stable_version": "0.6.0",
     "x86_64_linux_musl": {
       "checksum": "3c60ca31578f980d13993183772f352491eba3b7b959fc26d31a1f817879a990"
     },
@@ -638,6 +685,7 @@
     }
   },
   "0.6.0": {
+    "previous_stable_version": "0.5.2",
     "x86_64_linux_musl": {
       "checksum": "4712c9edc0a69a63a219ebeb43a4f5514239840202160f59d8445fa8f5e77683"
     },
@@ -652,6 +700,7 @@
     "version": "0.5.2"
   },
   "0.5.2": {
+    "previous_stable_version": "0.5.1",
     "x86_64_linux_musl": {
       "checksum": "70f02a7e56c0a7c0e0602ee1b0914af94737e9abc140173dbea3124849682b60"
     },
@@ -663,6 +712,7 @@
     }
   },
   "0.5.1": {
+    "previous_stable_version": "0.5.0",
     "x86_64_linux_musl": {
       "checksum": "cd8a96b562fff40d787db6da0e3c7adc70e2af720b985ec16187b02e9de96340"
     },
@@ -674,6 +724,7 @@
     }
   },
   "0.5.0": {
+    "previous_stable_version": "0.4.2",
     "x86_64_linux_musl": {
       "checksum": "4534b0b542994e940e0725bb28a43e4c3a3502b3b0df9056dc654532e3fdbcbe"
     },
@@ -688,6 +739,7 @@
     "version": "0.4.2"
   },
   "0.4.2": {
+    "previous_stable_version": "0.4.1",
     "x86_64_linux_musl": {
       "checksum": "400edab6e6f66927c8f929dcab3e48a7f3017ceaeba7aee12c992ad33b84bdce"
     },
@@ -699,6 +751,7 @@
     }
   },
   "0.4.1": {
+    "previous_stable_version": "0.4.0",
     "x86_64_linux_musl": {
       "checksum": "edced8daedf5169ceb8ad39aa1752e738eaf7f285c88cc8807a21324f52f431c"
     },
@@ -710,6 +763,7 @@
     }
   },
   "0.4.0": {
+    "previous_stable_version": "0.3.0",
     "x86_64_linux_musl": {
       "checksum": "c747832e99506a8dc02bb7f7ce8a00c51e9d4aa8a93087bedecc444cc5a5c8ec"
     },
@@ -724,6 +778,7 @@
     "version": "0.3.0"
   },
   "0.3.0": {
+    "previous_stable_version": "0.2.6",
     "x86_64_linux_musl": {
       "checksum": "f0a6462663b1f92a87ecadcea96352c0aa01bcbd80e13ac3a3a1422f771d981e"
     },
@@ -738,6 +793,7 @@
     "version": "0.2.6"
   },
   "0.2.6": {
+    "previous_stable_version": "0.2.5",
     "x86_64_linux_musl": {
       "checksum": "d4860faf38a5e47c3783c7e76deb5858e809b95de154df5ce057119bb0dd7622"
     },
@@ -749,6 +805,7 @@
     }
   },
   "0.2.5": {
+    "previous_stable_version": "0.2.3",
     "x86_64_linux_musl": {
       "checksum": "6e0191cd70315532e87d8f326f0895521ab88b97613cbd97033385a87dd2c5c3"
     },
@@ -760,6 +817,7 @@
     }
   },
   "0.2.3": {
+    "previous_stable_version": "0.2.2",
     "x86_64_linux_musl": {
       "checksum": "cb3cf9056123bf93b1715d4c0d01d22b7cbe652204ef3e3a5e3bf24fd389c420"
     },
@@ -771,6 +829,7 @@
     }
   },
   "0.2.2": {
+    "previous_stable_version": "0.2.1",
     "x86_64_linux_musl": {
       "checksum": "f55ec16db6f5d41312d2352db6d6aaa43c47f24a37982c8adc52ad4997ede488"
     },
@@ -782,6 +841,7 @@
     }
   },
   "0.2.1": {
+    "previous_stable_version": "0.2.0",
     "x86_64_linux_musl": {
       "checksum": "0003322bd2f1e33d8b9261ef21cf4947935d590aa1d8290a4cdec394e8c48d3a"
     },

--- a/manifests/cargo-dinghy.json
+++ b/manifests/cargo-dinghy.json
@@ -17,6 +17,7 @@
     "version": "0.6.4"
   },
   "0.6.4": {
+    "previous_stable_version": "0.6.3",
     "x86_64_linux_musl": {
       "checksum": "b1453cff8f0f65f09312e88306e64e4c55bba5fb6daec5d8df1ab0ca4acef97f"
     },
@@ -25,6 +26,7 @@
     }
   },
   "0.6.3": {
+    "previous_stable_version": "0.6.2",
     "x86_64_linux_musl": {
       "checksum": "4faa2b0ba479222284f90885f66d0afc97ecee4e2b234042912a451fbd7b8dc8"
     },
@@ -33,6 +35,7 @@
     }
   },
   "0.6.2": {
+    "previous_stable_version": "0.6.1",
     "x86_64_linux_musl": {
       "checksum": "b6cd5b91e61a14befa3260802bb387ef6b8deba78dad0fd8ab80d487319140e9"
     },
@@ -41,6 +44,7 @@
     }
   },
   "0.6.1": {
+    "previous_stable_version": "0.6.0",
     "x86_64_linux_musl": {
       "checksum": "1016d349f40f54332ba7269926d4e1a56295bb54c27fc0ff5b137d68f6ffa6d4"
     },
@@ -49,6 +53,7 @@
     }
   },
   "0.6.0": {
+    "previous_stable_version": "0.5.1",
     "x86_64_linux_musl": {
       "checksum": "3755cd6187bf8192f359809143c080618acf9777a0d7a3351ecde6f67a4cfc47"
     },
@@ -60,6 +65,7 @@
     "version": "0.5.1"
   },
   "0.5.1": {
+    "previous_stable_version": "0.5.0",
     "x86_64_linux_musl": {
       "checksum": "ded1f77c4514d763977eabe069fa62625745098715c54ad8427502557c412f05"
     },
@@ -68,6 +74,7 @@
     }
   },
   "0.5.0": {
+    "previous_stable_version": "0.4.71",
     "x86_64_linux_musl": {
       "checksum": "e1f65a240c6e3587cd661d3b004e5af3da9f2b9c4e44f465e87f3717371d05fa"
     },
@@ -79,6 +86,7 @@
     "version": "0.4.71"
   },
   "0.4.71": {
+    "previous_stable_version": "0.4.70",
     "x86_64_linux_musl": {
       "checksum": "64115114488ffc8b7006d2f9f35d19baba6e3acd2292133aac2dd64d24e59d99"
     },
@@ -87,6 +95,7 @@
     }
   },
   "0.4.70": {
+    "previous_stable_version": "0.4.69",
     "x86_64_linux_musl": {
       "checksum": "880ea253cdf3b989e9b45dba36e66abf9fa358bd805cdfced57437099eb00d21"
     },
@@ -95,6 +104,7 @@
     }
   },
   "0.4.69": {
+    "previous_stable_version": "0.4.68",
     "x86_64_linux_musl": {
       "checksum": "b42985472ff399a6e00e1590cbc6dbe576b6a1c23bf36e9369898ba7152c72ff"
     },
@@ -103,6 +113,7 @@
     }
   },
   "0.4.68": {
+    "previous_stable_version": "0.4.67",
     "x86_64_linux_musl": {
       "checksum": "8b17bbe806b459ac7f2692d1df9bdec5fabdc46513cb45f620b0a4124d0c8bdb"
     },
@@ -111,6 +122,7 @@
     }
   },
   "0.4.67": {
+    "previous_stable_version": "0.4.66",
     "x86_64_linux_musl": {
       "checksum": "e4175dbcb96abacdceee60055495e315bd065cbf66a3741ef7294f1d9b944448"
     },
@@ -119,6 +131,7 @@
     }
   },
   "0.4.66": {
+    "previous_stable_version": "0.4.63",
     "x86_64_linux_musl": {
       "checksum": "10664353ce1ed10cefdf766bd9acbb9c357497011d11f281ba1d3ec24eb8a7f7"
     },
@@ -127,6 +140,7 @@
     }
   },
   "0.4.63": {
+    "previous_stable_version": "0.4.62",
     "x86_64_linux_musl": {
       "checksum": "bbd791675e71e5ba4165d0fbde08c1572fa3771f12169b29831ff43b212578b2"
     },
@@ -135,6 +149,7 @@
     }
   },
   "0.4.62": {
+    "previous_stable_version": "0.4.61",
     "x86_64_linux_musl": {
       "checksum": "2da0eb7a004344a845010ecbe10a92b1ea1576ea0c98cd57836fc0ce4855b675"
     },
@@ -143,6 +158,7 @@
     }
   },
   "0.4.61": {
+    "previous_stable_version": "0.4.60",
     "x86_64_linux_musl": {
       "checksum": "8d1db2698c9684b000e1e0df4675a5db28228c97c6b8a15240c4498af4575005"
     },
@@ -151,6 +167,7 @@
     }
   },
   "0.4.60": {
+    "previous_stable_version": "0.4.59",
     "x86_64_linux_musl": {
       "checksum": "9881f4de90449c9251dbb9eeab85b7d73fb3c52219e0c044aa38afa6da7c0c86"
     },
@@ -159,6 +176,7 @@
     }
   },
   "0.4.59": {
+    "previous_stable_version": "0.4.57",
     "x86_64_linux_musl": {
       "checksum": "3d406ad00263c207ef339f570f8b2dc4a70bb040b11f81cbc4f61b8fa485d63a"
     },
@@ -167,6 +185,7 @@
     }
   },
   "0.4.57": {
+    "previous_stable_version": "0.4.55",
     "x86_64_linux_musl": {
       "checksum": "a15252b2c0707c627a5b24ac3d21754046098ddbbc1b792fc981f844cbf74786"
     },
@@ -175,6 +194,7 @@
     }
   },
   "0.4.55": {
+    "previous_stable_version": "0.4.51",
     "x86_64_linux_musl": {
       "checksum": "a1eb166f015cb1a07e48e2bd44ec15bd370cf9f8a3d40d243f8ec35e71df983f"
     },
@@ -183,6 +203,7 @@
     }
   },
   "0.4.51": {
+    "previous_stable_version": "0.4.50",
     "x86_64_linux_musl": {
       "checksum": "314d220264417960539db8a9cb1e8b81d010acc64e1d3e8bfcd3415608cea857"
     },
@@ -191,6 +212,7 @@
     }
   },
   "0.4.50": {
+    "previous_stable_version": "0.4.48",
     "x86_64_linux_musl": {
       "checksum": "6c885144ace5e9a064d5f201b8836418ce511266335eb56e72f6cfee3377abae"
     },
@@ -199,6 +221,7 @@
     }
   },
   "0.4.48": {
+    "previous_stable_version": "0.4.47",
     "x86_64_linux_musl": {
       "checksum": "a5ba0ff38a074edf9b16e1d10a550b567236953c11f2f92414b56877364bf02e"
     },
@@ -207,6 +230,7 @@
     }
   },
   "0.4.47": {
+    "previous_stable_version": "0.4.46",
     "x86_64_linux_musl": {
       "checksum": "3a7bad503bd2af5884acba5fd1d36a053610e4ffbf2bd2f32def3a125a388c0b"
     },
@@ -215,6 +239,7 @@
     }
   },
   "0.4.46": {
+    "previous_stable_version": "0.4.41",
     "x86_64_linux_musl": {
       "checksum": "5bf5c74385f8f629fc22842db9f22a017ce1161ab18695d3b673bef0767908c3"
     },
@@ -223,6 +248,7 @@
     }
   },
   "0.4.41": {
+    "previous_stable_version": "0.4.40",
     "x86_64_linux_musl": {
       "checksum": "30c25753544b0d7ced2341ee01b732031739f1611ee9792a900544f2330c3af6"
     },
@@ -231,6 +257,7 @@
     }
   },
   "0.4.40": {
+    "previous_stable_version": "0.4.39",
     "x86_64_linux_musl": {
       "checksum": "5d0348b5b6361c2654543e4fdcb4adf3138c2acabb84a4b31c0b4296420ca1bc"
     },
@@ -239,6 +266,7 @@
     }
   },
   "0.4.39": {
+    "previous_stable_version": "0.4.38",
     "x86_64_linux_musl": {
       "checksum": "4d6bdd598600ea70085fdedfd425faa6527e337819f23b998cc1deb5e01a6fd5"
     },
@@ -247,6 +275,7 @@
     }
   },
   "0.4.38": {
+    "previous_stable_version": "0.4.37",
     "x86_64_linux_musl": {
       "checksum": "4bd472b5e3718d08118f08bd2ac0fbd0ce28ddbf022314b66d2a9c61a7a55615"
     },
@@ -255,6 +284,7 @@
     }
   },
   "0.4.37": {
+    "previous_stable_version": "0.4.35",
     "x86_64_linux_musl": {
       "checksum": "b22e585e24363971eb925c66cb9ff3ad97612aba7264d0a27eaad871f9f3b02a"
     },
@@ -263,6 +293,7 @@
     }
   },
   "0.4.35": {
+    "previous_stable_version": "0.4.34",
     "x86_64_linux_musl": {
       "checksum": "8d10ff10fa6d4974c71fd0804d65901a88e17c472fded202c6215bc31cbb4eac"
     },

--- a/manifests/cargo-hack.json
+++ b/manifests/cargo-hack.json
@@ -8,6 +8,7 @@
     "version": "0.5.28"
   },
   "0.5.28": {
+    "previous_stable_version": "0.5.27",
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.28/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "87fb6dbb3e8272ec912f85b80366d0c4784fbcf0fe4e5981bf442efaf29dfe48"
@@ -34,6 +35,7 @@
     }
   },
   "0.5.27": {
+    "previous_stable_version": "0.5.26",
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.27/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "a57248a36e5f95b88eda8fbbfd1f1170992abe7d126c7778aa2bd0508625592f"
@@ -60,6 +62,7 @@
     }
   },
   "0.5.26": {
+    "previous_stable_version": "0.5.25",
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.26/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "e4bf3b5ee4be1d7e324c625f18ad85db22ab7bab9bb76988e3901358bc6b6e23"
@@ -86,6 +89,7 @@
     }
   },
   "0.5.25": {
+    "previous_stable_version": "0.5.24",
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.25/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "174ac9958cc93a197821012ab74a7b96836f0792ba031c3edfec3b81e7cacb93"
@@ -112,6 +116,7 @@
     }
   },
   "0.5.24": {
+    "previous_stable_version": "0.5.23",
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.24/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "645eaa98b5f582a2668ac38f139d5476ee605a6de3adaa4937d4ee84f1cce209"
@@ -138,6 +143,7 @@
     }
   },
   "0.5.23": {
+    "previous_stable_version": "0.5.22",
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.23/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "47d0b7f906395c39c249bb9be71541ca16bdaf7a6476ad20072ff9d7bc934664"
@@ -164,6 +170,7 @@
     }
   },
   "0.5.22": {
+    "previous_stable_version": "0.5.21",
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.22/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "39fb5278e5a5782c92e13c134c2826dc9a9b2ed37f1df354c3c82dae705eb464"
@@ -190,6 +197,7 @@
     }
   },
   "0.5.21": {
+    "previous_stable_version": "0.5.20",
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.21/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "eae32e44290f06e69ac2220c8d1e448c2a6f08f8672d2eee6e879ea4f7690457"
@@ -216,6 +224,7 @@
     }
   },
   "0.5.20": {
+    "previous_stable_version": "0.5.19",
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.20/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "82f2383ff38f26b4b12f9fc7c9bd43608a30eb6aea5b103795828c327a26af94"
@@ -242,6 +251,7 @@
     }
   },
   "0.5.19": {
+    "previous_stable_version": "0.5.18",
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.19/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "3c54b469fc5f57499468d3c1fe262d6a15b6829e43eb3c5070a9115bfb667a0c"
@@ -268,6 +278,7 @@
     }
   },
   "0.5.18": {
+    "previous_stable_version": "0.5.17",
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.18/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "38f923c7b3ec904536efe319534120307b76418ac4b9c4fe0a40b01f600e4041"
@@ -294,6 +305,7 @@
     }
   },
   "0.5.17": {
+    "previous_stable_version": "0.5.16",
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.17/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "2f7a0ea5a704e9d1ed171063fcad50be47ff8d2a130e5ff97bd8c0fad6a581dd"
@@ -316,6 +328,7 @@
     }
   },
   "0.5.16": {
+    "previous_stable_version": "0.5.15",
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.16/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "7625df89cf4689bdffb9616c5debf0afab3708478c81d882f911dc854507e2a6"
@@ -338,6 +351,7 @@
     }
   },
   "0.5.15": {
+    "previous_stable_version": "0.5.14",
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.15/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "85a183ee312ecc579be266388fd203886d56704e2468d4a1c98ee1057e7289f0"
@@ -360,6 +374,7 @@
     }
   },
   "0.5.14": {
+    "previous_stable_version": "0.5.13",
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.14/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "11e05d350cf1be6fe95e757f08708122a4ad4e39cbafddbe1baab2c58a547784"
@@ -382,6 +397,7 @@
     }
   },
   "0.5.13": {
+    "previous_stable_version": "0.5.12",
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.13/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "a6e8952a3e1084b28d4968dd2ee28d6777a64c1975d5572e6b081c403d7db996"
@@ -400,6 +416,7 @@
     }
   },
   "0.5.12": {
+    "previous_stable_version": "0.5.11",
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.12/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "04d33084d6ef8e44f5832205932763c18ad38f61ac8dbb48b31f0585d48641a0"
@@ -418,6 +435,7 @@
     }
   },
   "0.5.11": {
+    "previous_stable_version": "0.5.10",
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.11/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "c41ec44f641cb380f180ca03691e8410387bce2d91f3eecadbd09941124aa7f1"
@@ -432,6 +450,7 @@
     }
   },
   "0.5.10": {
+    "previous_stable_version": "0.5.9",
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.10/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "06e413c02196e3b5affe363d89c538bc947b24d4dc9678acfd5bc91d94e06868"
@@ -446,6 +465,7 @@
     }
   },
   "0.5.9": {
+    "previous_stable_version": "0.5.8",
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.9/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "98f4010e94700ad342be575156b642be6669afc04ae62eec438d06bd1dd87b4d"
@@ -460,6 +480,7 @@
     }
   },
   "0.5.8": {
+    "previous_stable_version": "0.5.7",
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.8/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "9ad5d16806deaf4255cd559c2c5411c09383d7c408ef4c8a4e491d0d416f8881"
@@ -474,6 +495,7 @@
     }
   },
   "0.5.7": {
+    "previous_stable_version": "0.5.6",
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.7/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "7235b068f65e8d4c14787aa3695984e3fbbcbd7f0c97537872e3c8391eca1db1"
@@ -488,6 +510,7 @@
     }
   },
   "0.5.6": {
+    "previous_stable_version": "0.5.5",
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.6/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "f0d616d878a674b01ff3eaad459bf93e9a424bf54ac12c0e131f70c9f4d98bdb"
@@ -502,6 +525,7 @@
     }
   },
   "0.5.5": {
+    "previous_stable_version": "0.5.4",
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.5/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "632f228655646f75a6fb237cd18d11b6aabf9b4814297eda65d3f354bf8c9268"
@@ -516,6 +540,7 @@
     }
   },
   "0.5.4": {
+    "previous_stable_version": "0.5.3",
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.4/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "9d90d56dc1c7a1f7747b8b0c27a85c7f630c60cbc7403f986711c275f1265d11"
@@ -530,6 +555,7 @@
     }
   },
   "0.5.3": {
+    "previous_stable_version": "0.5.2",
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.3/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "4c298cb156f1561e9e84e9ed0f2924d4265234e52ca15aefd743b114b5d161ca"
@@ -544,6 +570,7 @@
     }
   },
   "0.5.2": {
+    "previous_stable_version": "0.5.1",
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.2/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "d5b37eb22afca1ad817020ec52e776ee0c14c7bb0e9317381c63922d7c2514c9"
@@ -558,6 +585,7 @@
     }
   },
   "0.5.1": {
+    "previous_stable_version": "0.5.0",
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.1/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "f152cdc7c256d3432e4dbc5d5fb4e3a26a44faa809e1451cd752b7364861d84e"
@@ -572,6 +600,7 @@
     }
   },
   "0.5.0": {
+    "previous_stable_version": "0.4.8",
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.0/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "903be266e25b87511234f8f39a84f0a9ebd40b52ccc2299d4eda4c8da8bfd9d9"
@@ -589,6 +618,7 @@
     "version": "0.4.8"
   },
   "0.4.8": {
+    "previous_stable_version": "0.4.7",
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.4.8/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "3c2728ec5f7e67014bb1eb4099f7fbe6962b7e13c35988d7316e3d00efc455b8"
@@ -603,6 +633,7 @@
     }
   },
   "0.4.7": {
+    "previous_stable_version": "0.4.6",
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.4.7/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "7bd068ded6cb4f7671b309a04c73c8d24826d2ee92432e280cfbe9bd6620264b"
@@ -617,6 +648,7 @@
     }
   },
   "0.4.6": {
+    "previous_stable_version": "0.4.5",
     "x86_64_linux_gnu": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.4.6/cargo-hack-x86_64-unknown-linux-gnu.tar.gz",
       "checksum": "cff0ba4789bffe84fd03204fd4f0adb92bc59eedb64b934e4016d68f2c7cd16a"
@@ -631,6 +663,7 @@
     }
   },
   "0.4.5": {
+    "previous_stable_version": "0.4.4",
     "x86_64_linux_gnu": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.4.5/cargo-hack-x86_64-unknown-linux-gnu.tar.gz",
       "checksum": "a6fbf921254a74a043b7b565ea1a1e3cdab4eaef828a637160a4847aca18f27c"
@@ -645,6 +678,7 @@
     }
   },
   "0.4.4": {
+    "previous_stable_version": "0.4.3",
     "x86_64_linux_gnu": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.4.4/cargo-hack-x86_64-unknown-linux-gnu.tar.gz",
       "checksum": "9e72fd36e5ab4c17225a9b42db87b9bc5886b1b3b298f774d68565318ccde021"

--- a/manifests/cargo-llvm-cov.json
+++ b/manifests/cargo-llvm-cov.json
@@ -24,6 +24,7 @@
     "version": "0.5.24"
   },
   "0.5.24": {
+    "previous_stable_version": "0.5.23",
     "x86_64_linux_musl": {
       "checksum": "e1c15ac5a583eeb4c478eed0222c3a3629aff3c9f151d8bdf7b50704ef9073c6"
     },
@@ -41,6 +42,7 @@
     }
   },
   "0.5.23": {
+    "previous_stable_version": "0.5.22",
     "x86_64_linux_musl": {
       "checksum": "cdbb1c34bffeb2b5b986f16e3e1dd08c01d9ef2cbd1cf2d989ae7a184ce91302"
     },
@@ -58,6 +60,7 @@
     }
   },
   "0.5.22": {
+    "previous_stable_version": "0.5.21",
     "x86_64_linux_musl": {
       "checksum": "6a3f93f12e93853844dfa8b697ff86aaa688b9f44b82ba75b3f4ddd8905f3de5"
     },
@@ -75,6 +78,7 @@
     }
   },
   "0.5.21": {
+    "previous_stable_version": "0.5.20",
     "x86_64_linux_musl": {
       "checksum": "bd23aced73f17c2178569c058f6cd78478cb38b233c45660eacab853b42353d6"
     },
@@ -92,6 +96,7 @@
     }
   },
   "0.5.20": {
+    "previous_stable_version": "0.5.19",
     "x86_64_linux_musl": {
       "checksum": "688aefd7b53917d29b3fa8d81cb449e98138c6b9a6c768eff412f9a523fd3e62"
     },
@@ -109,6 +114,7 @@
     }
   },
   "0.5.19": {
+    "previous_stable_version": "0.5.18",
     "x86_64_linux_musl": {
       "checksum": "79129f4adf9b9dd239a7facd041630a6b29c123a3e0ccabfbce44c71d391fc17"
     },
@@ -126,6 +132,7 @@
     }
   },
   "0.5.18": {
+    "previous_stable_version": "0.5.17",
     "x86_64_linux_musl": {
       "checksum": "eb5db22d1c4e67913d983145fd8473edad8f84b60b08398b634b275ccf1ae324"
     },
@@ -143,6 +150,7 @@
     }
   },
   "0.5.17": {
+    "previous_stable_version": "0.5.16",
     "x86_64_linux_musl": {
       "checksum": "20b563871c1ac1a83ae5683dc97fa0a1bf15ca16407b3daf751dbf652ecbea95"
     },
@@ -160,6 +168,7 @@
     }
   },
   "0.5.16": {
+    "previous_stable_version": "0.5.15",
     "x86_64_linux_musl": {
       "checksum": "d7759f9d465907f4a8fa24f10bfa0817863f62c412ffaae7b8dadab370201f9b"
     },
@@ -177,6 +186,7 @@
     }
   },
   "0.5.15": {
+    "previous_stable_version": "0.5.14",
     "x86_64_linux_musl": {
       "checksum": "407b0ddf85e6a39dfe5379761fc1074c7e79f7b518c732072bda1e4fc854d0fb"
     },
@@ -194,6 +204,7 @@
     }
   },
   "0.5.14": {
+    "previous_stable_version": "0.5.13",
     "x86_64_linux_musl": {
       "checksum": "688e56f78611f7866842f5b86e27672225b28c8a536c75d6c0a3fd67082474ea"
     },
@@ -211,6 +222,7 @@
     }
   },
   "0.5.13": {
+    "previous_stable_version": "0.5.12",
     "x86_64_linux_musl": {
       "checksum": "e57875cba95527149d15d7f9c66b9d624d8154040f19aedbca96e2c6b7687ffb"
     },
@@ -228,6 +240,7 @@
     }
   },
   "0.5.12": {
+    "previous_stable_version": "0.5.11",
     "x86_64_linux_musl": {
       "checksum": "998b1d9e630295459743fe7051a7e3d04e82836456171493eb5983dde710b07e"
     },
@@ -245,6 +258,7 @@
     }
   },
   "0.5.11": {
+    "previous_stable_version": "0.5.10",
     "x86_64_linux_musl": {
       "checksum": "3bd355e29b8e29d0b42f0c95ec487cd8e00ffa419ba65b83968740a641a46c1e"
     },
@@ -262,6 +276,7 @@
     }
   },
   "0.5.10": {
+    "previous_stable_version": "0.5.9",
     "x86_64_linux_musl": {
       "checksum": "6ff31ac54aacc133c8d462c99b353dc31924aa9d0bc088ffdd8caa8cc7a14be4"
     },
@@ -279,6 +294,7 @@
     }
   },
   "0.5.9": {
+    "previous_stable_version": "0.5.8",
     "x86_64_linux_musl": {
       "checksum": "aadde3416c86403f72986f6c68001d2a46497ee8892f5affdb6b681213b586a2"
     },
@@ -296,6 +312,7 @@
     }
   },
   "0.5.8": {
+    "previous_stable_version": "0.5.7",
     "x86_64_linux_musl": {
       "checksum": "78a2b85c54d2ecf76ad7309278901c2f4d6dcc611ef095844e8c6bd87b2d6a72"
     },
@@ -313,6 +330,7 @@
     }
   },
   "0.5.7": {
+    "previous_stable_version": "0.5.6",
     "x86_64_linux_musl": {
       "checksum": "e085b93a22d5f0daaa5c1bcce79885e549057f41b1229c08435c939c4fdf87ed"
     },
@@ -330,6 +348,7 @@
     }
   },
   "0.5.6": {
+    "previous_stable_version": "0.5.5",
     "x86_64_linux_musl": {
       "checksum": "9b45fb8b1fbac1977ed828c248228f31cc2caf6f2ce8b27bd38c25b7275ef701"
     },
@@ -347,6 +366,7 @@
     }
   },
   "0.5.5": {
+    "previous_stable_version": "0.5.4",
     "x86_64_linux_musl": {
       "checksum": "58f459604beef46eff43d14fc41cb39437a2834bece9b91823cafce7a3e91428"
     },
@@ -364,6 +384,7 @@
     }
   },
   "0.5.4": {
+    "previous_stable_version": "0.5.3",
     "x86_64_linux_musl": {
       "checksum": "c4912bb56a25a8ea17bbea843019386d191d789d66d19d3fa70b49fc1efb4599"
     },
@@ -381,6 +402,7 @@
     }
   },
   "0.5.3": {
+    "previous_stable_version": "0.5.2",
     "x86_64_linux_musl": {
       "checksum": "d155c41fef38ac35c315fe420d229fca5fd754d12c6ae0bd300bc25c1274c1fc"
     },
@@ -398,6 +420,7 @@
     }
   },
   "0.5.2": {
+    "previous_stable_version": "0.5.1",
     "x86_64_linux_musl": {
       "checksum": "e62fb99bb24c5f422a5b007e692abfbeccef932882b9ca356291e01112f78e79"
     },
@@ -415,6 +438,7 @@
     }
   },
   "0.5.1": {
+    "previous_stable_version": "0.5.0",
     "x86_64_linux_musl": {
       "checksum": "883c623ef0a66d6b1045c8dba1ec43c30b7a018b3e977ababcb2eef15f537c80"
     },
@@ -432,6 +456,7 @@
     }
   },
   "0.5.0": {
+    "previous_stable_version": "0.4.14",
     "x86_64_linux_musl": {
       "checksum": "186111094fe5da1176dab4cda351f964103ca4fcdc41b08ec701363ebba00d11"
     },
@@ -452,6 +477,7 @@
     "version": "0.4.14"
   },
   "0.4.14": {
+    "previous_stable_version": "0.4.13",
     "x86_64_linux_musl": {
       "checksum": "c5d08670b667c7c34fe3ac8580e3c1ee1dd2b554db1f1ee476ef7f7114df103d"
     },
@@ -469,6 +495,7 @@
     }
   },
   "0.4.13": {
+    "previous_stable_version": "0.4.12",
     "x86_64_linux_musl": {
       "checksum": "44e7e84da6d533d2975ff3c448cb27d429728e629ae896691364b0c4a9726ba9"
     },
@@ -486,6 +513,7 @@
     }
   },
   "0.4.12": {
+    "previous_stable_version": "0.4.11",
     "x86_64_linux_musl": {
       "checksum": "810235170247ebeb63bfe8707d16db6dd99bcaa368b38020f656c9a5d7881b68"
     },
@@ -503,6 +531,7 @@
     }
   },
   "0.4.11": {
+    "previous_stable_version": "0.4.10",
     "x86_64_linux_musl": {
       "checksum": "ce328017159b3120733bb3a3760ec27277c0234837f72ffba4abca054eed19cc"
     },
@@ -520,6 +549,7 @@
     }
   },
   "0.4.10": {
+    "previous_stable_version": "0.4.9",
     "x86_64_linux_musl": {
       "checksum": "a5106d477a994b8afd40e7ebb85317b5960c19c31d548a244c46b50b3c7c3e41"
     },
@@ -537,6 +567,7 @@
     }
   },
   "0.4.9": {
+    "previous_stable_version": "0.4.8",
     "x86_64_linux_musl": {
       "checksum": "01d66a160b0c3049897f00397056e340a908222afa252ce8a67ab8c18a3983a5"
     },
@@ -554,6 +585,7 @@
     }
   },
   "0.4.8": {
+    "previous_stable_version": "0.4.7",
     "x86_64_linux_musl": {
       "checksum": "e65c92a945e3d8c23bc02f4b72d2380783d4d5c73c4f33d0f94595e62062c47f"
     },
@@ -571,6 +603,7 @@
     }
   },
   "0.4.7": {
+    "previous_stable_version": "0.4.6",
     "x86_64_linux_musl": {
       "checksum": "2c354260c0ab47c5f8a1d9dd54284311ded7b5b36e211b06852edc70a22f536c"
     },
@@ -588,6 +621,7 @@
     }
   },
   "0.4.6": {
+    "previous_stable_version": "0.4.5",
     "x86_64_linux_musl": {
       "checksum": "2291c74e9924f24518a1b2595897f41ce796186185dc904d8dea53ee22d9c894"
     },
@@ -605,6 +639,7 @@
     }
   },
   "0.4.5": {
+    "previous_stable_version": "0.4.4",
     "x86_64_linux_musl": {
       "checksum": "29ccdd0fba1869f4afaa2f696557d33fe7c8f41bdd4c47870db4a9ea056b80b0"
     },
@@ -622,6 +657,7 @@
     }
   },
   "0.4.4": {
+    "previous_stable_version": "0.4.3",
     "x86_64_linux_musl": {
       "checksum": "156575db66d144399cf02a2e70af36be6d4ac4a69b2babd893d73e0f7bac0742"
     },
@@ -636,6 +672,7 @@
     }
   },
   "0.4.3": {
+    "previous_stable_version": "0.4.2",
     "x86_64_linux_musl": {
       "checksum": "29bb725e7e21cfae91859b56d60035979a50a0da53ec8594cc8d5b7e37805dfc"
     },
@@ -650,6 +687,7 @@
     }
   },
   "0.4.2": {
+    "previous_stable_version": "0.4.1",
     "x86_64_linux_musl": {
       "checksum": "f103a601b687f33e35236b3da16543788eb2e0044a34939b325537baa6171d55"
     },
@@ -664,6 +702,7 @@
     }
   },
   "0.4.1": {
+    "previous_stable_version": "0.4.0",
     "x86_64_linux_musl": {
       "checksum": "0604d4dff928379df7c8e1693ded89cfb364ab9b08c88b03ae924160dcd92b3b"
     },
@@ -678,6 +717,7 @@
     }
   },
   "0.4.0": {
+    "previous_stable_version": "0.3.3",
     "x86_64_linux_musl": {
       "checksum": "55ad6fdacbeff5e848b4bbb0dc0ea1cf855b51d30a34b08c84f0f87792ed576a"
     },
@@ -695,6 +735,7 @@
     "version": "0.3.3"
   },
   "0.3.3": {
+    "previous_stable_version": "0.3.2",
     "x86_64_linux_musl": {
       "checksum": "021b3e34a8818b54b78f5db5efa9cf8cc04f6123137695f9fd858e53c5694f48"
     },
@@ -709,6 +750,7 @@
     }
   },
   "0.3.2": {
+    "previous_stable_version": "0.3.1",
     "x86_64_linux_musl": {
       "checksum": "e852181f617ed12b4f69b3b40fd5db0914c27ff6852639ebb505563108f8f79a"
     },
@@ -723,6 +765,7 @@
     }
   },
   "0.3.1": {
+    "previous_stable_version": "0.3.0",
     "x86_64_linux_musl": {
       "checksum": "014229fe5a8a9c41cf8291fda9288f729b69d54155b24396c7ab6ef10d84da4a"
     },
@@ -737,6 +780,7 @@
     }
   },
   "0.3.0": {
+    "previous_stable_version": "0.2.4",
     "x86_64_linux_musl": {
       "checksum": "a1e8ca2fa2532d61c972d1aae74eb5186a7766d82a9062ce6b6212783d0b7c9c"
     },
@@ -754,6 +798,7 @@
     "version": "0.2.4"
   },
   "0.2.4": {
+    "previous_stable_version": "0.2.3",
     "x86_64_linux_musl": {
       "checksum": "b3ce5762df4cafd49b21507841e5bc6dcf55a2702ee7431aded473a0641f2115"
     },
@@ -768,6 +813,7 @@
     }
   },
   "0.2.3": {
+    "previous_stable_version": "0.2.2",
     "x86_64_linux_musl": {
       "checksum": "71fd8a8c1ad55c38f8c403e1dc5dc7c399a2107017741c8238ea5b50d308a487"
     },
@@ -782,6 +828,7 @@
     }
   },
   "0.2.2": {
+    "previous_stable_version": "0.2.1",
     "x86_64_linux_musl": {
       "checksum": "d5f6e661a54d9df7e32575d4c075a7644c76587a0d35e1fea7a399dd2515c2d6"
     },
@@ -796,6 +843,7 @@
     }
   },
   "0.2.1": {
+    "previous_stable_version": "0.2.0",
     "x86_64_linux_musl": {
       "checksum": "9c04d52b830cb9b129198229f2358bca85798851d418c48d1cb180a0e93f6866"
     },
@@ -810,6 +858,7 @@
     }
   },
   "0.2.0": {
+    "previous_stable_version": "0.1.16",
     "x86_64_linux_musl": {
       "checksum": "13bb3143de2017e34eeb80deb7d71a31d4daf20e148c159d75d07174d6a86afc"
     },
@@ -827,6 +876,7 @@
     "version": "0.1.16"
   },
   "0.1.16": {
+    "previous_stable_version": "0.1.15",
     "x86_64_linux_musl": {
       "checksum": "4baea3a569ffe977039a7092786a6f53a41734055e929a7da174974c7bf7bf7e"
     },
@@ -841,6 +891,7 @@
     }
   },
   "0.1.15": {
+    "previous_stable_version": "0.1.14",
     "x86_64_linux_musl": {
       "checksum": "ebdec5d6bfa4abf4521932855739221aea964b52c9a914e4a682ee672497a2cf"
     },
@@ -852,6 +903,7 @@
     }
   },
   "0.1.14": {
+    "previous_stable_version": "0.1.13",
     "x86_64_linux_musl": {
       "checksum": "b72f98a053a4895468415ed938bb342a63c3708b41b0809ff9f35c7ac0ac381c"
     },
@@ -863,6 +915,7 @@
     }
   },
   "0.1.13": {
+    "previous_stable_version": "0.1.12",
     "x86_64_linux_musl": {
       "checksum": "3583ff08159c650e8e312b4a1b221e87df618e9b75b5b3187942438f0b0f970d"
     },
@@ -874,6 +927,7 @@
     }
   },
   "0.1.12": {
+    "previous_stable_version": "0.1.11",
     "x86_64_linux_musl": {
       "checksum": "775ffd8c1bd4ed5dcded78164ec182ca4650a3d98b0700fc1c5daf3b6e33014f"
     },
@@ -885,6 +939,7 @@
     }
   },
   "0.1.11": {
+    "previous_stable_version": "0.1.10",
     "x86_64_linux_musl": {
       "checksum": "b262bbc7e600a251ccf937d62fdd01e59f006109c3a6518f30e17dd3b99988d7"
     },
@@ -896,6 +951,7 @@
     }
   },
   "0.1.10": {
+    "previous_stable_version": "0.1.9",
     "x86_64_linux_musl": {
       "checksum": "b72463f53eeea3e4eea82772a77d9f9e3918e2155c341fa87a043f21daeebeb5"
     },
@@ -907,6 +963,7 @@
     }
   },
   "0.1.9": {
+    "previous_stable_version": "0.1.8",
     "x86_64_linux_musl": {
       "checksum": "8b0b825f26415f2b8998c99660f543f8ade9bc0421258beebc6328efbd6b4dd7"
     },
@@ -918,6 +975,7 @@
     }
   },
   "0.1.8": {
+    "previous_stable_version": "0.1.7",
     "x86_64_linux_musl": {
       "checksum": "87e1ab05ae768823035c9d897bca8855058b94ccd6b15a2642decaf2fa7ae86c"
     },
@@ -929,6 +987,7 @@
     }
   },
   "0.1.7": {
+    "previous_stable_version": "0.1.6",
     "x86_64_linux_musl": {
       "checksum": "3d8d830e0a19b2e9229fff690dc803d1d442dcf4831b52294bb02bde0dce2e3f"
     },
@@ -940,6 +999,7 @@
     }
   },
   "0.1.6": {
+    "previous_stable_version": "0.1.5",
     "x86_64_linux_musl": {
       "checksum": "9fdb60de8c1a1fbca35924967c6650f16ecf5312492aba2471ed375fcdde45d2"
     },
@@ -951,6 +1011,7 @@
     }
   },
   "0.1.5": {
+    "previous_stable_version": "0.1.4",
     "x86_64_linux_musl": {
       "checksum": "a96f14a58ec235f003be5fe58e57ffe4981f741425e51ff780a2be71adeb3146"
     },
@@ -962,6 +1023,7 @@
     }
   },
   "0.1.4": {
+    "previous_stable_version": "0.1.3",
     "x86_64_linux_musl": {
       "checksum": "5b1b58bb4c325d5086fba70e40aa70870e1ed77371a7e3f1bc3d772ebf9f5642"
     },
@@ -973,6 +1035,7 @@
     }
   },
   "0.1.3": {
+    "previous_stable_version": "0.1.2",
     "x86_64_linux_musl": {
       "checksum": "526cde2b2dd53db834ff2788846e65793c88ecd1866190247febbaaa20ceda50"
     },
@@ -984,6 +1047,7 @@
     }
   },
   "0.1.2": {
+    "previous_stable_version": "0.1.1",
     "x86_64_linux_musl": {
       "checksum": "89e5162db8f9a4537aa563c17b0989537594a6cc388cfc858008e4aba2b15d80"
     },
@@ -995,6 +1059,7 @@
     }
   },
   "0.1.1": {
+    "previous_stable_version": "0.1.0",
     "x86_64_linux_musl": {
       "checksum": "ef3f6535f997ccfaa6d2612e8e3b41b3fe7a34e44c60b295a0f439ce80afa3c4"
     },

--- a/manifests/cargo-make.json
+++ b/manifests/cargo-make.json
@@ -25,6 +25,7 @@
     "version": "0.36.12"
   },
   "0.36.12": {
+    "previous_stable_version": "0.36.11",
     "x86_64_linux_musl": {
       "checksum": "111c5896fc73d0601eba8b5a4c9edf75c7b7e9f7ab9261e5e1432fb43fc83061"
     },
@@ -39,6 +40,7 @@
     }
   },
   "0.36.11": {
+    "previous_stable_version": "0.36.10",
     "x86_64_linux_musl": {
       "checksum": "0de56c00063a3f18d23ef386e3d3c55dddb37208f69a8592b36d283d2bc07db0"
     },
@@ -53,6 +55,7 @@
     }
   },
   "0.36.10": {
+    "previous_stable_version": "0.36.9",
     "x86_64_linux_musl": {
       "checksum": "5b902720ba24eca8c67798b46dc0465e38a761b66fd4198162c13ce1cc1bd933"
     },
@@ -67,6 +70,7 @@
     }
   },
   "0.36.9": {
+    "previous_stable_version": "0.36.8",
     "x86_64_linux_musl": {
       "checksum": "28abd201805fb193ac95c1f4596373078cfd395f2e4735cd46050bab4e37b64f"
     },
@@ -81,6 +85,7 @@
     }
   },
   "0.36.8": {
+    "previous_stable_version": "0.36.7",
     "x86_64_linux_musl": {
       "checksum": "cffdf9b4f43d2d24165012e44b648e5c82edc3d0b13427d5335b23f125527bd4"
     },
@@ -95,6 +100,7 @@
     }
   },
   "0.36.7": {
+    "previous_stable_version": "0.36.6",
     "x86_64_linux_musl": {
       "checksum": "c758364568cee83e597d1d063212435d42d1b36105188e4ef10a5fd25897539e"
     },
@@ -109,6 +115,7 @@
     }
   },
   "0.36.6": {
+    "previous_stable_version": "0.36.5",
     "x86_64_linux_musl": {
       "checksum": "900323cd32566ac5675f33bf2661717e3eb8ebcdc6100eede428d04376fba07a"
     },
@@ -120,6 +127,7 @@
     }
   },
   "0.36.5": {
+    "previous_stable_version": "0.36.4",
     "x86_64_linux_musl": {
       "checksum": "95e9964640d5e45ac7756e0cf0496612b8d790ef0cbdda8c99c476e27106d44d"
     },
@@ -131,6 +139,7 @@
     }
   },
   "0.36.4": {
+    "previous_stable_version": "0.36.3",
     "x86_64_linux_musl": {
       "checksum": "2fc65e1f34789da87cab387027a8179e3589a8a78b0fa3063b26f63be8cb507b"
     },
@@ -142,6 +151,7 @@
     }
   },
   "0.36.3": {
+    "previous_stable_version": "0.36.2",
     "x86_64_linux_musl": {
       "checksum": "7dbb719698fc05f7c58ead0650fdc77f253faf98c14f1260733b3943d8d59122"
     },
@@ -153,6 +163,7 @@
     }
   },
   "0.36.2": {
+    "previous_stable_version": "0.36.1",
     "x86_64_linux_musl": {
       "checksum": "f38140a74fada27ae20e859bd3d8b5f464df12416fa110e443db99b4708a3d5b"
     },
@@ -164,6 +175,7 @@
     }
   },
   "0.36.1": {
+    "previous_stable_version": "0.36.0",
     "x86_64_linux_musl": {
       "checksum": "b5f52ebb95a123d1026914231144f389ae1c993439afd12f974b2ed2c2d384f1"
     },
@@ -175,6 +187,7 @@
     }
   },
   "0.36.0": {
+    "previous_stable_version": "0.35.16",
     "x86_64_linux_musl": {
       "checksum": "fd98a0330412963326bf9767f86acb232f9c058bc8b6e21f61e78bd79122bb65"
     },
@@ -189,6 +202,7 @@
     "version": "0.35.16"
   },
   "0.35.16": {
+    "previous_stable_version": "0.35.15",
     "x86_64_linux_musl": {
       "checksum": "59c27cb85df7e26db7210bd9c8c2b9624cb408b9ae0cba24d16264b89bee975c"
     },
@@ -200,6 +214,7 @@
     }
   },
   "0.35.15": {
+    "previous_stable_version": "0.35.14",
     "x86_64_linux_musl": {
       "checksum": "016be6571afb2281ec4841693cf8eb485d9073eaabe5f799d80c2e7dc2cac878"
     },
@@ -211,6 +226,7 @@
     }
   },
   "0.35.14": {
+    "previous_stable_version": "0.35.13",
     "x86_64_linux_musl": {
       "checksum": "73b872ca41998df4ead9dcc39dafd745c4aafe82cfd490d45e7e1bb5544a2649"
     },
@@ -219,6 +235,7 @@
     }
   },
   "0.35.13": {
+    "previous_stable_version": "0.35.12",
     "x86_64_linux_musl": {
       "checksum": "d24a36f707b43a9b6102095bb1bb5cbcd12b2f793c280a9ab7f02a12ae3b1bce"
     },
@@ -230,6 +247,7 @@
     }
   },
   "0.35.12": {
+    "previous_stable_version": "0.35.11",
     "x86_64_linux_musl": {
       "checksum": "fcc769ffa3233ebea09938b3db1ff5b9102be369955aa8ed7aaaeb95f7c0cdd9"
     },
@@ -241,6 +259,7 @@
     }
   },
   "0.35.11": {
+    "previous_stable_version": "0.35.10",
     "x86_64_linux_musl": {
       "checksum": "b198d8cebeb3a78c4b96e977a7adcfdaa5a974e5eb7227481afe1f3cf54b0590"
     },
@@ -252,6 +271,7 @@
     }
   },
   "0.35.10": {
+    "previous_stable_version": "0.35.9",
     "x86_64_linux_musl": {
       "checksum": "56c0d84d4e5151504b1803248ea3a141d80aa91867af70f27236529c40c9f277"
     },
@@ -263,6 +283,7 @@
     }
   },
   "0.35.9": {
+    "previous_stable_version": "0.35.8",
     "x86_64_linux_musl": {
       "checksum": "5759db0b6ffbe17ee2d762cad59814e086b1b619dabc4b2a14518035cc1bebc7"
     },
@@ -274,6 +295,7 @@
     }
   },
   "0.35.8": {
+    "previous_stable_version": "0.35.7",
     "x86_64_linux_musl": {
       "checksum": "e99e105c1bef9c54fad91715f7842ca0e8301d4aaf5f9a8d4949e37dbfd5fe7d"
     },
@@ -285,6 +307,7 @@
     }
   },
   "0.35.7": {
+    "previous_stable_version": "0.35.6",
     "x86_64_linux_musl": {
       "checksum": "cdacd5dc3cd5f2c92657e6776034ac70b1efe8497ef5ac807ac2f10361cb2992"
     },
@@ -296,6 +319,7 @@
     }
   },
   "0.35.6": {
+    "previous_stable_version": "0.35.5",
     "x86_64_linux_musl": {
       "checksum": "de90c2b0dd8ea7f065f2e25cf914d9bc4a8ae5541bc4d90f47e4a41db5665681"
     },
@@ -307,6 +331,7 @@
     }
   },
   "0.35.5": {
+    "previous_stable_version": "0.35.4",
     "x86_64_linux_musl": {
       "checksum": "a993e24ce1e707be544dfb37988162994e531ff616c8b8b4c27ea29967562242"
     },
@@ -318,6 +343,7 @@
     }
   },
   "0.35.4": {
+    "previous_stable_version": "0.35.2",
     "x86_64_linux_musl": {
       "checksum": "cb836d9df047b7186ef1ab360b71f79c77a3b7a2f4a83ce89fb42f6f0df01402"
     },
@@ -329,6 +355,7 @@
     }
   },
   "0.35.2": {
+    "previous_stable_version": "0.35.1",
     "x86_64_linux_musl": {
       "checksum": "5e50e9b4b9272adbb9301872e795d10917df8ad01704a507616627897e51c5c3"
     },
@@ -340,6 +367,7 @@
     }
   },
   "0.35.1": {
+    "previous_stable_version": "0.35.0",
     "x86_64_linux_musl": {
       "checksum": "b3ded2426d987a784497a89891a271ff3184c8cce53243df9ca51a70ac77a6e0"
     },
@@ -351,6 +379,7 @@
     }
   },
   "0.35.0": {
+    "previous_stable_version": "0.34.0",
     "x86_64_linux_musl": {
       "checksum": "429c60665b20d43c6492045539add3f41a6339a0fb83d3d7d5bb66f926ccff36"
     },
@@ -365,6 +394,7 @@
     "version": "0.34.0"
   },
   "0.34.0": {
+    "previous_stable_version": "0.33.0",
     "x86_64_linux_musl": {
       "checksum": "e5c32dfb43f02713b3e34e9120fe29efa1b4493bfabcd207955d3027fd7e9da5"
     },
@@ -379,6 +409,7 @@
     "version": "0.33.0"
   },
   "0.33.0": {
+    "previous_stable_version": "0.32.17",
     "x86_64_linux_musl": {
       "checksum": "670d3419372f58c0563179e8702ec1d031a76d840a376685ad05423434ecc773"
     },
@@ -393,6 +424,7 @@
     "version": "0.32.17"
   },
   "0.32.17": {
+    "previous_stable_version": "0.32.16",
     "x86_64_linux_musl": {
       "checksum": "21f8b5416135d4fc686fb2e7c1b6f355b810bcbe94707c8094275ccae409b820"
     },
@@ -404,6 +436,7 @@
     }
   },
   "0.32.16": {
+    "previous_stable_version": "0.32.15",
     "x86_64_linux_musl": {
       "checksum": "f84bf2c9f8b6d57d8cfc2cff185a3bf1725ad7f411292cc22c83cd2eac4d3fad"
     },
@@ -415,6 +448,7 @@
     }
   },
   "0.32.15": {
+    "previous_stable_version": "0.32.14",
     "x86_64_linux_musl": {
       "checksum": "4837542b1f9046563228ed98c11c1caf0ea1cb213c14297ada5c71d2a0fed96d"
     },
@@ -426,6 +460,7 @@
     }
   },
   "0.32.14": {
+    "previous_stable_version": "0.32.13",
     "x86_64_linux_musl": {
       "checksum": "189b57dddce8944fc27a7bec0696d204fe1a70b4291181c0e563850befba7b2a"
     },
@@ -437,6 +472,7 @@
     }
   },
   "0.32.13": {
+    "previous_stable_version": "0.32.12",
     "x86_64_linux_musl": {
       "checksum": "62f895828ba1dd3dfb49eba643b4017c727730b586de9a52963919c123f13827"
     },
@@ -448,6 +484,7 @@
     }
   },
   "0.32.12": {
+    "previous_stable_version": "0.32.11",
     "x86_64_linux_musl": {
       "checksum": "dc71a66f4ad8125d9950170caec894f58244a59afb1b672480743f0c7c5ceae3"
     },
@@ -459,6 +496,7 @@
     }
   },
   "0.32.11": {
+    "previous_stable_version": "0.32.10",
     "x86_64_linux_musl": {
       "checksum": "6495d2d5db41df2b6abe966ec2fd86b7aef71701245dfd24fb7baa3137b53444"
     },
@@ -470,6 +508,7 @@
     }
   },
   "0.32.10": {
+    "previous_stable_version": "0.32.9",
     "x86_64_linux_musl": {
       "checksum": "c9c22f5069b660b83e888fe1eaa9f51d1fd413b94fb197324cc7dfbc82668b13"
     },
@@ -481,6 +520,7 @@
     }
   },
   "0.32.9": {
+    "previous_stable_version": "0.32.8",
     "x86_64_linux_musl": {
       "checksum": "737cb605580df41033c5623d7a52fc6ae8fb65e2d41a6ab175ce970d8e78f3ab"
     },
@@ -492,6 +532,7 @@
     }
   },
   "0.32.8": {
+    "previous_stable_version": "0.32.7",
     "x86_64_linux_musl": {
       "checksum": "0ac947ba9a5c61bc83607170661285cdc96436bfbb05c47681cfa74a2bc4a2e5"
     },
@@ -503,6 +544,7 @@
     }
   },
   "0.32.7": {
+    "previous_stable_version": "0.32.6",
     "x86_64_linux_musl": {
       "checksum": "9429ab55b6140ed72a035480f875b8a5209a353aabe058bd7756fc23f0a23ed1"
     },
@@ -514,6 +556,7 @@
     }
   },
   "0.32.6": {
+    "previous_stable_version": "0.32.5",
     "x86_64_linux_musl": {
       "checksum": "058aaf5f5815d134a45b8bc8e73e36ee21e8ed0ec004e0b9ef770df6e1091822"
     },
@@ -525,6 +568,7 @@
     }
   },
   "0.32.5": {
+    "previous_stable_version": "0.32.4",
     "x86_64_linux_musl": {
       "checksum": "4abc84163d764dc7e6c9ff3a42f5e93a10b51ecaf7b86d373e57953cf37de4c3"
     },
@@ -536,6 +580,7 @@
     }
   },
   "0.32.4": {
+    "previous_stable_version": "0.32.3",
     "x86_64_linux_musl": {
       "checksum": "176d3230e2b25a9f4f49f3dce353afe6d5334ef35591474dbf2081bd2129c2d8"
     },
@@ -547,6 +592,7 @@
     }
   },
   "0.32.3": {
+    "previous_stable_version": "0.32.2",
     "x86_64_linux_musl": {
       "checksum": "467215bea54c98a6de07ec343de567fc9fae4a8e8c45d6c04b6dce8ea866d539"
     },
@@ -558,6 +604,7 @@
     }
   },
   "0.32.2": {
+    "previous_stable_version": "0.32.1",
     "x86_64_linux_musl": {
       "checksum": "3b9ac1c1fd5a3e49322efdb11195f1c56e118398e8e1a85476d496466a880ad1"
     },
@@ -569,6 +616,7 @@
     }
   },
   "0.32.1": {
+    "previous_stable_version": "0.32.0",
     "x86_64_linux_musl": {
       "checksum": "db0d5230bb7c1e335adae1506db9494164b44235f08c3d8822b85370ad1b52e0"
     },
@@ -580,6 +628,7 @@
     }
   },
   "0.32.0": {
+    "previous_stable_version": "0.31.1",
     "x86_64_linux_musl": {
       "checksum": "49367fe8feafa082b79892b56d694f6dfc9eb98c3389782adfb38d17f4282217"
     },
@@ -594,6 +643,7 @@
     "version": "0.31.1"
   },
   "0.31.1": {
+    "previous_stable_version": "0.31.0",
     "x86_64_linux_musl": {
       "checksum": "96308d4d56cc9fbe6fec29e4e21a8b36eef6c4c2f44a63ee2b5cc51582639956"
     },
@@ -605,6 +655,7 @@
     }
   },
   "0.31.0": {
+    "previous_stable_version": "0.30.8",
     "x86_64_linux_musl": {
       "checksum": "44d822d0a522fbfb40e4773c13c15385d6558a9a82a0162d4381967470e51692"
     },
@@ -619,6 +670,7 @@
     "version": "0.30.8"
   },
   "0.30.8": {
+    "previous_stable_version": "0.30.7",
     "x86_64_linux_musl": {
       "checksum": "872ea97a41b93fa8c2f73ca4cb19c34b9eea56722a4a8b0b25aba0addef19245"
     },
@@ -630,6 +682,7 @@
     }
   },
   "0.30.7": {
+    "previous_stable_version": "0.30.6",
     "x86_64_linux_musl": {
       "checksum": "417d334e88812e9c8b154b1ca5e7dc9d4575bccc3ed347549d8c9f95bda795fb"
     },
@@ -641,6 +694,7 @@
     }
   },
   "0.30.6": {
+    "previous_stable_version": "0.30.5",
     "x86_64_linux_musl": {
       "checksum": "2de70a59c320c2fc2486f39ef373fbba08f43eb7d23b2d873acc4f7291568b09"
     },
@@ -652,6 +706,7 @@
     }
   },
   "0.30.5": {
+    "previous_stable_version": "0.30.4",
     "x86_64_linux_musl": {
       "checksum": "1e3057a6e313382180b10d2a8416d6a484476e9f7c4cde8a21b383c1150aa72b"
     },
@@ -663,6 +718,7 @@
     }
   },
   "0.30.4": {
+    "previous_stable_version": "0.30.3",
     "x86_64_linux_musl": {
       "checksum": "15b96f573701f5d192238ec2e5e42f3d007b6c1c08e130dd2488c1156748c2c2"
     },
@@ -674,6 +730,7 @@
     }
   },
   "0.30.3": {
+    "previous_stable_version": "0.30.2",
     "x86_64_linux_musl": {
       "checksum": "b15afb2cda4528103ad3b150d144aa1658bb9e7fa1a8d1f53da9525978579057"
     },
@@ -685,6 +742,7 @@
     }
   },
   "0.30.2": {
+    "previous_stable_version": "0.30.1",
     "x86_64_macos": {
       "checksum": "03bb9800436e847e7de7b7894eac830b80f1d6f88c47dac78cfbc593c2fac34b"
     },
@@ -693,6 +751,7 @@
     }
   },
   "0.30.1": {
+    "previous_stable_version": "0.30.0",
     "x86_64_linux_musl": {
       "checksum": "03820ece1c11bfbdbac8cceb5c0166c83b4cfb5e5f15775d648b1d30e2bc471d"
     },
@@ -704,6 +763,7 @@
     }
   },
   "0.30.0": {
+    "previous_stable_version": "0.29.0",
     "x86_64_linux_musl": {
       "checksum": "7dfab94855e71c168ab315ec6b4ddd2682665ee4231abcacab1ecb88e9181352"
     },
@@ -718,6 +778,7 @@
     "version": "0.29.0"
   },
   "0.29.0": {
+    "previous_stable_version": "0.28.0",
     "x86_64_linux_musl": {
       "checksum": "440aa36e4fdd94000c8e4e7905d7d2ffca29cd7c090310361ed3aa863b6a6c65"
     },
@@ -732,6 +793,7 @@
     "version": "0.28.0"
   },
   "0.28.0": {
+    "previous_stable_version": "0.27.0",
     "x86_64_linux_musl": {
       "checksum": "5044b89a97c8f432af40ac3a51de9a36ddee13ce1a793ae1e56f1664b575460f"
     },
@@ -746,6 +808,7 @@
     "version": "0.27.0"
   },
   "0.27.0": {
+    "previous_stable_version": "0.26.2",
     "x86_64_linux_musl": {
       "checksum": "2cb90f8a8d56b78617c7bc222b0635225375ec89350c820cbed9875153aeb9a0"
     },
@@ -760,6 +823,7 @@
     "version": "0.26.2"
   },
   "0.26.2": {
+    "previous_stable_version": "0.26.1",
     "x86_64_linux_musl": {
       "checksum": "c7b4454fa6242835c685b7ea4998436646c5212bbf69975024eb6ff2f8bc3ff9"
     },
@@ -771,6 +835,7 @@
     }
   },
   "0.26.1": {
+    "previous_stable_version": "0.26.0",
     "x86_64_linux_musl": {
       "checksum": "f87fa6887dc4bba5a124addb6df3192f9e756ee0058bf81617d0a33123d97ae8"
     },
@@ -782,6 +847,7 @@
     }
   },
   "0.26.0": {
+    "previous_stable_version": "0.25.1",
     "x86_64_linux_musl": {
       "checksum": "f2382c97ff13ebbac87b3b40e0c116d5a3193f7dc0ae5969b2907ece7f5764d7"
     },
@@ -796,6 +862,7 @@
     "version": "0.25.1"
   },
   "0.25.1": {
+    "previous_stable_version": "0.25.0",
     "x86_64_linux_musl": {
       "checksum": "5fc2b4723bf0eec930321624a2854d9e2a6722f4691a398f7a31959d9c825779"
     },
@@ -807,6 +874,7 @@
     }
   },
   "0.25.0": {
+    "previous_stable_version": "0.24.3",
     "x86_64_linux_musl": {
       "checksum": "eed6d0126d6a8c71d9271080e5005720d3f1f227b119b0c784921a0a9e3f6cf6"
     },
@@ -821,6 +889,7 @@
     "version": "0.24.3"
   },
   "0.24.3": {
+    "previous_stable_version": "0.24.2",
     "x86_64_linux_musl": {
       "checksum": "58dc12726bc306840c868d16d7674901c0e65a0f798e06885b7738239077f22e"
     },
@@ -832,6 +901,7 @@
     }
   },
   "0.24.2": {
+    "previous_stable_version": "0.24.1",
     "x86_64_linux_musl": {
       "checksum": "482447d87724b73dd2274239c37ad0a67ae0aed20c772ed76c22c4a473bc826f"
     },
@@ -843,6 +913,7 @@
     }
   },
   "0.24.1": {
+    "previous_stable_version": "0.24.0",
     "x86_64_linux_musl": {
       "checksum": "063335cac1e8d40807a3b75351f129a611632d6891866ac7977a8394f2675668"
     },
@@ -854,6 +925,7 @@
     }
   },
   "0.24.0": {
+    "previous_stable_version": "0.23.0",
     "x86_64_linux_musl": {
       "checksum": "2848528ea16dd786de013a5b1bb2a7c9cc087c55cafff72d1045891fb27cb80b"
     },
@@ -868,6 +940,7 @@
     "version": "0.23.0"
   },
   "0.23.0": {
+    "previous_stable_version": "0.22.2",
     "x86_64_linux_musl": {
       "checksum": "044ac1dca4085c19b695d843c6b7e277f3d956c194188d07a98b2766cc1e5eb1"
     },
@@ -882,6 +955,7 @@
     "version": "0.22.2"
   },
   "0.22.2": {
+    "previous_stable_version": "0.22.1",
     "x86_64_linux_musl": {
       "checksum": "aaed06d001bda6a26d3a208839a4c6006871f4e92cc8c9f08195bde812cdfe99"
     },
@@ -893,6 +967,7 @@
     }
   },
   "0.22.1": {
+    "previous_stable_version": "0.22.0",
     "x86_64_linux_musl": {
       "checksum": "e7030116bb29582ca6cf2cfbf0b0946729f20f256a7ad0259865b52054dfc5c6"
     },
@@ -904,6 +979,7 @@
     }
   },
   "0.22.0": {
+    "previous_stable_version": "0.21.0",
     "x86_64_linux_musl": {
       "checksum": "556c195f830bd7f21024fe8d6115383adf5aadc1c16c1e9d11f53cdbe8c4e4c9"
     },
@@ -918,6 +994,7 @@
     "version": "0.21.0"
   },
   "0.21.0": {
+    "previous_stable_version": "0.20.0",
     "x86_64_linux_musl": {
       "checksum": "78593830b8884d515e9bc50573c3037f3d7e5088cc388dfddd3a5fbacc7e4767"
     },
@@ -932,6 +1009,7 @@
     "version": "0.20.0"
   },
   "0.20.0": {
+    "previous_stable_version": "0.19.5",
     "x86_64_linux_musl": {
       "checksum": "33c61bba8f88b41195e5731d75c5525f4870b0c41c4241e258ab15c2ce32cc40"
     },
@@ -946,6 +1024,7 @@
     "version": "0.19.5"
   },
   "0.19.5": {
+    "previous_stable_version": "0.19.4",
     "x86_64_linux_musl": {
       "checksum": "556eece0a9b14101e352b7f841229dba3d34d9437017e082ff733e89a55ae0c6"
     },
@@ -957,6 +1036,7 @@
     }
   },
   "0.19.4": {
+    "previous_stable_version": "0.19.3",
     "x86_64_linux_musl": {
       "checksum": "b34e19709e45d355992ecccf387a369c4cf3668f3f88966fe9f7627687f330fb"
     },
@@ -968,6 +1048,7 @@
     }
   },
   "0.19.3": {
+    "previous_stable_version": "0.19.2",
     "x86_64_linux_musl": {
       "checksum": "72cad5d9755eb66038853e1a59d8d6ad8aa582b3989f8d4c36840ab5e9e9f46f"
     },
@@ -979,6 +1060,7 @@
     }
   },
   "0.19.2": {
+    "previous_stable_version": "0.19.1",
     "x86_64_linux_musl": {
       "checksum": "2177e3b78bf08fc1859e8f4655b56c6429c9e744ceba732b47a3e7876395a489"
     },
@@ -990,6 +1072,7 @@
     }
   },
   "0.19.1": {
+    "previous_stable_version": "0.18.0",
     "x86_64_linux_musl": {
       "checksum": "08d1ac7b77125d37e05523d8babaa9748555fc035158c2b0f985dcfd95afa9a3"
     },
@@ -1004,6 +1087,7 @@
     "version": "0.18.0"
   },
   "0.18.0": {
+    "previous_stable_version": "0.17.1",
     "x86_64_linux_musl": {
       "checksum": "eefee39f6f5aaa6d112c59bd098d3f7fb615064c5db0e7697320217c790eb5db"
     },
@@ -1018,6 +1102,7 @@
     "version": "0.17.1"
   },
   "0.17.1": {
+    "previous_stable_version": "0.17.0",
     "x86_64_linux_musl": {
       "checksum": "da8e9408d715b503b53e7b531476271c78e528b028e31a0d35355decb5a36055"
     },
@@ -1029,6 +1114,7 @@
     }
   },
   "0.17.0": {
+    "previous_stable_version": "0.16.10",
     "x86_64_linux_musl": {
       "checksum": "69a6f590bce791070c8b703f2c8c97193ace062c1edad82c7e4c2445a1e00e56"
     },
@@ -1043,6 +1129,7 @@
     "version": "0.16.10"
   },
   "0.16.10": {
+    "previous_stable_version": "0.16.9",
     "x86_64_linux_musl": {
       "checksum": "0fb5dc49936869c246dbfb9990ff1aeaaa3979fea0d637294c504908101bdecf"
     },
@@ -1054,6 +1141,7 @@
     }
   },
   "0.16.9": {
+    "previous_stable_version": "0.16.8",
     "x86_64_linux_musl": {
       "checksum": "0125031fdbba5c0c945cc8837c28fcf2359df6a1b15f5c61513577d676d5ac69"
     },
@@ -1065,6 +1153,7 @@
     }
   },
   "0.16.8": {
+    "previous_stable_version": "0.16.7",
     "x86_64_linux_musl": {
       "checksum": "24f09baf6898d3403641a7c26077303f81388202510b91b12debdefadd0288e2"
     },
@@ -1076,6 +1165,7 @@
     }
   },
   "0.16.7": {
+    "previous_stable_version": "0.16.6",
     "x86_64_linux_musl": {
       "checksum": "728a992713b946d9052206fba39da462dc4167ba8e4ae9a4e94fedd79b4085df"
     },
@@ -1087,6 +1177,7 @@
     }
   },
   "0.16.6": {
+    "previous_stable_version": "0.16.5",
     "x86_64_linux_musl": {
       "checksum": "3a47efa015f6d7e781432192dca0ebafbbd3a2782eb6dfe22685f3aa809c46d6"
     },
@@ -1098,11 +1189,13 @@
     }
   },
   "0.16.5": {
+    "previous_stable_version": "0.16.4",
     "x86_64_macos": {
       "checksum": "2767b8e1201e27878ee62aa090ff15021add35beaffe6988c151bbb2f61b2a22"
     }
   },
   "0.16.4": {
+    "previous_stable_version": "0.16.3",
     "x86_64_linux_musl": {
       "checksum": "60ba004ea2a0d92ff6f49ad4905c134accf32161d364f0967ebc655a31b16aa4"
     },
@@ -1114,6 +1207,7 @@
     }
   },
   "0.16.3": {
+    "previous_stable_version": "0.16.2",
     "x86_64_linux_musl": {
       "checksum": "2fc4275687f37229f57844747c7a82c246250c4d78047ce0b429a061376a6ec8"
     },
@@ -1125,6 +1219,7 @@
     }
   },
   "0.16.2": {
+    "previous_stable_version": "0.16.1",
     "x86_64_linux_musl": {
       "checksum": "d8fd83d3de549dfab7ce2ef649935bc8d1e659287e9c5a01708df12aa7f0aa4a"
     },
@@ -1136,6 +1231,7 @@
     }
   },
   "0.16.1": {
+    "previous_stable_version": "0.16.0",
     "x86_64_macos": {
       "checksum": "91298f542f535cd36ab6217be9fadd1682408fa899e4a76cc48a506f31f17812"
     },
@@ -1144,6 +1240,7 @@
     }
   },
   "0.16.0": {
+    "previous_stable_version": "0.15.3",
     "x86_64_linux_musl": {
       "checksum": "2201fbfb7298f3e7240aad55838d9c899fa5c3004b4991e4aa3bac0941ad4046"
     },
@@ -1158,6 +1255,7 @@
     "version": "0.15.3"
   },
   "0.15.3": {
+    "previous_stable_version": "0.15.2",
     "x86_64_linux_musl": {
       "checksum": "7f20242b8bb9d22844c931a2eee4869044287fda2139488bfa9f75f8c7fbaeb8"
     },
@@ -1169,6 +1267,7 @@
     }
   },
   "0.15.2": {
+    "previous_stable_version": "0.15.1",
     "x86_64_linux_musl": {
       "checksum": "f7abe3e1247bbd0fed211ccd902f98a6390c473e271f4f0c37d3e19a5862945c"
     },

--- a/manifests/cargo-minimal-versions.json
+++ b/manifests/cargo-minimal-versions.json
@@ -27,6 +27,7 @@
     "version": "0.1.13"
   },
   "0.1.13": {
+    "previous_stable_version": "0.1.12",
     "x86_64_linux_musl": {
       "checksum": "7bafe9e8c27207845edb3940e3a91f7cbae7a318472267610017fb6b10d8c7a2"
     },
@@ -47,6 +48,7 @@
     }
   },
   "0.1.12": {
+    "previous_stable_version": "0.1.11",
     "x86_64_linux_musl": {
       "checksum": "14d33bd273110fc3a4ebc96eab922442e2663f1c8d8da746d66a917fa2957297"
     },
@@ -67,6 +69,7 @@
     }
   },
   "0.1.11": {
+    "previous_stable_version": "0.1.10",
     "x86_64_linux_musl": {
       "checksum": "a7d3f6ba4cff8643b06e5a17f7967043f49a9144b7ae8d24d9542fc29ef1d4f2"
     },
@@ -87,6 +90,7 @@
     }
   },
   "0.1.10": {
+    "previous_stable_version": "0.1.9",
     "x86_64_linux_musl": {
       "checksum": "de28bdc0a9ff95ce607eea9b090525dc967138029f31a0c5173143e3dbe080d3"
     },
@@ -107,6 +111,7 @@
     }
   },
   "0.1.9": {
+    "previous_stable_version": "0.1.8",
     "x86_64_linux_musl": {
       "checksum": "4ad1c41f00a8258c9c64f713fcb48bab23617273d9363146acdfc4a803ee711c"
     },
@@ -127,6 +132,7 @@
     }
   },
   "0.1.8": {
+    "previous_stable_version": "0.1.7",
     "x86_64_linux_musl": {
       "checksum": "0aa5c502202831dae2ea3c327788e95c9077ae914879dc2f78d66c6b2d4be12e"
     },
@@ -147,6 +153,7 @@
     }
   },
   "0.1.7": {
+    "previous_stable_version": "0.1.6",
     "x86_64_linux_musl": {
       "checksum": "70f3a766a785b905b975d988e0acbc7a0685feef91bf05d164d27349e4ad14e2"
     },
@@ -167,6 +174,7 @@
     }
   },
   "0.1.6": {
+    "previous_stable_version": "0.1.5",
     "x86_64_linux_musl": {
       "checksum": "06f7e18c8afcceb82728b0502d9cf173dc7ba1f70f623c7423e10a15a6adfdbd"
     },
@@ -187,6 +195,7 @@
     }
   },
   "0.1.5": {
+    "previous_stable_version": "0.1.4",
     "x86_64_linux_musl": {
       "checksum": "ce4ed231f04e84e11fff96bd0e54cb762a6bf64b981b1083b380938710df94ac"
     },
@@ -204,6 +213,7 @@
     }
   },
   "0.1.4": {
+    "previous_stable_version": "0.1.3",
     "x86_64_linux_musl": {
       "checksum": "739944284263057f8f6a3854e67e66d3d02ed435cc9af9dcc638dc8c09a55d3b"
     },
@@ -221,6 +231,7 @@
     }
   },
   "0.1.3": {
+    "previous_stable_version": "0.1.2",
     "x86_64_linux_musl": {
       "checksum": "89fd8fa3a37d76568122cbce3ba6a4bd7600a1b893be0eef59e8733887758264"
     },
@@ -235,6 +246,7 @@
     }
   },
   "0.1.2": {
+    "previous_stable_version": "0.1.1",
     "x86_64_linux_musl": {
       "checksum": "d42cf0af9ca7c449dbad815b450cfbee478c263dbaa3952399e72090d85c4798"
     },
@@ -249,6 +261,7 @@
     }
   },
   "0.1.1": {
+    "previous_stable_version": "0.1.0",
     "x86_64_linux_musl": {
       "checksum": "c80f49034fb8d87869b210535f4d89ad4562ae00da3b97d7a30eae3e17350ae6"
     },

--- a/manifests/cargo-nextest.json
+++ b/manifests/cargo-nextest.json
@@ -24,6 +24,7 @@
     "version": "0.9.57"
   },
   "0.9.57": {
+    "previous_stable_version": "0.9.56",
     "x86_64_linux_gnu": {
       "checksum": "5fc2416dd001ec89d904a345465da0b91452896b74621a82fec33e33d4856320"
     },
@@ -41,6 +42,7 @@
     }
   },
   "0.9.56": {
+    "previous_stable_version": "0.9.55",
     "x86_64_linux_gnu": {
       "checksum": "914f380306a7216c8b79ca4408cc39073eaaea9e7b2101e2bfe0c123636a478b"
     },
@@ -58,6 +60,7 @@
     }
   },
   "0.9.55": {
+    "previous_stable_version": "0.9.54",
     "x86_64_linux_gnu": {
       "checksum": "b5bab814d720561c002b5cbe899f997c20407689cfba23754b5a6c20ae3cac4a"
     },
@@ -75,6 +78,7 @@
     }
   },
   "0.9.54": {
+    "previous_stable_version": "0.9.53",
     "x86_64_linux_gnu": {
       "checksum": "ed393824489793854193906946d972afc1e3c32a18aed5bc9dafc2cb3547bead"
     },
@@ -92,6 +96,7 @@
     }
   },
   "0.9.53": {
+    "previous_stable_version": "0.9.52",
     "x86_64_linux_gnu": {
       "checksum": "b07def6a5e5521481eb5853e5f17650be406ce8c57ce917a90d2866c788e5967"
     },
@@ -109,6 +114,7 @@
     }
   },
   "0.9.52": {
+    "previous_stable_version": "0.9.51",
     "x86_64_linux_gnu": {
       "checksum": "55bf039be0d14e4266eaacd765a292294c8627787dcb31d503690a9c14ad21fc"
     },
@@ -126,6 +132,7 @@
     }
   },
   "0.9.51": {
+    "previous_stable_version": "0.9.50",
     "x86_64_linux_gnu": {
       "checksum": "5cbf80e72737d63a601f139d6ff1c42ca9cf6204cd7991f7d6ce7458f2c12bbc"
     },
@@ -143,6 +150,7 @@
     }
   },
   "0.9.50": {
+    "previous_stable_version": "0.9.49",
     "x86_64_linux_gnu": {
       "checksum": "4586cfb628f70f6493d9f861b0c71dbe66622128e935ca3c922010bd460673ba"
     },
@@ -160,6 +168,7 @@
     }
   },
   "0.9.49": {
+    "previous_stable_version": "0.9.48",
     "x86_64_linux_gnu": {
       "checksum": "5e19c5038c9940da4c47a9ae87f94b352dc98c2ab75b4b9aeae227cdff8440d2"
     },
@@ -177,6 +186,7 @@
     }
   },
   "0.9.48": {
+    "previous_stable_version": "0.9.47",
     "x86_64_linux_gnu": {
       "checksum": "9730218bacb5f6c1697a4f44a94958a3ce708e8cc7ff430ac007075620b49b09"
     },
@@ -194,6 +204,7 @@
     }
   },
   "0.9.47": {
+    "previous_stable_version": "0.9.46",
     "x86_64_linux_gnu": {
       "checksum": "8518f212d10ab67ad620bcf8dff755a0f083757440881143c31a3904821f260f"
     },
@@ -211,11 +222,13 @@
     }
   },
   "0.9.46": {
+    "previous_stable_version": "0.9.45",
     "x86_64_macos": {
       "checksum": "938fa847ab1d7d0fa94dbeb9bdea817187bcf89c59d2a871b24042b09ad17944"
     }
   },
   "0.9.45": {
+    "previous_stable_version": "0.9.44",
     "x86_64_linux_gnu": {
       "checksum": "fb7dd79b1b16e2c8a4476c72091988852966ad42dd969eaf3469b84bb996f08c"
     },
@@ -233,6 +246,7 @@
     }
   },
   "0.9.44": {
+    "previous_stable_version": "0.9.43",
     "x86_64_linux_gnu": {
       "checksum": "544e15a10bdea2e98da6762d062a61fe1e1a24235200895c9f1c4817d3d9fec1"
     },
@@ -250,6 +264,7 @@
     }
   },
   "0.9.43": {
+    "previous_stable_version": "0.9.42",
     "x86_64_linux_gnu": {
       "checksum": "448e6700d5b0e459b9dcd73f6ebc76fd57bd1c621f4ac5f2c915ac90d6e89c84"
     },
@@ -267,6 +282,7 @@
     }
   },
   "0.9.42": {
+    "previous_stable_version": "0.9.41",
     "x86_64_linux_gnu": {
       "checksum": "baaed41d21ff120fed927e022c9bf74e8d31dc50a4342e7849894fc341f31c53"
     },
@@ -284,11 +300,13 @@
     }
   },
   "0.9.41": {
+    "previous_stable_version": "0.9.40",
     "x86_64_macos": {
       "checksum": "1d2983bed390e6e5fb13222dc0724bb54a3f67226e87e7a304c7dd3f0003ca61"
     }
   },
   "0.9.40": {
+    "previous_stable_version": "0.9.39",
     "x86_64_linux_gnu": {
       "checksum": "d9ab201015d93bc1e47b0c9da0a778d746fb7f22c610cdc9f2dabd441dd7fc76"
     },
@@ -306,6 +324,7 @@
     }
   },
   "0.9.39": {
+    "previous_stable_version": "0.9.38",
     "x86_64_linux_gnu": {
       "checksum": "759d6766f4686af03c99d9d641286b313b8acad01f5795d825eb33014ae0867a"
     },
@@ -323,6 +342,7 @@
     }
   },
   "0.9.38": {
+    "previous_stable_version": "0.9.37",
     "x86_64_linux_gnu": {
       "checksum": "ce6a30df41bc32158d0136b59757f41e9da9b9633ca00a5f96f03c4586ea7bf5"
     },
@@ -340,6 +360,7 @@
     }
   },
   "0.9.37": {
+    "previous_stable_version": "0.9.36",
     "x86_64_linux_gnu": {
       "checksum": "da51679397ed055a0cc2f2e63ff934d179372bbd88f937f71f7255fd5c528755"
     },
@@ -357,6 +378,7 @@
     }
   },
   "0.9.36": {
+    "previous_stable_version": "0.9.35",
     "x86_64_linux_gnu": {
       "checksum": "d2b0f7b0773e60a93aba72a9ae5c11fc348e58f38fe25d6e1877725d9e6ae475"
     },
@@ -374,6 +396,7 @@
     }
   },
   "0.9.35": {
+    "previous_stable_version": "0.9.34",
     "x86_64_linux_gnu": {
       "checksum": "fa6fbc8d848e595d847eaeddea432dad6944a4cfc4ac3156ef91173772a1c4ab"
     },
@@ -391,6 +414,7 @@
     }
   },
   "0.9.34": {
+    "previous_stable_version": "0.9.33",
     "x86_64_linux_gnu": {
       "checksum": "a96acb41a9ca14d5cd5aef9e8a12c1be8f8a3362bafe4f3a3da32c56b9c1abc5"
     },
@@ -408,6 +432,7 @@
     }
   },
   "0.9.33": {
+    "previous_stable_version": "0.9.32",
     "x86_64_linux_gnu": {
       "checksum": "6bfd0f9f156dcad38f40282320b38cb513f19023617b9df327026cc8e41a2795"
     },
@@ -425,6 +450,7 @@
     }
   },
   "0.9.32": {
+    "previous_stable_version": "0.9.31",
     "x86_64_linux_gnu": {
       "checksum": "3c4688160d7055494ba4343b6f84c80d229576df6acf6c4caf955b01e52a67a9"
     },
@@ -442,6 +468,7 @@
     }
   },
   "0.9.31": {
+    "previous_stable_version": "0.9.30",
     "x86_64_linux_gnu": {
       "checksum": "e086b4d84f08ff750afc917dbe89803e3aece8ff166ab380d2c4437cd459da72"
     },
@@ -459,6 +486,7 @@
     }
   },
   "0.9.30": {
+    "previous_stable_version": "0.9.29",
     "x86_64_linux_gnu": {
       "checksum": "6607736082fa6557012cd1b388cc63d3ec4b5eb344d41404c0726bfaa37c108b"
     },
@@ -476,6 +504,7 @@
     }
   },
   "0.9.29": {
+    "previous_stable_version": "0.9.28",
     "x86_64_linux_gnu": {
       "checksum": "b57d1662827d85be4ea37e9e4ca0bc53b96dc564fb8d8ab2300fda3b53423895"
     },
@@ -493,6 +522,7 @@
     }
   },
   "0.9.28": {
+    "previous_stable_version": "0.9.27",
     "x86_64_linux_gnu": {
       "checksum": "fa0f8843469cf3c541b6dedb9321ba04573d9ba75bf8608a028537ba924f0bd8"
     },
@@ -504,6 +534,7 @@
     }
   },
   "0.9.27": {
+    "previous_stable_version": "0.9.26",
     "x86_64_linux_gnu": {
       "checksum": "da3054259e0aac51d3a4392778a594fa22cef2ae22494c2cc109ffe1b895e1f6"
     },
@@ -515,6 +546,7 @@
     }
   },
   "0.9.26": {
+    "previous_stable_version": "0.9.25",
     "x86_64_linux_gnu": {
       "checksum": "fda7a9d8964d87da648fb2336957a5ea4c3584671eeac4d378a258873395814a"
     },
@@ -526,6 +558,7 @@
     }
   },
   "0.9.25": {
+    "previous_stable_version": "0.9.24",
     "x86_64_linux_gnu": {
       "checksum": "5a0af54644702a17690d3e9bfe5b007f5eb04a423a31560011818f6e6b828011"
     },
@@ -537,6 +570,7 @@
     }
   },
   "0.9.24": {
+    "previous_stable_version": "0.9.23",
     "x86_64_linux_gnu": {
       "checksum": "a51b6fedb9b7a4d1616bed1e84a9c001a7b74f1c238d0f82fd06f2c2c1852a15"
     },
@@ -548,6 +582,7 @@
     }
   },
   "0.9.23": {
+    "previous_stable_version": "0.9.22",
     "x86_64_linux_gnu": {
       "checksum": "e55ea8d86b2667fa630e1b3cf61eb1d5f079619ccc63c193b64545a2b6bc5cea"
     },
@@ -559,6 +594,7 @@
     }
   },
   "0.9.22": {
+    "previous_stable_version": "0.9.21",
     "x86_64_linux_gnu": {
       "checksum": "b0d05e3fc88b0fb8320a05fc860f2f5030e8f6ee2662e62750a194e8af5546f6"
     },
@@ -570,6 +606,7 @@
     }
   },
   "0.9.21": {
+    "previous_stable_version": "0.9.20",
     "x86_64_linux_gnu": {
       "checksum": "33b905ef2202b97e7103ff7765a42547e25b2d6b781f6f985442e2b438d1aa62"
     },
@@ -581,6 +618,7 @@
     }
   },
   "0.9.20": {
+    "previous_stable_version": "0.9.19",
     "x86_64_linux_gnu": {
       "checksum": "d1de19dc8e5d46aaa5fc00394e1a7ccb04160761a4d262f58d1eb6b73b80d73b"
     },
@@ -592,6 +630,7 @@
     }
   },
   "0.9.19": {
+    "previous_stable_version": "0.9.18",
     "x86_64_linux_gnu": {
       "checksum": "fd351b31fdb2ce547027928918820d7f07e3a1782e419427028f4993ae7be8ef"
     },
@@ -603,6 +642,7 @@
     }
   },
   "0.9.18": {
+    "previous_stable_version": "0.9.17",
     "x86_64_linux_gnu": {
       "checksum": "acbeaf13acdf5913dae7c628eaf834e2ad166567fdfbb8fc5bb1a7e3fcf1ea0d"
     },
@@ -614,6 +654,7 @@
     }
   },
   "0.9.17": {
+    "previous_stable_version": "0.9.16",
     "x86_64_linux_gnu": {
       "checksum": "2ac1d189f8efdc3ef6f487b1230c41f4f417b26caee07fef2845828cd5282ee6"
     },
@@ -625,6 +666,7 @@
     }
   },
   "0.9.16": {
+    "previous_stable_version": "0.9.15",
     "x86_64_linux_gnu": {
       "checksum": "64889b60a9d13082b2848c262072bf113635c70a71b89656e7d9848dbb10f58b"
     },
@@ -636,6 +678,7 @@
     }
   },
   "0.9.15": {
+    "previous_stable_version": "0.9.14",
     "x86_64_linux_gnu": {
       "checksum": "d80d666195a97d0e41c371f7e763855475d08d9a5209aa5302598d926bbb590c"
     },
@@ -647,6 +690,7 @@
     }
   },
   "0.9.14": {
+    "previous_stable_version": "0.9.13",
     "x86_64_linux_gnu": {
       "checksum": "42bcff26fec36c213371108cbf1c7d5baeccf3ae84f4f177db222d59268db417"
     },
@@ -658,6 +702,7 @@
     }
   },
   "0.9.13": {
+    "previous_stable_version": "0.9.12",
     "x86_64_linux_gnu": {
       "checksum": "299338ee9dba31b1b1df06142ce6fbfb3388f42b5047b33bc6f83db1b903a6b8"
     },
@@ -669,6 +714,7 @@
     }
   },
   "0.9.12": {
+    "previous_stable_version": "0.9.11",
     "x86_64_linux_gnu": {
       "checksum": "62a3bd60304f031a9e8de2eb5359ac709bbf43c979b2885cf719ee6982925a1b"
     },
@@ -680,6 +726,7 @@
     }
   },
   "0.9.11": {
+    "previous_stable_version": "0.9.10",
     "x86_64_linux_gnu": {
       "checksum": "edf8b5de7ae39fc1f7c1a5696f92fecee67ea40eb2937b707c026421cd2b0ef7"
     },
@@ -691,6 +738,7 @@
     }
   },
   "0.9.10": {
+    "previous_stable_version": "0.9.9",
     "x86_64_linux_gnu": {
       "checksum": "72f2452beab162849800e451f002b7b666599c1fbf48ba0f1e4e1f66d1a3f964"
     },
@@ -702,6 +750,7 @@
     }
   },
   "0.9.9": {
+    "previous_stable_version": "0.9.8",
     "x86_64_linux_gnu": {
       "checksum": "a68f660fc632ba9f56d34c108e12268c776b3a4af12e4a57919defea2749a4fb"
     },
@@ -713,6 +762,7 @@
     }
   },
   "0.9.8": {
+    "previous_stable_version": "0.9.7",
     "x86_64_linux_gnu": {
       "checksum": "9f2bcac8b65bafb12573b0106db48b29d9ceba4acaa351cc5f2504d38245de61"
     },
@@ -724,6 +774,7 @@
     }
   },
   "0.9.7": {
+    "previous_stable_version": "0.9.6",
     "x86_64_linux_gnu": {
       "checksum": "f837faa4e747a82f73f01e735dc9304e64bda55adcf857b9448158d1817cafbc"
     },
@@ -735,6 +786,7 @@
     }
   },
   "0.9.6": {
+    "previous_stable_version": "0.9.5",
     "x86_64_linux_gnu": {
       "checksum": "de73c56b53a96dbdbb0625727cd7296afebfc3b3b561310330732aefd20808bf"
     },
@@ -746,6 +798,7 @@
     }
   },
   "0.9.5": {
+    "previous_stable_version": "0.9.4",
     "x86_64_linux_gnu": {
       "checksum": "170abd2e313faab81ff5f9a029feec552fed6f9131790206554870a8e33ff6ab"
     },

--- a/manifests/cargo-no-dev-deps.json
+++ b/manifests/cargo-no-dev-deps.json
@@ -27,6 +27,7 @@
     "version": "0.2.3"
   },
   "0.2.3": {
+    "previous_stable_version": "0.2.2",
     "x86_64_linux_musl": {
       "checksum": "ccd4ee0b1cbe122657d5968ad27712b9ecb291aa58e5ec6e1b2964e78f9f00ee"
     },
@@ -47,6 +48,7 @@
     }
   },
   "0.2.2": {
+    "previous_stable_version": "0.2.1",
     "x86_64_linux_musl": {
       "checksum": "06871d1243c12568ec1df16d1fe663413b86ac4b9993f208e8b683a9d6fb2c95"
     },
@@ -67,6 +69,7 @@
     }
   },
   "0.2.1": {
+    "previous_stable_version": "0.2.0",
     "x86_64_linux_musl": {
       "checksum": "decd3116739cb5bc956ea467864e18742b012e1b5368ef30e748bb23fba11d53"
     },
@@ -87,6 +90,7 @@
     }
   },
   "0.2.0": {
+    "previous_stable_version": "0.1.0",
     "x86_64_linux_musl": {
       "checksum": "446d7879e260d1a6170ee105c211255e0729d2db50d4d6378c60ebc19b26b056"
     },

--- a/manifests/cargo-tarpaulin.json
+++ b/manifests/cargo-tarpaulin.json
@@ -24,6 +24,7 @@
     "version": "0.26.1"
   },
   "0.26.1": {
+    "previous_stable_version": "0.26.0",
     "x86_64_linux_musl": {
       "checksum": "d8f07d68b2739a545ffa6f45b093922cb23d0726d086b3d4c405aa374b154186"
     },
@@ -41,6 +42,7 @@
     }
   },
   "0.26.0": {
+    "previous_stable_version": "0.25.2",
     "x86_64_linux_musl": {
       "checksum": "c0c89310eecf34ede08e4c82a3be34ae5982e7a751b48290b05c5e829ae9c948"
     },
@@ -61,6 +63,7 @@
     "version": "0.25.2"
   },
   "0.25.2": {
+    "previous_stable_version": "0.25.1",
     "x86_64_linux_musl": {
       "checksum": "89f0f28baa818f445336da35c204206544b5e1160892ca0d5f50fe034abff771"
     },
@@ -78,6 +81,7 @@
     }
   },
   "0.25.1": {
+    "previous_stable_version": "0.25.0",
     "x86_64_linux_musl": {
       "checksum": "3af89e49bb98caf0ce01f87bbe4493dd4219e0e47aa577149fb3d9046b39965a"
     },
@@ -95,6 +99,7 @@
     }
   },
   "0.25.0": {
+    "previous_stable_version": "0.24.0",
     "x86_64_linux_musl": {
       "checksum": "e6ae2d11e684ee20f3860b1833de6fcb6ac44db5fc49a82a179bb969924870f3"
     },

--- a/manifests/cargo-udeps.json
+++ b/manifests/cargo-udeps.json
@@ -37,6 +37,7 @@
     "version": "0.1.41"
   },
   "0.1.41": {
+    "previous_stable_version": "0.1.40",
     "x86_64_linux_musl": {
       "checksum": "9895062bb4563c6eb6f0d1134f443d95550e3aefa51c9dc65a716550ef12fa74"
     },
@@ -57,6 +58,7 @@
     }
   },
   "0.1.40": {
+    "previous_stable_version": "0.1.39",
     "x86_64_linux_musl": {
       "checksum": "6bb8bc63de21e47afb44e9b1fcc2f5444120a0658bfe7b2b64a0eb575667ee59"
     },
@@ -77,6 +79,7 @@
     }
   },
   "0.1.39": {
+    "previous_stable_version": "0.1.38",
     "x86_64_linux_musl": {
       "checksum": "6476cf5711a150c53b563ecb1680b45365c86b054079b483333a961e14dd2c8a"
     },
@@ -97,6 +100,7 @@
     }
   },
   "0.1.38": {
+    "previous_stable_version": "0.1.35",
     "x86_64_linux_gnu": {
       "checksum": "5993f873ae46a94237b8e9be7bf990f9da165fc516b1ffa17ec680a0f52d07c3"
     },
@@ -108,6 +112,7 @@
     }
   },
   "0.1.35": {
+    "previous_stable_version": "0.1.33",
     "x86_64_linux_gnu": {
       "checksum": "a2291a214210d5c658697abc6a183dbb28f14dbb2757be364e6465c315561160"
     },
@@ -119,6 +124,7 @@
     }
   },
   "0.1.33": {
+    "previous_stable_version": "0.1.32",
     "x86_64_linux_gnu": {
       "checksum": "3f861a2c9be2b3b2333a2a37d6fc5914c5aae4b02a824c97e221c46f08252c7b"
     },
@@ -130,6 +136,7 @@
     }
   },
   "0.1.32": {
+    "previous_stable_version": "0.1.31",
     "x86_64_linux_gnu": {
       "checksum": "dbb1a726366dcf07b0ae4ce3edaff518b15d04a8e90063ca0b13b4afea7b95d9"
     },
@@ -141,6 +148,7 @@
     }
   },
   "0.1.31": {
+    "previous_stable_version": "0.1.30",
     "x86_64_linux_gnu": {
       "checksum": "46e6253a81db1a7dbe4712852e24094eba65057d74051941cb9de8c6a4a0e457"
     },
@@ -152,6 +160,7 @@
     }
   },
   "0.1.30": {
+    "previous_stable_version": "0.1.29",
     "x86_64_linux_gnu": {
       "checksum": "369e270ea2bb14d3ab92e99a1f12334efcac27d5c1714b74aacc956550780575"
     },
@@ -163,6 +172,7 @@
     }
   },
   "0.1.29": {
+    "previous_stable_version": "0.1.28",
     "x86_64_linux_gnu": {
       "checksum": "21e88dce237a69fb5b36771b83cb6b6fca20c09a2b5c576ea8efaf7218a5c641"
     },
@@ -174,6 +184,7 @@
     }
   },
   "0.1.28": {
+    "previous_stable_version": "0.1.27",
     "x86_64_linux_gnu": {
       "checksum": "d916d8915e8175f1fcc5e949662367a71835ecd7f6bd998ad8c474ad1224c2de"
     },
@@ -185,6 +196,7 @@
     }
   },
   "0.1.27": {
+    "previous_stable_version": "0.1.26",
     "x86_64_linux_gnu": {
       "checksum": "3cfa4a13aebe2db7002dbfed48e051945d109d9dc0eb8fc2a58ca0034509afb7"
     },
@@ -196,6 +208,7 @@
     }
   },
   "0.1.26": {
+    "previous_stable_version": "0.1.25",
     "x86_64_linux_gnu": {
       "checksum": "a6afb71254ffa24aff510efe393ba948750c2382e88f385b04e00013614d9908"
     },
@@ -207,6 +220,7 @@
     }
   },
   "0.1.25": {
+    "previous_stable_version": "0.1.24",
     "x86_64_linux_gnu": {
       "checksum": "6ea23ee2cda4490d131c915474601343757283c979017dbda93b820a895ffdcc"
     },
@@ -218,6 +232,7 @@
     }
   },
   "0.1.24": {
+    "previous_stable_version": "0.1.23",
     "x86_64_linux_gnu": {
       "checksum": "c0fb48dc24923ad9595a7e1de870713c02791d7ac36de3c37070748b604674eb"
     },
@@ -229,6 +244,7 @@
     }
   },
   "0.1.23": {
+    "previous_stable_version": "0.1.22",
     "x86_64_linux_gnu": {
       "checksum": "a88fb952d257536c93d53a45d3c343428a887d92e0f2f5b1fa27c9ef82e3ef24"
     },
@@ -240,6 +256,7 @@
     }
   },
   "0.1.22": {
+    "previous_stable_version": "0.1.21",
     "x86_64_linux_gnu": {
       "checksum": "6f787362cad3770f08727f62221f4108ea7cfc2b7d69d6d7fc98164042e3a12e"
     },
@@ -251,6 +268,7 @@
     }
   },
   "0.1.21": {
+    "previous_stable_version": "0.1.20",
     "x86_64_linux_gnu": {
       "checksum": "63760a60a8d248495ea92bea7d7a159c43c7c2260797b553e4cbe0dff339e38d"
     },
@@ -262,6 +280,7 @@
     }
   },
   "0.1.20": {
+    "previous_stable_version": "0.1.19",
     "x86_64_linux_gnu": {
       "checksum": "d6cfbe77f437cdf43af05f2405551900fc26051b02063e6967f08d772ffd55d5"
     },
@@ -273,6 +292,7 @@
     }
   },
   "0.1.19": {
+    "previous_stable_version": "0.1.18",
     "x86_64_linux_gnu": {
       "checksum": "e00e15b4c0b92e5022deb3e3233cce0ad672e2115409617336596509a0539ff0"
     },
@@ -284,6 +304,7 @@
     }
   },
   "0.1.18": {
+    "previous_stable_version": "0.1.17",
     "x86_64_linux_gnu": {
       "checksum": "c4d46673bfa3e3ca776c1e05551e02cf03feb811cbe5145cbbf6a6656392e1d7"
     },
@@ -295,6 +316,7 @@
     }
   },
   "0.1.17": {
+    "previous_stable_version": "0.1.16",
     "x86_64_linux_gnu": {
       "checksum": "45f8d023bf4eb1f256a0f14df46ab3d4d95ec1d1dd613e84c6fca9efa9ae078b"
     },
@@ -306,6 +328,7 @@
     }
   },
   "0.1.16": {
+    "previous_stable_version": "0.1.15",
     "x86_64_linux_gnu": {
       "checksum": "356998cf01dfa46bbed729cd622a8c27ba299a0597e13d3ff2279b60466e6177"
     },
@@ -317,6 +340,7 @@
     }
   },
   "0.1.15": {
+    "previous_stable_version": "0.1.14",
     "x86_64_linux_gnu": {
       "checksum": "40b21ac14657b70cb24e322cc21b23fa1225048651c7babcb3b0089036f33272"
     },
@@ -328,6 +352,7 @@
     }
   },
   "0.1.14": {
+    "previous_stable_version": "0.1.13",
     "x86_64_linux_gnu": {
       "checksum": "44ae26b5b1334458d3f3624fab610d78ad73815b23b51825641366652c1730b4"
     },
@@ -339,6 +364,7 @@
     }
   },
   "0.1.13": {
+    "previous_stable_version": "0.1.12",
     "x86_64_linux_gnu": {
       "checksum": "8c3ba8017c52ab8579de0df4f16ac15dabbe070b2040f21a89e4c7d5819cfa9f"
     },
@@ -350,6 +376,7 @@
     }
   },
   "0.1.12": {
+    "previous_stable_version": "0.1.11",
     "x86_64_linux_gnu": {
       "checksum": "1e9c5b7034cc74482bdf5ac3e03155b7041997be05902517abf4aa1ee5b243ad"
     },
@@ -361,6 +388,7 @@
     }
   },
   "0.1.11": {
+    "previous_stable_version": "0.1.10",
     "x86_64_linux_gnu": {
       "checksum": "5034f09ef5afabc65cfe1577bc067d849f5d2f08936df67d7eddf0acf5126825"
     },
@@ -372,6 +400,7 @@
     }
   },
   "0.1.10": {
+    "previous_stable_version": "0.1.9",
     "x86_64_linux_gnu": {
       "checksum": "2179f38ed4265af2584e4bb6510d98579ab61a3c3bd6e44d1be377297758a90a"
     },
@@ -383,6 +412,7 @@
     }
   },
   "0.1.9": {
+    "previous_stable_version": "0.1.8",
     "x86_64_linux_gnu": {
       "checksum": "222c0babc34825bca02ea9459095af45caeaef0f4bd98fd80f14c4aa2d9a6f67"
     },
@@ -394,6 +424,7 @@
     }
   },
   "0.1.8": {
+    "previous_stable_version": "0.1.7",
     "x86_64_linux_gnu": {
       "checksum": "db00d972d14376ea059f84fc411576f8cec2ad4ad29a407374266294d6758e3f"
     },
@@ -405,6 +436,7 @@
     }
   },
   "0.1.7": {
+    "previous_stable_version": "0.1.6",
     "x86_64_linux_gnu": {
       "checksum": "469915bcdc5daca376b1296a04207163cc03a3eea5f142463a3ccbf180e49c63"
     },

--- a/manifests/cross.json
+++ b/manifests/cross.json
@@ -8,6 +8,7 @@
     "version": "0.2.5"
   },
   "0.2.5": {
+    "previous_stable_version": "0.2.4",
     "x86_64_linux_musl": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.2.5/cross-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "a486cefa6cb486971b97be321ea9dfc2e90c1979550295314a368f53fab6d588"
@@ -22,6 +23,7 @@
     }
   },
   "0.2.4": {
+    "previous_stable_version": "0.2.3",
     "x86_64_linux_musl": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.2.4/cross-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "7ed556a4f3d68adbf679724b839853393d44c86321c4cf0636e8aef5610be556"
@@ -36,6 +38,7 @@
     }
   },
   "0.2.3": {
+    "previous_stable_version": "0.2.2",
     "x86_64_linux_musl": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.2.3/cross-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "1bfeeef09259e9e15995c6f429970371714735415f64b9a4463da0867b7961c5"
@@ -50,6 +53,7 @@
     }
   },
   "0.2.2": {
+    "previous_stable_version": "0.2.1",
     "x86_64_linux_musl": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.2.2/cross-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "e31df42dc18659ef3caf0f6b41a8fabb0c7356ba95c87516625271791a113439"
@@ -64,6 +68,7 @@
     }
   },
   "0.2.1": {
+    "previous_stable_version": "0.2.0",
     "x86_64_linux_musl": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.2.1/cross-v0.2.1-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "b2e2ff0c25cb1787c0e44984136c2243b14df20023adcc7cfb9170ecfde7ad68"
@@ -78,6 +83,7 @@
     }
   },
   "0.2.0": {
+    "previous_stable_version": "0.1.16",
     "x86_64_linux_musl": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.2.0/cross-v0.2.0-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "53a05bacf658e4572b7a3d233259f1093d7243152af564ac3e9e96873b6e5d5d"
@@ -95,6 +101,7 @@
     "version": "0.1.16"
   },
   "0.1.16": {
+    "previous_stable_version": "0.1.15",
     "x86_64_linux_musl": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.1.16/cross-v0.1.16-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "bc9ceed6ad99137c06f8e8ca8079f736b4752a575bc80cbdf4a99236685d0045"
@@ -105,6 +112,7 @@
     }
   },
   "0.1.15": {
+    "previous_stable_version": "0.1.14",
     "x86_64_linux_musl": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.1.15/cross-v0.1.15-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "cefa9bb181e15b5f1b58be49e21ebddaf38938d23f051caf59fe363657180a8e"
@@ -115,6 +123,7 @@
     }
   },
   "0.1.14": {
+    "previous_stable_version": "0.1.13",
     "x86_64_linux_musl": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.1.14/cross-v0.1.14-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "495c38aa910083ce1acadb0f5d2753089ca86e53473f1957b8f9ef8855307f2a"
@@ -125,6 +134,7 @@
     }
   },
   "0.1.13": {
+    "previous_stable_version": "0.1.12",
     "x86_64_linux_musl": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.1.13/cross-v0.1.13-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "749fd8fa5de62ede0ad64f770199b3a1222449542c9ebd29460ad8574d068754"
@@ -135,6 +145,7 @@
     }
   },
   "0.1.12": {
+    "previous_stable_version": "0.1.11",
     "x86_64_linux_musl": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.1.12/cross-v0.1.12-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "cbc08f5ed2ccea4ca5260c5b036c492031ede2f0951ba654fd8fa7f9ca2e2732"
@@ -145,6 +156,7 @@
     }
   },
   "0.1.11": {
+    "previous_stable_version": "0.1.10",
     "x86_64_linux_musl": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.1.11/cross-v0.1.11-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "d8fd0337e1c06728a0a098d4b54a300f297f2248c5d6e199b7a7769b8f8268a2"
@@ -155,6 +167,7 @@
     }
   },
   "0.1.10": {
+    "previous_stable_version": "0.1.9",
     "x86_64_linux_musl": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.1.10/cross-v0.1.10-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "73054fa744c4edf0be458a78a1ebbd1ebf62b4d550e53027302ca690c169daea"
@@ -165,6 +178,7 @@
     }
   },
   "0.1.9": {
+    "previous_stable_version": "0.1.8",
     "x86_64_linux_musl": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.1.9/cross-v0.1.9-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "0269bfee8b75d4b08963ea66f5c2651b3cbd0f6e4eba1158cd1409b6761cef29"
@@ -175,6 +189,7 @@
     }
   },
   "0.1.8": {
+    "previous_stable_version": "0.1.7",
     "x86_64_linux_musl": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.1.8/cross-v0.1.8-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "e58286e05d7f22b0f537d0dab9a631831044d9116326b18ad0980397e9ec7885"
@@ -185,6 +200,7 @@
     }
   },
   "0.1.7": {
+    "previous_stable_version": "0.1.6",
     "x86_64_linux_musl": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.1.7/cross-v0.1.7-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "6095ee63f8438b12ef197310f53de7a587eb9894140c0ecf55eed810cf3886a3"
@@ -195,6 +211,7 @@
     }
   },
   "0.1.6": {
+    "previous_stable_version": "0.1.5",
     "x86_64_linux_musl": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.1.6/cross-v0.1.6-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "3182adfca3b1dd5d9001118955f0919dd4819e236c7d9f48d9cfc59567e08165"
@@ -205,12 +222,14 @@
     }
   },
   "0.1.5": {
+    "previous_stable_version": "0.1.4",
     "x86_64_macos": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.1.5/cross-v0.1.5-x86_64-apple-darwin.tar.gz",
       "checksum": "4edf23abbab77000f3b2dbf6e8b2fe235484df46c720efdef882cc04f7aa162c"
     }
   },
   "0.1.4": {
+    "previous_stable_version": "0.1.3",
     "x86_64_linux_musl": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.1.4/cross-v0.1.4-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "cf233a80ef89003b8b4a60da39742753df5cc7280e8fea830dd7e95dc2c404bb"
@@ -221,6 +240,7 @@
     }
   },
   "0.1.3": {
+    "previous_stable_version": "0.1.2",
     "x86_64_linux_musl": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.1.3/cross-v0.1.3-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "25772e17ccb25b88be3eb764456f49ce46474520b9657044e0da20d00c7b28c9"
@@ -231,12 +251,14 @@
     }
   },
   "0.1.2": {
+    "previous_stable_version": "0.1.1",
     "x86_64_linux_musl": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.1.2/cross-v0.1.2-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "de1f4017f042e99e688b9bd1ed0b8708652e1df91ad2325638a40553425ba8e2"
     }
   },
   "0.1.1": {
+    "previous_stable_version": "0.1.0",
     "x86_64_linux_musl": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.1.1/cross-v0.1.1-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "4572d4da5ae7f87da7ab06f5148f246b30e512b2aeb51028041f2455c2c68e66"

--- a/manifests/dprint.json
+++ b/manifests/dprint.json
@@ -27,6 +27,7 @@
     "version": "0.40.2"
   },
   "0.40.2": {
+    "previous_stable_version": "0.40.1",
     "x86_64_linux_musl": {
       "checksum": "5c8418466937191f711ce4ba59e9ec28036daec01a08a505a17570a5edaec4c3"
     },
@@ -44,6 +45,7 @@
     }
   },
   "0.40.1": {
+    "previous_stable_version": "0.40.0",
     "x86_64_linux_musl": {
       "checksum": "0bc9cf7e191bd0c9a3e0ff84c77837da1a14f399220246d1955774135c0e40e6"
     },
@@ -61,6 +63,7 @@
     }
   },
   "0.40.0": {
+    "previous_stable_version": "0.39.1",
     "x86_64_linux_musl": {
       "checksum": "4ca464e5d57d2fcffaa724a4fcecd4b75a8a264df8e673feda0ca94267d07416"
     },
@@ -81,6 +84,7 @@
     "version": "0.39.1"
   },
   "0.39.1": {
+    "previous_stable_version": "0.39.0",
     "x86_64_linux_musl": {
       "checksum": "5e6ff56f68d31ff8411367fa021a15b29092d0d48bcd8b2741953927652da953"
     },
@@ -98,6 +102,7 @@
     }
   },
   "0.39.0": {
+    "previous_stable_version": "0.38.3",
     "x86_64_linux_musl": {
       "checksum": "85a05abe62b607b0b632dc2dfb70f1f0c25d0ba1c917ec5c57e4aba226617d42"
     },
@@ -118,6 +123,7 @@
     "version": "0.38.3"
   },
   "0.38.3": {
+    "previous_stable_version": "0.38.2",
     "x86_64_linux_musl": {
       "checksum": "51616da543b45d07a8da2aab1d2072f5b301078b70b1039da63a84749e0e3a65"
     },
@@ -135,6 +141,7 @@
     }
   },
   "0.38.2": {
+    "previous_stable_version": "0.38.1",
     "x86_64_linux_musl": {
       "checksum": "d57cdd843412c4a8b16a12c7a8b021494093eb011352aefe4f440592bdbfa37d"
     },
@@ -152,6 +159,7 @@
     }
   },
   "0.38.1": {
+    "previous_stable_version": "0.38.0",
     "x86_64_linux_musl": {
       "checksum": "6da012131c66ddea1437a3cbe50cbfaaf070fe0c1ecd6942a198c62d6982d9bd"
     },
@@ -169,6 +177,7 @@
     }
   },
   "0.38.0": {
+    "previous_stable_version": "0.37.1",
     "x86_64_linux_musl": {
       "checksum": "a518a2e3dc29b7db1af4b463feaee605657acba5cef6b846117bddbcec579400"
     },
@@ -189,6 +198,7 @@
     "version": "0.37.1"
   },
   "0.37.1": {
+    "previous_stable_version": "0.37.0",
     "x86_64_linux_musl": {
       "checksum": "a8a824eed75f1030c721a7e91ae79cbd5f48f8c19470d92ec5fd0dff2715add6"
     },
@@ -206,6 +216,7 @@
     }
   },
   "0.37.0": {
+    "previous_stable_version": "0.36.1",
     "x86_64_linux_musl": {
       "checksum": "714abf53b00f536bbd8ef1abc88f21fe4172952d39ea87bc5d139f8cbba28be1"
     },
@@ -226,6 +237,7 @@
     "version": "0.36.1"
   },
   "0.36.1": {
+    "previous_stable_version": "0.36.0",
     "x86_64_linux_musl": {
       "checksum": "da2597babb5948f3eb03939d9d96916db3e164b5c4f4dcf82303ba71356a8181"
     },
@@ -243,6 +255,7 @@
     }
   },
   "0.36.0": {
+    "previous_stable_version": "0.35.4",
     "x86_64_linux_musl": {
       "checksum": "fd5dfb6f63389413984166c05754274d2ac9685f2a54e80619b016d7f527ea17"
     },
@@ -263,6 +276,7 @@
     "version": "0.35.4"
   },
   "0.35.4": {
+    "previous_stable_version": "0.35.3",
     "x86_64_linux_musl": {
       "checksum": "a061268da99878970993d988b42de6324aea4cdce437fc1ca46ec51add4162dd"
     },
@@ -280,6 +294,7 @@
     }
   },
   "0.35.3": {
+    "previous_stable_version": "0.35.1",
     "x86_64_linux_musl": {
       "checksum": "05c109b7174c76345d04903fb6e16548de6ae684b24fc3849dccaa9e940fe5f0"
     },
@@ -297,6 +312,7 @@
     }
   },
   "0.35.1": {
+    "previous_stable_version": "0.35.0",
     "x86_64_linux_musl": {
       "checksum": "0e472818121e092a41c36cfcedee1021f8e4133465d97b85572448b35e322d6b"
     },
@@ -314,6 +330,7 @@
     }
   },
   "0.35.0": {
+    "previous_stable_version": "0.34.5",
     "x86_64_linux_musl": {
       "checksum": "e5bf6ea8fb9a9b236c8b03415a33e524e6721414a94786853be84e8d6a17351a"
     },
@@ -334,6 +351,7 @@
     "version": "0.34.5"
   },
   "0.34.5": {
+    "previous_stable_version": "0.34.4",
     "x86_64_linux_musl": {
       "checksum": "ad0296a8f4614a57e107df57e4f1f0f25ac32aeebdc201396160b5d046c26f55"
     },
@@ -351,6 +369,7 @@
     }
   },
   "0.34.4": {
+    "previous_stable_version": "0.34.2",
     "x86_64_linux_musl": {
       "checksum": "088d41a1b13b4623148119af9a3c2f618794170484294c210d5acd64f94a5cc6"
     },
@@ -368,6 +387,7 @@
     }
   },
   "0.34.2": {
+    "previous_stable_version": "0.34.1",
     "x86_64_linux_musl": {
       "checksum": "aee0a7ee92e67b9cc3d8d215dce4e0985c1239a1e674fbb987ac9e719f969ac8"
     },
@@ -385,6 +405,7 @@
     }
   },
   "0.34.1": {
+    "previous_stable_version": "0.34.0",
     "x86_64_linux_musl": {
       "checksum": "dd5833178a7986acaeea8abbac687754f3ee7ce39371ac55c3e17113938027c9"
     },
@@ -402,6 +423,7 @@
     }
   },
   "0.34.0": {
+    "previous_stable_version": "0.33.0",
     "x86_64_linux_musl": {
       "checksum": "227572fbcb761310dd21c2286fdc56a033f408919706895f7bf3913f241cf63a"
     },
@@ -422,6 +444,7 @@
     "version": "0.33.0"
   },
   "0.33.0": {
+    "previous_stable_version": "0.32.2",
     "x86_64_linux_gnu": {
       "checksum": "77c52e21df129e96a7860163029e267f38e705bc7be014b79668ad15f6e0c8e2"
     },
@@ -442,6 +465,7 @@
     "version": "0.32.2"
   },
   "0.32.2": {
+    "previous_stable_version": "0.32.1",
     "x86_64_linux_gnu": {
       "checksum": "8e8d0f32e5522a61f6251fb3b9c6be106584ccdfdb13008b276c1ee8bfdc6ffa"
     },
@@ -459,6 +483,7 @@
     }
   },
   "0.32.1": {
+    "previous_stable_version": "0.32.0",
     "x86_64_linux_gnu": {
       "checksum": "def34c9b2846a4a3675f324eee97b82d1834e522bfd42476ae91a036d2d1ded9"
     },
@@ -476,6 +501,7 @@
     }
   },
   "0.32.0": {
+    "previous_stable_version": "0.31.1",
     "x86_64_linux_gnu": {
       "checksum": "c339d67de7b2b119590629440b9809deb4f220b38c2f9bfd4c41af330731b901"
     },
@@ -496,6 +522,7 @@
     "version": "0.31.1"
   },
   "0.31.1": {
+    "previous_stable_version": "0.31.0",
     "x86_64_linux_gnu": {
       "checksum": "50ac53a230b44ac4c6f1259dc7223fdfa142bb0b8f15626008b2b770e7ee8e6b"
     },
@@ -513,6 +540,7 @@
     }
   },
   "0.31.0": {
+    "previous_stable_version": "0.30.3",
     "x86_64_linux_gnu": {
       "checksum": "7e7b8617b357c6925534f35f3c8f9b76b19884e665d7c3c30792395e8334fa86"
     },
@@ -533,6 +561,7 @@
     "version": "0.30.3"
   },
   "0.30.3": {
+    "previous_stable_version": "0.30.2",
     "x86_64_linux_gnu": {
       "checksum": "cefdc43953d9e20ec136219a33f9b866d67620e11975135a57562c3beb5b4842"
     },
@@ -550,6 +579,7 @@
     }
   },
   "0.30.2": {
+    "previous_stable_version": "0.30.1",
     "x86_64_linux_gnu": {
       "checksum": "c2a2c8dbc7b8f2e5e3ad2d3f7640f11df4e4745a54b5ba066b3bd6288265f6f4"
     },
@@ -567,6 +597,7 @@
     }
   },
   "0.30.1": {
+    "previous_stable_version": "0.30.0",
     "x86_64_linux_gnu": {
       "checksum": "c8b45ca831b742c3555060e4895e4adcd03894a2ad017f0fb9919adb99060197"
     },
@@ -584,6 +615,7 @@
     }
   },
   "0.30.0": {
+    "previous_stable_version": "0.29.1",
     "x86_64_linux_gnu": {
       "checksum": "8ca8c0d834f8e7c6f7be10c32e1c54fd99067997b0a15f22f598ad492029abb9"
     },
@@ -601,6 +633,7 @@
     "version": "0.29.1"
   },
   "0.29.1": {
+    "previous_stable_version": "0.29.0",
     "x86_64_linux_gnu": {
       "checksum": "be43c8ab4f3c4dc82490d33662307935a0665318e4f0609452cbe9d5f9a2f6b4"
     },
@@ -615,6 +648,7 @@
     }
   },
   "0.29.0": {
+    "previous_stable_version": "0.28.0",
     "x86_64_linux_gnu": {
       "checksum": "b355e3b023dc3d659bba2828bcd1bc3fa976d5cc1512a64df6e606800585e56f"
     },
@@ -632,6 +666,7 @@
     "version": "0.28.0"
   },
   "0.28.0": {
+    "previous_stable_version": "0.27.1",
     "x86_64_linux_gnu": {
       "checksum": "c53ff412c826749a3ff7a1c13265bd2012e03130600868656bb3d43c23e9768c"
     },
@@ -649,6 +684,7 @@
     "version": "0.27.1"
   },
   "0.27.1": {
+    "previous_stable_version": "0.27.0",
     "x86_64_linux_gnu": {
       "checksum": "588f4f904fa3f7346d7bea008d9b4f8905a0d9df2da45c93d1f250b5fdaad6f2"
     },
@@ -663,6 +699,7 @@
     }
   },
   "0.27.0": {
+    "previous_stable_version": "0.26.0",
     "x86_64_linux_gnu": {
       "checksum": "0bb1dd7a4c688bb89d4a70d5b76881f9766bd6e02b32dcb8e7311b7d3a581fe3"
     },
@@ -680,6 +717,7 @@
     "version": "0.26.0"
   },
   "0.26.0": {
+    "previous_stable_version": "0.25.1",
     "x86_64_linux_gnu": {
       "checksum": "d192142a310044178be97064f858f5a9327d73e6ee0ed6bc6b5a90378bf0f606"
     },
@@ -697,6 +735,7 @@
     "version": "0.25.1"
   },
   "0.25.1": {
+    "previous_stable_version": "0.25.0",
     "x86_64_linux_gnu": {
       "checksum": "5d9fd5a46f230ebcc19323a718d59f69871a647efddd9ec1c3579ef809c7222a"
     },
@@ -711,6 +750,7 @@
     }
   },
   "0.25.0": {
+    "previous_stable_version": "0.24.4",
     "x86_64_linux_gnu": {
       "checksum": "7dcb818e7a626504762685b8f77f49caffdcea4830bc4eaaeed8f3f5ceecb0ea"
     },
@@ -728,6 +768,7 @@
     "version": "0.24.4"
   },
   "0.24.4": {
+    "previous_stable_version": "0.24.3",
     "x86_64_linux_gnu": {
       "checksum": "1abbc9940b998793d3269f9f40d86d69aa78a7c62664f2889a1c3aba560049dc"
     },
@@ -742,6 +783,7 @@
     }
   },
   "0.24.3": {
+    "previous_stable_version": "0.24.2",
     "x86_64_linux_gnu": {
       "checksum": "f735d07f51f9d655d0710efcf0288fb9cdb76cc7b1e0f9a58ef79b6a3c6a57e4"
     },
@@ -756,6 +798,7 @@
     }
   },
   "0.24.2": {
+    "previous_stable_version": "0.24.1",
     "x86_64_linux_gnu": {
       "checksum": "5388a8f82b9c073ee9b854ee67603216ee42fbc92a4d97b45f16a67893a25d6a"
     },
@@ -770,6 +813,7 @@
     }
   },
   "0.24.1": {
+    "previous_stable_version": "0.24.0",
     "x86_64_linux_gnu": {
       "checksum": "3b1b80921f2996b4989e904f90a5cbda77dd510e74c7b94ea7fc46477b310a39"
     },
@@ -784,6 +828,7 @@
     }
   },
   "0.24.0": {
+    "previous_stable_version": "0.23.1",
     "x86_64_linux_gnu": {
       "checksum": "02de50aacbf9d3cc5fad45b503faba8cdd72626b7baedc7de430dc6db7b63e8a"
     },
@@ -801,6 +846,7 @@
     "version": "0.23.1"
   },
   "0.23.1": {
+    "previous_stable_version": "0.23.0",
     "x86_64_linux_gnu": {
       "checksum": "c57923a76ce8b5b134371f337db437a59b4ea5a86875c55339d366ad409bfd2a"
     },
@@ -815,6 +861,7 @@
     }
   },
   "0.23.0": {
+    "previous_stable_version": "0.22.2",
     "x86_64_linux_gnu": {
       "checksum": "488b0e78e5e607b5ad18ca02cadc55b23ee8ecde214c72881501097ba9b8d17b"
     },
@@ -832,6 +879,7 @@
     "version": "0.22.2"
   },
   "0.22.2": {
+    "previous_stable_version": "0.22.1",
     "x86_64_linux_gnu": {
       "checksum": "e57168da7a15efd980bc433afba2815697f51c4708313526fe95a25c83a5ba85"
     },
@@ -846,6 +894,7 @@
     }
   },
   "0.22.1": {
+    "previous_stable_version": "0.22.0",
     "x86_64_linux_gnu": {
       "checksum": "20178b34672777805960ca56643e74e0dbf07cdca648c923b4292d70131db7b5"
     },
@@ -857,6 +906,7 @@
     }
   },
   "0.22.0": {
+    "previous_stable_version": "0.21.2",
     "x86_64_linux_gnu": {
       "checksum": "cf0f87fca34c6f1727da7737b1d8accdb705e8660023d031a35eced91a87aa9f"
     },
@@ -871,6 +921,7 @@
     "version": "0.21.2"
   },
   "0.21.2": {
+    "previous_stable_version": "0.20.0",
     "x86_64_linux_gnu": {
       "checksum": "5af30a5668d7ed285b5ac541822055b5dadc728e152af2ae966dfbc5f3be3466"
     },
@@ -885,6 +936,7 @@
     "version": "0.20.0"
   },
   "0.20.0": {
+    "previous_stable_version": "0.19.2",
     "x86_64_linux_gnu": {
       "checksum": "5bb80558cba2f2f530e26e3acef2688523ffe826f40794f7bfffd954bd181992"
     },
@@ -899,6 +951,7 @@
     "version": "0.19.2"
   },
   "0.19.2": {
+    "previous_stable_version": "0.19.1",
     "x86_64_linux_gnu": {
       "checksum": "2c481ffe7b20c905ec8288281738f080a1bf650875c6c00a8728ca23d6fa8aed"
     },
@@ -910,6 +963,7 @@
     }
   },
   "0.19.1": {
+    "previous_stable_version": "0.19.0",
     "x86_64_linux_gnu": {
       "checksum": "97450b4830e2ea518b9b7d10c0e9cdd84e2f3a146a3b8d62ac6a323b8435dcd0"
     },
@@ -921,6 +975,7 @@
     }
   },
   "0.19.0": {
+    "previous_stable_version": "0.18.2",
     "x86_64_linux_gnu": {
       "checksum": "6f3ddfc5eaec246e225c1fd7f6644e537936296673da4699a314af0738108f3d"
     },
@@ -935,6 +990,7 @@
     "version": "0.18.2"
   },
   "0.18.2": {
+    "previous_stable_version": "0.18.1",
     "x86_64_linux_gnu": {
       "checksum": "aa7ec5bec46142c8d851845ee50032c2f2928960669712cb3b45bfc0d000a3c8"
     },
@@ -946,6 +1002,7 @@
     }
   },
   "0.18.1": {
+    "previous_stable_version": "0.18.0",
     "x86_64_linux_gnu": {
       "checksum": "955723c75429c58d5b513d85424421f8a1fb01bac5027f00efa968fcb232fc3f"
     },
@@ -957,6 +1014,7 @@
     }
   },
   "0.18.0": {
+    "previous_stable_version": "0.17.3",
     "x86_64_linux_gnu": {
       "checksum": "6f0b460e81ad26cfdb325e8eea01e972d6575ed3a563ffe7fe58f504eacc07b6"
     },
@@ -971,6 +1029,7 @@
     "version": "0.17.3"
   },
   "0.17.3": {
+    "previous_stable_version": "0.17.2",
     "x86_64_linux_gnu": {
       "checksum": "dc8ee039ecdcadd2b5abe5c1b96e220ffc04aeb43a6b1461db5fc3940f18884d"
     },
@@ -982,6 +1041,7 @@
     }
   },
   "0.17.2": {
+    "previous_stable_version": "0.17.1",
     "x86_64_linux_gnu": {
       "checksum": "4c40db2ea98c8c950568a4883054ce950ee523346936ed9e200e3b2ae86b0e3b"
     },
@@ -993,6 +1053,7 @@
     }
   },
   "0.17.1": {
+    "previous_stable_version": "0.17.0",
     "x86_64_linux_gnu": {
       "checksum": "2cb7a12d5d66bbaccbe544036feaefe3e0844ea93144b416bef3bcde072c1c89"
     },
@@ -1004,6 +1065,7 @@
     }
   },
   "0.17.0": {
+    "previous_stable_version": "0.16.3",
     "x86_64_linux_gnu": {
       "checksum": "0369bf22e6bcff3da8ae72b15f7b3b7d44fb9bea91cb989a29c95eb47fe42086"
     },
@@ -1018,6 +1080,7 @@
     "version": "0.16.3"
   },
   "0.16.3": {
+    "previous_stable_version": "0.16.1",
     "x86_64_linux_gnu": {
       "checksum": "89e68f2ceaaeec4713c01177452789bf27189665beac40fe61bd819f549fc748"
     },
@@ -1029,6 +1092,7 @@
     }
   },
   "0.16.1": {
+    "previous_stable_version": "0.16.0",
     "x86_64_linux_gnu": {
       "checksum": "a8c6033e3efd0a7bfabe577b3de33a716e73aeff70d485f13e537ced143dde76"
     },
@@ -1040,6 +1104,7 @@
     }
   },
   "0.16.0": {
+    "previous_stable_version": "0.15.1",
     "x86_64_linux_gnu": {
       "checksum": "65b8580d046a92cffa2f3b6a39d16e470a8af61caf45953d80fdd257c13995fa"
     },
@@ -1054,6 +1119,7 @@
     "version": "0.15.1"
   },
   "0.15.1": {
+    "previous_stable_version": "0.15.0",
     "x86_64_linux_gnu": {
       "checksum": "12bc594c74e8a1e73da2927bca082acbc6ae7b04b84f212a15c9df400ffd35f7"
     },
@@ -1065,6 +1131,7 @@
     }
   },
   "0.15.0": {
+    "previous_stable_version": "0.14.1",
     "x86_64_linux_gnu": {
       "checksum": "3ab70ddb0d1218eec1facfcabacf2d9732e070b04f324f837eed8463ea10703d"
     },
@@ -1079,6 +1146,7 @@
     "version": "0.14.1"
   },
   "0.14.1": {
+    "previous_stable_version": "0.14.0",
     "x86_64_linux_gnu": {
       "checksum": "0946e3fae7212e80379241ea555d3570f297423f227b1b9e568552fc4a9b8a3f"
     },
@@ -1090,6 +1158,7 @@
     }
   },
   "0.14.0": {
+    "previous_stable_version": "0.13.1",
     "x86_64_linux_gnu": {
       "checksum": "18be4651601822e425de7f536e56f5095b257ffc0fdc019759bd967d8f888e1f"
     },
@@ -1104,6 +1173,7 @@
     "version": "0.13.1"
   },
   "0.13.1": {
+    "previous_stable_version": "0.13.0",
     "x86_64_linux_gnu": {
       "checksum": "219443b85b843b820f97e8d590a6bda750ad7fcefb62ab07030992583eaa410d"
     },
@@ -1115,6 +1185,7 @@
     }
   },
   "0.13.0": {
+    "previous_stable_version": "0.12.0",
     "x86_64_linux_gnu": {
       "checksum": "632a12524ff5b312582b3ec651d810bcad3610b0b8efddcb6f8cfc7890d56f63"
     },
@@ -1129,6 +1200,7 @@
     "version": "0.12.0"
   },
   "0.12.0": {
+    "previous_stable_version": "0.11.1",
     "x86_64_linux_gnu": {
       "checksum": "ff8934e44b5a42601a14d3a60c29259e8b3a1ebb132e1d6db5741857a86b3384"
     },
@@ -1143,6 +1215,7 @@
     "version": "0.11.1"
   },
   "0.11.1": {
+    "previous_stable_version": "0.11.0",
     "x86_64_linux_gnu": {
       "checksum": "842ac6cf2d15062a9c5be2918f028a58d00740db0c2b9d3a25672f07d98a23c8"
     },
@@ -1154,6 +1227,7 @@
     }
   },
   "0.11.0": {
+    "previous_stable_version": "0.10.0",
     "x86_64_linux_gnu": {
       "checksum": "f396e88900c848f55507fbca63207d84c1485dce11fe8b77f4e51e44b284cb4f"
     },
@@ -1168,6 +1242,7 @@
     "version": "0.10.0"
   },
   "0.10.0": {
+    "previous_stable_version": "0.9.1",
     "x86_64_linux_gnu": {
       "checksum": "d459ace41a816314d6cdc90c7eba44c40079d35520f10393d4d87c28248f9b64"
     },
@@ -1182,6 +1257,7 @@
     "version": "0.9.1"
   },
   "0.9.1": {
+    "previous_stable_version": "0.9.0",
     "x86_64_linux_gnu": {
       "checksum": "d8f8490f56661633ce7c569b14e1c551c5d2a72879f6b6107d877586643977ca"
     },
@@ -1193,6 +1269,7 @@
     }
   },
   "0.9.0": {
+    "previous_stable_version": "0.8.0",
     "x86_64_linux_gnu": {
       "checksum": "0abd4b359bd8d87ef58bdb803770a9e4ab4f9f68f3377acf036624a50df56650"
     },
@@ -1207,6 +1284,7 @@
     "version": "0.8.0"
   },
   "0.8.0": {
+    "previous_stable_version": "0.7.4",
     "x86_64_linux_gnu": {
       "checksum": "294c6d8296206be52032c63c3f28ceb412fe92ad6dee468f02b93316f18a3be1"
     },
@@ -1221,6 +1299,7 @@
     "version": "0.7.4"
   },
   "0.7.4": {
+    "previous_stable_version": "0.7.3",
     "x86_64_linux_gnu": {
       "checksum": "50e42237094c59229227c0ab8bf1edb93aa54d968ee56d4e9ddcdbcf38dedb0c"
     },
@@ -1232,6 +1311,7 @@
     }
   },
   "0.7.3": {
+    "previous_stable_version": "0.7.2",
     "x86_64_linux_gnu": {
       "checksum": "ec6b32a8bb742d9735bb217091431f0c12e35bbfc288238ecd575f3937c41ca9"
     },
@@ -1243,6 +1323,7 @@
     }
   },
   "0.7.2": {
+    "previous_stable_version": "0.7.1",
     "x86_64_linux_gnu": {
       "checksum": "39a07c31b7305240eb43aa3ef2f542e17d4535aa64c1f1042795dd5b56b75400"
     },
@@ -1254,6 +1335,7 @@
     }
   },
   "0.7.1": {
+    "previous_stable_version": "0.7.0",
     "x86_64_linux_gnu": {
       "checksum": "640e4bb8e63658fd35bd4a10eedef1f7e690bff32cd2337087d620608b981934"
     },
@@ -1265,6 +1347,7 @@
     }
   },
   "0.7.0": {
+    "previous_stable_version": "0.6.3",
     "x86_64_linux_gnu": {
       "checksum": "b1f559d28e3f0bc2385d17b2d28102487e231228fe0a40ae69e772065375ade1"
     },
@@ -1279,6 +1362,7 @@
     "version": "0.6.3"
   },
   "0.6.3": {
+    "previous_stable_version": "0.6.2",
     "x86_64_linux_gnu": {
       "checksum": "dbeb29cd5877d52e603265e85f6fd26d0a122ab4c8de66a93cb24e09d5da23bf"
     },
@@ -1290,6 +1374,7 @@
     }
   },
   "0.6.2": {
+    "previous_stable_version": "0.6.1",
     "x86_64_linux_gnu": {
       "checksum": "dfab688f5a2306e7ca1d0f58bf245954cb6805bfb3d87b90d3d75991e501dd7d"
     },
@@ -1301,6 +1386,7 @@
     }
   },
   "0.6.1": {
+    "previous_stable_version": "0.6.0",
     "x86_64_linux_gnu": {
       "checksum": "36b6719ffbc608c7a9c2fec6be99f76e88e8ff81a89d45e010e694cf610048f8"
     },
@@ -1312,6 +1398,7 @@
     }
   },
   "0.6.0": {
+    "previous_stable_version": "0.5.8",
     "x86_64_linux_gnu": {
       "checksum": "1cd56f16b3f9c27f3c40fcb00b38363a3955c0c182108ee943c5e6fa13a7ea9a"
     },
@@ -1326,6 +1413,7 @@
     "version": "0.5.8"
   },
   "0.5.8": {
+    "previous_stable_version": "0.5.7",
     "x86_64_linux_gnu": {
       "checksum": "b7ded26218ca3e7b1a80675e025e34442dd5d0315fbe8c11b9095b7b9a8d814b"
     },
@@ -1337,6 +1425,7 @@
     }
   },
   "0.5.7": {
+    "previous_stable_version": "0.5.6",
     "x86_64_linux_gnu": {
       "checksum": "a82061612937efb631d8747f457ac109f5cb2d8772c1d66c8659bc12f29c11f9"
     },
@@ -1348,6 +1437,7 @@
     }
   },
   "0.5.6": {
+    "previous_stable_version": "0.5.5",
     "x86_64_linux_gnu": {
       "checksum": "8d31183001ae3bf9f151f93b91dc374adc0fb286d8575cfd71ff01e287dc8016"
     },
@@ -1359,6 +1449,7 @@
     }
   },
   "0.5.5": {
+    "previous_stable_version": "0.5.4",
     "x86_64_linux_gnu": {
       "checksum": "7f4be451f682b7992f4db4c127054f9aa9ec898ceabcfc8f175ca977d087bb4c"
     },
@@ -1370,6 +1461,7 @@
     }
   },
   "0.5.4": {
+    "previous_stable_version": "0.5.3",
     "x86_64_linux_gnu": {
       "checksum": "f1640b238846294b07018b668e8767f538636ea87edc5f337c7614118db9387b"
     },
@@ -1381,6 +1473,7 @@
     }
   },
   "0.5.3": {
+    "previous_stable_version": "0.5.2",
     "x86_64_linux_gnu": {
       "checksum": "5a87236acf7dd142209a2c64f2d4716515502643cc6b1e4a4fa0e9570fc23b4c"
     },
@@ -1392,6 +1485,7 @@
     }
   },
   "0.5.2": {
+    "previous_stable_version": "0.5.1",
     "x86_64_linux_gnu": {
       "checksum": "0896aed3e0de22abaa38466d25db00af8898d980dd8fa3818b0ba92a10ec3f47"
     },
@@ -1403,6 +1497,7 @@
     }
   },
   "0.5.1": {
+    "previous_stable_version": "0.5.0",
     "x86_64_linux_gnu": {
       "checksum": "7eba6068def0b5e9e647a02e1521a6d1c9e20d761c110bbb3f6badc8e41f0925"
     },
@@ -1414,6 +1509,7 @@
     }
   },
   "0.5.0": {
+    "previous_stable_version": "0.4.5",
     "x86_64_linux_gnu": {
       "checksum": "51870e9586d1e98ddac92cc4334ddb628c2af0743ede0ccbe389d761f07cffc5"
     },
@@ -1428,6 +1524,7 @@
     "version": "0.4.5"
   },
   "0.4.5": {
+    "previous_stable_version": "0.4.4",
     "x86_64_linux_gnu": {
       "checksum": "47ebdd71ba513fb18cfb0f19b95a6cecf27fecc8da9c17b7cf75bd608f5022f8"
     },
@@ -1439,6 +1536,7 @@
     }
   },
   "0.4.4": {
+    "previous_stable_version": "0.4.3",
     "x86_64_linux_gnu": {
       "checksum": "0ef7044896f80504e1bceec17ee22657226227092a0ee6cdb063757956affcea"
     },
@@ -1450,6 +1548,7 @@
     }
   },
   "0.4.3": {
+    "previous_stable_version": "0.4.2",
     "x86_64_linux_gnu": {
       "checksum": "b377462db6778f77bee112221298b88c2d1fb541304af92657de58f9eef27e93"
     },
@@ -1461,6 +1560,7 @@
     }
   },
   "0.4.2": {
+    "previous_stable_version": "0.4.1",
     "x86_64_linux_gnu": {
       "checksum": "191d5666593022917b0c51da568da5ddfe6e5d964289c49a1b67408ea6b82229"
     },
@@ -1472,6 +1572,7 @@
     }
   },
   "0.4.1": {
+    "previous_stable_version": "0.4.0",
     "x86_64_linux_gnu": {
       "checksum": "6d3cd69790b871d479169b0d1688bbbf9b3bc6fa40a39a6f8b3769e5dbcfabf2"
     },

--- a/manifests/grcov.json
+++ b/manifests/grcov.json
@@ -24,6 +24,7 @@
     "version": "0.8.18"
   },
   "0.8.18": {
+    "previous_stable_version": "0.8.16",
     "x86_64_linux_musl": {
       "checksum": "43b1b44a79b2fec04a4057ccaf199a1b015e02200d44c8c1a4eff4f2b2edfa87"
     },
@@ -41,6 +42,7 @@
     }
   },
   "0.8.16": {
+    "previous_stable_version": "0.8.15",
     "x86_64_linux_musl": {
       "checksum": "c414d6c72c693c103a99ac33eb759fe870c2ebc90486853ce2d72e94f0392853"
     },
@@ -58,6 +60,7 @@
     }
   },
   "0.8.15": {
+    "previous_stable_version": "0.8.13",
     "x86_64_linux_musl": {
       "checksum": "b4e369090a105aa264c287c1ced52d7cc04ec964179bd8affe05bcb762e75ea4"
     },
@@ -75,6 +78,7 @@
     }
   },
   "0.8.13": {
+    "previous_stable_version": "0.8.12",
     "x86_64_linux_musl": {
       "checksum": "e6c9108459ce028bc0ae257f73060f54e30f07e22d003b4c84dd74080a0cc5ce"
     },
@@ -92,6 +96,7 @@
     }
   },
   "0.8.12": {
+    "previous_stable_version": "0.8.11",
     "x86_64_linux_musl": {
       "checksum": "e1e270550337ce9b9bf190615fdfc09ba0d7d50b6f62b342ae438665edeaaa52"
     },
@@ -109,6 +114,7 @@
     }
   },
   "0.8.11": {
+    "previous_stable_version": "0.8.10",
     "x86_64_linux_musl": {
       "checksum": "054641c3e8cbdf78ec5643a903e6fc0560287343e03435e3adfbbb809f282b53"
     },
@@ -126,6 +132,7 @@
     }
   },
   "0.8.10": {
+    "previous_stable_version": "0.8.9",
     "x86_64_linux_musl": {
       "checksum": "8afc04b10914fd7ebaad061b5c1d31be0e42b5c1efc65caab21522f517e8023e"
     },
@@ -143,6 +150,7 @@
     }
   },
   "0.8.9": {
+    "previous_stable_version": "0.8.8",
     "x86_64_linux_musl": {
       "checksum": "a511886708da766c6441771edb7bb413a02a519f316f1ae51a0df8e5cc71d62f"
     },
@@ -160,6 +168,7 @@
     }
   },
   "0.8.8": {
+    "previous_stable_version": "0.8.7",
     "x86_64_linux_musl": {
       "checksum": "a05051eee645073fcccedcfda0d488f5cf7d80e0374b9b1b7faacde3c966d8ed"
     },

--- a/manifests/just.json
+++ b/manifests/just.json
@@ -27,6 +27,7 @@
     "version": "1.14.0"
   },
   "1.14.0": {
+    "previous_stable_version": "1.13.0",
     "x86_64_linux_musl": {
       "checksum": "19848d0282e95f30188305b1bbd5a087793e5c6f27f5ac98207ab256027183df"
     },
@@ -47,6 +48,7 @@
     "version": "1.13.0"
   },
   "1.13.0": {
+    "previous_stable_version": "1.12.0",
     "x86_64_linux_musl": {
       "checksum": "f76fce93a71686f6aa6b2db1a39184e736f9ac8248c0489e003c617b49eb2676"
     },
@@ -67,6 +69,7 @@
     "version": "1.12.0"
   },
   "1.12.0": {
+    "previous_stable_version": "1.11.0",
     "x86_64_linux_musl": {
       "checksum": "a8e1278f3a2c81384f9a146e74fc40b5204f00776cccfb4da4d36e45716546d4"
     },
@@ -87,6 +90,7 @@
     "version": "1.11.0"
   },
   "1.11.0": {
+    "previous_stable_version": "1.10.0",
     "x86_64_linux_musl": {
       "checksum": "c8068fcd03b800492ad0e5da84761034cb412542d6ded0a234da2a9fc578d540"
     },
@@ -107,6 +111,7 @@
     "version": "1.10.0"
   },
   "1.10.0": {
+    "previous_stable_version": "1.9.0",
     "x86_64_linux_musl": {
       "checksum": "388fef161a2d178cc4165fb2d096aafb87248742edbd35cc8cc0de431d4c0a95"
     },
@@ -127,6 +132,7 @@
     "version": "1.9.0"
   },
   "1.9.0": {
+    "previous_stable_version": "1.8.0",
     "x86_64_linux_musl": {
       "checksum": "a7e2349a2d9e0a04466c71924cd7d0744ceedb0a56817322aae6b8ccda889be3"
     },
@@ -147,6 +153,7 @@
     "version": "1.8.0"
   },
   "1.8.0": {
+    "previous_stable_version": "1.7.0",
     "x86_64_linux_musl": {
       "checksum": "140986a33c901656375068727da33329f7ffb2b555338cc001c245b68131c349"
     },
@@ -167,6 +174,7 @@
     "version": "1.7.0"
   },
   "1.7.0": {
+    "previous_stable_version": "1.6.0",
     "x86_64_linux_musl": {
       "checksum": "f474bbc5cc73af368fc7bb33c538874786cc3305211f5ab30e2384309ef3f2f0"
     },
@@ -187,6 +195,7 @@
     "version": "1.6.0"
   },
   "1.6.0": {
+    "previous_stable_version": "1.5.0",
     "x86_64_linux_musl": {
       "checksum": "c9e1112fddcb022eb34bcdef4500c603139400d9ac86b9b858ba5fe7e2831281"
     },
@@ -207,6 +216,7 @@
     "version": "1.5.0"
   },
   "1.5.0": {
+    "previous_stable_version": "1.4.0",
     "x86_64_linux_musl": {
       "checksum": "414147908f10a7e9e82b0148de79280ca9c48a70f7cd7bab1ce2d77959446fac"
     },
@@ -227,6 +237,7 @@
     "version": "1.4.0"
   },
   "1.4.0": {
+    "previous_stable_version": "1.3.0",
     "x86_64_linux_musl": {
       "checksum": "006a30ceb69f9c93e2dc1d8bac3845395ef5ddb4e6eead762a8cf29e68f6e2a4"
     },
@@ -247,6 +258,7 @@
     "version": "1.3.0"
   },
   "1.3.0": {
+    "previous_stable_version": "1.2.0",
     "x86_64_linux_musl": {
       "checksum": "1c52f337f9e5950829ff990f583d0ddedc11a071d5340980ac7d49dc3095995e"
     },
@@ -267,6 +279,7 @@
     "version": "1.2.0"
   },
   "1.2.0": {
+    "previous_stable_version": "1.1.3",
     "x86_64_linux_musl": {
       "checksum": "7102b1ba543745774df500db962dec2e3a01aa2553dd0c3f334e8fdadea41d25"
     },
@@ -287,6 +300,7 @@
     "version": "1.1.3"
   },
   "1.1.3": {
+    "previous_stable_version": "1.1.2",
     "x86_64_linux_musl": {
       "checksum": "63099f09106d5c5fe5579b3430a3ce4a02c193560842247ae70335575a24318c"
     },
@@ -304,6 +318,7 @@
     }
   },
   "1.1.2": {
+    "previous_stable_version": "1.1.1",
     "x86_64_linux_musl": {
       "checksum": "7d4d620ea73b58233b170ecc93dd1ef59336eeb9b59f94dc5ca7e06ed520e0cb"
     },
@@ -321,6 +336,7 @@
     }
   },
   "1.1.1": {
+    "previous_stable_version": "1.1.0",
     "x86_64_linux_musl": {
       "checksum": "ee7bf76941e8d7a41bab6716390a293e381a4a32bc46ad4d9d112f540aad34ba"
     },
@@ -338,6 +354,7 @@
     }
   },
   "1.1.0": {
+    "previous_stable_version": "1.0.1",
     "x86_64_linux_musl": {
       "checksum": "2dc78e8470dbdb0569a781ca85d86c01189ca16853d0aa997cb15b2fa1f70423"
     },
@@ -355,6 +372,7 @@
     "version": "1.0.1"
   },
   "1.0.1": {
+    "previous_stable_version": "1.0.0",
     "x86_64_linux_musl": {
       "checksum": "e8695fb60126158f7708dd48e36f51028fbed00ab62d9477b0e86ef1de6cbc73"
     },
@@ -369,6 +387,7 @@
     }
   },
   "1.0.0": {
+    "previous_stable_version": "0.11.2",
     "x86_64_linux_musl": {
       "checksum": "342f8582d929b9212ffcbe9f7749e12908053cf215eb8d4a965c47ea2f24b0a4"
     },
@@ -386,6 +405,7 @@
     "version": "0.11.2"
   },
   "0.11.2": {
+    "previous_stable_version": "0.11.0",
     "x86_64_linux_musl": {
       "checksum": "5cd03d96518dd67eb691f6783293c62d610fc63ee0a9ba5223f4c1383c2a4661"
     },
@@ -400,6 +420,7 @@
     }
   },
   "0.11.0": {
+    "previous_stable_version": "0.10.7",
     "x86_64_linux_musl": {
       "checksum": "7aef288e87d052bb6411ce4938167b5287963a4fa40515c9a2b403ce98342fec"
     },
@@ -417,6 +438,7 @@
     "version": "0.10.7"
   },
   "0.10.7": {
+    "previous_stable_version": "0.10.6",
     "x86_64_linux_musl": {
       "checksum": "54927f5e261a4965a5f406374b48eb39da6c15f859098626aca24765b6e158c1"
     },
@@ -431,11 +453,13 @@
     }
   },
   "0.10.6": {
+    "previous_stable_version": "0.10.5",
     "aarch64_linux_musl": {
       "checksum": "ccc9efd7f33cf7b18136d39540aea5e1d32337a9122cd29755dd54313fed4464"
     }
   },
   "0.10.5": {
+    "previous_stable_version": "0.10.4",
     "x86_64_linux_musl": {
       "checksum": "261e6912e3f63a37baa69d2dee5cc9f95f2523eaab38e3b73030ec1a1afde80e"
     },
@@ -450,6 +474,7 @@
     }
   },
   "0.10.4": {
+    "previous_stable_version": "0.10.3",
     "x86_64_linux_musl": {
       "checksum": "4d1f3e3bef97edeee26f1a3760ac404dcb3a1f52930405c8bd3cd3e5b70545d8"
     },
@@ -461,6 +486,7 @@
     }
   },
   "0.10.3": {
+    "previous_stable_version": "0.10.2",
     "x86_64_linux_musl": {
       "checksum": "0f43a286dfe67ed94034843cb72cec61a024303118ec19bd618bc4e15a0970ac"
     },
@@ -472,6 +498,7 @@
     }
   },
   "0.10.2": {
+    "previous_stable_version": "0.10.1",
     "x86_64_linux_musl": {
       "checksum": "280a6edf58076e90d2002b44d38f93dcd708209c446dbcc38344ed6d21a8aaf7"
     },
@@ -483,6 +510,7 @@
     }
   },
   "0.10.1": {
+    "previous_stable_version": "0.10.0",
     "x86_64_linux_musl": {
       "checksum": "5f99ddf0969eb2cfc3eee4b3b296e4ec495015c38eba65e91e89b764ca06f3bc"
     },
@@ -494,6 +522,7 @@
     }
   },
   "0.10.0": {
+    "previous_stable_version": "0.9.9",
     "x86_64_linux_musl": {
       "checksum": "661f3ebf1504f99cd96dfcb148f5e1d30e93c9c182680aab855cb881c3e0f13e"
     },
@@ -508,6 +537,7 @@
     "version": "0.9.9"
   },
   "0.9.9": {
+    "previous_stable_version": "0.9.8",
     "x86_64_linux_musl": {
       "checksum": "2c21ba77d25e385ebe751d0ced27225313a2c4c849b1b9ce397ca5ef6766afc1"
     },
@@ -519,6 +549,7 @@
     }
   },
   "0.9.8": {
+    "previous_stable_version": "0.9.7",
     "x86_64_linux_musl": {
       "checksum": "d41db56e50731d7019f998a958c8f640b4d61a887d814175159a4b53cd1fc4fe"
     },
@@ -530,6 +561,7 @@
     }
   },
   "0.9.7": {
+    "previous_stable_version": "0.9.6",
     "x86_64_linux_musl": {
       "checksum": "cc5e50f64732e561043d469ffac99f335023c93978a45c8fbc921eb4e955e688"
     },
@@ -541,6 +573,7 @@
     }
   },
   "0.9.6": {
+    "previous_stable_version": "0.9.5",
     "x86_64_linux_musl": {
       "checksum": "1253ac5b61eca3eaf5c69dd4b7e7ec551dec78821e9308f0b3f2a00020934f0e"
     },

--- a/manifests/mdbook-linkcheck.json
+++ b/manifests/mdbook-linkcheck.json
@@ -18,6 +18,7 @@
     "version": "0.7.7"
   },
   "0.7.7": {
+    "previous_stable_version": "0.7.6",
     "x86_64_linux_gnu": {
       "checksum": "18cebca9493804b307b39a44af2664cdfa881e84b8d92a94205d6c51572318ef"
     },

--- a/manifests/mdbook.json
+++ b/manifests/mdbook.json
@@ -24,6 +24,7 @@
     "version": "0.4.33"
   },
   "0.4.33": {
+    "previous_stable_version": "0.4.32",
     "x86_64_linux_musl": {
       "checksum": "f56043b14b2d554b98aa6cd5e15bcbe81c095cea67a937c6c724300da4fc4005"
     },
@@ -38,6 +39,7 @@
     }
   },
   "0.4.32": {
+    "previous_stable_version": "0.4.31",
     "x86_64_linux_musl": {
       "checksum": "ac38f040eb462752548c865d6c9e900aa862852d42190cd773d5f20cd7b757f9"
     },
@@ -52,6 +54,7 @@
     }
   },
   "0.4.31": {
+    "previous_stable_version": "0.4.30",
     "x86_64_linux_musl": {
       "checksum": "0332c3149dcc0b6ad1baab6cbf73f90e45b919fea3bd9c55fb5739fa980b2eaf"
     },
@@ -66,6 +69,7 @@
     }
   },
   "0.4.30": {
+    "previous_stable_version": "0.4.29",
     "x86_64_linux_musl": {
       "checksum": "c911f8e5b501707a6b84a5b7162f3c6543f580e5261034d23d2843319da12bb0"
     },
@@ -80,6 +84,7 @@
     }
   },
   "0.4.29": {
+    "previous_stable_version": "0.4.28",
     "x86_64_linux_musl": {
       "checksum": "e46da842fc1cba24efbf0028ef372435cfe2b5a55b87b287e698ae87d6a9e44c"
     },
@@ -94,6 +99,7 @@
     }
   },
   "0.4.28": {
+    "previous_stable_version": "0.4.27",
     "x86_64_linux_musl": {
       "checksum": "84e3a4982c19e19b1d058af30b8835097109f520cb6c2e9e03413a896c9787aa"
     },
@@ -108,6 +114,7 @@
     }
   },
   "0.4.27": {
+    "previous_stable_version": "0.4.26",
     "x86_64_linux_musl": {
       "checksum": "44ee34f8a6a1e0788f870c0bfd890dfce112c70f63e7254c5d8f20525600bc7b"
     },
@@ -122,6 +129,7 @@
     }
   },
   "0.4.26": {
+    "previous_stable_version": "0.4.25",
     "x86_64_linux_musl": {
       "checksum": "8a6334a932f2adf05c2647e86e9ef028714717c0a8e57b1e2d9c85f251f1a734"
     },
@@ -136,6 +144,7 @@
     }
   },
   "0.4.25": {
+    "previous_stable_version": "0.4.24",
     "x86_64_linux_musl": {
       "checksum": "f8481706ceda01d170aa02e1d87cf61abb24e5b67f9081f3d306f2861f1af5aa"
     },
@@ -150,6 +159,7 @@
     }
   },
   "0.4.24": {
+    "previous_stable_version": "0.4.23",
     "x86_64_linux_musl": {
       "checksum": "0795d994a9315d972804b0d2fe119f924db97362f3e855cadfbd5a203002b239"
     },
@@ -164,6 +174,7 @@
     }
   },
   "0.4.23": {
+    "previous_stable_version": "0.4.22",
     "x86_64_linux_musl": {
       "checksum": "a31f7f10046d6b4fe229fd5af308187ef76888a232fdd6f3ba085e484182024d"
     },
@@ -178,6 +189,7 @@
     }
   },
   "0.4.22": {
+    "previous_stable_version": "0.4.21",
     "x86_64_linux_musl": {
       "checksum": "ecfaedf19686e0ab487c9028f9796b5ef758a1fb882010fc8ff8a5f8c698f83f"
     },
@@ -192,6 +204,7 @@
     }
   },
   "0.4.21": {
+    "previous_stable_version": "0.4.20",
     "x86_64_linux_gnu": {
       "checksum": "ec3c978a255b444987fd6e0805147f4ea75d221f68c6e27dbf3e8a28aba166b7"
     },
@@ -203,6 +216,7 @@
     }
   },
   "0.4.20": {
+    "previous_stable_version": "0.4.19",
     "x86_64_linux_gnu": {
       "checksum": "77e49898e2570370d30d0221393f6114ab66ad138ef4e9e2da2a5e652a090255"
     },
@@ -214,6 +228,7 @@
     }
   },
   "0.4.19": {
+    "previous_stable_version": "0.4.18",
     "x86_64_linux_gnu": {
       "checksum": "50a419363d8233f42a038ff3c5d977d44b7cb7f860f34b4567161241642aec9a"
     },
@@ -225,6 +240,7 @@
     }
   },
   "0.4.18": {
+    "previous_stable_version": "0.4.17",
     "x86_64_linux_gnu": {
       "checksum": "d276b0e594d5980de6a7917ce74c348f28d3cb8b353ca4eaae344ae8a4c40bea"
     },
@@ -236,6 +252,7 @@
     }
   },
   "0.4.17": {
+    "previous_stable_version": "0.4.16",
     "x86_64_linux_gnu": {
       "checksum": "04f32a87356d3df34e2a3dfbd2bc1fb0d52b01a271bf86ccfdd434c718aab6c8"
     },
@@ -247,6 +264,7 @@
     }
   },
   "0.4.16": {
+    "previous_stable_version": "0.4.15",
     "x86_64_linux_gnu": {
       "checksum": "bb658a9185cbff52d95ef1c089b33f77ec3b2784e9dd3db18779a28e2bb446f0"
     },
@@ -258,6 +276,7 @@
     }
   },
   "0.4.15": {
+    "previous_stable_version": "0.4.14",
     "x86_64_linux_gnu": {
       "checksum": "4ce861733f08e58ffcd35ed0beb536734fca2543f13b6efc59623234fb17a6fd"
     },
@@ -269,6 +288,7 @@
     }
   },
   "0.4.14": {
+    "previous_stable_version": "0.4.13",
     "x86_64_linux_gnu": {
       "checksum": "0ed75f6e4115f02d806932c4b1a8d9aca276ea1bbc3979524b4a8847bd3510e4"
     },
@@ -280,6 +300,7 @@
     }
   },
   "0.4.13": {
+    "previous_stable_version": "0.4.12",
     "x86_64_linux_gnu": {
       "checksum": "f040334cc62a3779c23a0df6eb648de445ca747d8f87956927a9b13c5bffff40"
     },
@@ -291,6 +312,7 @@
     }
   },
   "0.4.12": {
+    "previous_stable_version": "0.4.11",
     "x86_64_linux_gnu": {
       "checksum": "2a0953c50d8156e84f193f15a506ef0adbac66f1942b794de5210ca9ca73dd33"
     },
@@ -302,6 +324,7 @@
     }
   },
   "0.4.11": {
+    "previous_stable_version": "0.4.10",
     "x86_64_linux_gnu": {
       "checksum": "d26c32fa09e0199ffa30705beb05a16b17a2fb2e96977de277f96695f6185049"
     },
@@ -313,6 +336,7 @@
     }
   },
   "0.4.10": {
+    "previous_stable_version": "0.4.9",
     "x86_64_linux_gnu": {
       "checksum": "90e7c8d4866e9837bfdcb89291d26e627db61e53c8678862f11ccea44871b386"
     },
@@ -324,6 +348,7 @@
     }
   },
   "0.4.9": {
+    "previous_stable_version": "0.4.8",
     "x86_64_linux_gnu": {
       "checksum": "19e281061a74fdacfe3ac99247b89d6f14e8ee2b950b0c253045b29fdedb78b9"
     },
@@ -335,6 +360,7 @@
     }
   },
   "0.4.8": {
+    "previous_stable_version": "0.4.7",
     "x86_64_linux_gnu": {
       "checksum": "4734a224a7bb8f9436fe2cb32065346446f6b34a1bc474156c3c1837a8767e4c"
     },
@@ -346,6 +372,7 @@
     }
   },
   "0.4.7": {
+    "previous_stable_version": "0.4.6",
     "x86_64_linux_gnu": {
       "checksum": "6f1f5d41f3b503f0d5b08798c4645af2b7c753e1bebeefef8157e897a70a46b1"
     },
@@ -357,6 +384,7 @@
     }
   },
   "0.4.6": {
+    "previous_stable_version": "0.4.5",
     "x86_64_linux_gnu": {
       "checksum": "2469cb81f8de93c99bfbeaa6227acad3c7f6a58821d2056a91704e720b79a5c9"
     },
@@ -368,6 +396,7 @@
     }
   },
   "0.4.5": {
+    "previous_stable_version": "0.4.4",
     "x86_64_linux_gnu": {
       "checksum": "c6810849bfdcf9fdeafb693129308c8e4b7811134e1fe413eb7bacac697b9789"
     },
@@ -379,6 +408,7 @@
     }
   },
   "0.4.4": {
+    "previous_stable_version": "0.4.3",
     "x86_64_linux_gnu": {
       "checksum": "a518d005ed6a264e49998917d33e08769ac1d9c812405e7d214673aea625411d"
     },
@@ -390,6 +420,7 @@
     }
   },
   "0.4.3": {
+    "previous_stable_version": "0.4.2",
     "x86_64_linux_gnu": {
       "checksum": "f493c5900b0267bf62ce135cfdc3f5d79038f3a0d4d29c1b9a71e681b3b36f49"
     },
@@ -401,6 +432,7 @@
     }
   },
   "0.4.2": {
+    "previous_stable_version": "0.4.1",
     "x86_64_linux_gnu": {
       "checksum": "bb24820961c9d71e42f2c2bc06915b27624924d40b7d16e6592a465af9b7162e"
     },
@@ -412,6 +444,7 @@
     }
   },
   "0.4.1": {
+    "previous_stable_version": "0.4.0",
     "x86_64_linux_gnu": {
       "checksum": "a5f6c15107fd5a6c933bbed167d8c130676fa7a0cde225b86fb7fea0e88ac975"
     },
@@ -423,6 +456,7 @@
     }
   },
   "0.4.0": {
+    "previous_stable_version": "0.3.7",
     "x86_64_linux_gnu": {
       "checksum": "9a4e11b7a8a7571c0557fda4cbd0b0cf0f2e901e7ce2950ef41a7620b0e86bec"
     },
@@ -437,6 +471,7 @@
     "version": "0.3.7"
   },
   "0.3.7": {
+    "previous_stable_version": "0.3.6",
     "x86_64_linux_gnu": {
       "checksum": "9b61fe2476dfd8b8459702966bf2f226f9d6eddc00133adf09e37d30e7eab117"
     },
@@ -448,6 +483,7 @@
     }
   },
   "0.3.6": {
+    "previous_stable_version": "0.3.5",
     "x86_64_linux_gnu": {
       "checksum": "2dc365bb0fe0413acbe612e85363a93677ba245eaf96b3f40de9241333d7e4a6"
     },
@@ -459,6 +495,7 @@
     }
   },
   "0.3.5": {
+    "previous_stable_version": "0.3.4",
     "x86_64_linux_gnu": {
       "checksum": "e03cc253650fa0b4780fab4d75df64c48d35d48f452fcf61c5ec0ae652f9bd8e"
     },
@@ -470,6 +507,7 @@
     }
   },
   "0.3.4": {
+    "previous_stable_version": "0.3.3",
     "x86_64_linux_gnu": {
       "checksum": "c457371017737ebb2c3b6553712d6ab53dda1949397770eb270e5caf2a7080f3"
     },
@@ -481,6 +519,7 @@
     }
   },
   "0.3.3": {
+    "previous_stable_version": "0.3.2",
     "x86_64_linux_gnu": {
       "checksum": "ec2c0199fb03f0cdaf8456166616553aca0816f909de68fd494bed11a9e0b41f"
     },
@@ -492,6 +531,7 @@
     }
   },
   "0.3.2": {
+    "previous_stable_version": "0.3.1",
     "x86_64_linux_gnu": {
       "checksum": "3410ba48cdd816ccbcd7b7784db1802f023d741e8a4cbbb8fe7c45dce41fed4a"
     },
@@ -503,6 +543,7 @@
     }
   },
   "0.3.1": {
+    "previous_stable_version": "0.3.0",
     "x86_64_linux_gnu": {
       "checksum": "4511fb1d4d95331099a4c1777d6af8022ac5783af70b83f018c78c896a4027ab"
     },
@@ -511,6 +552,7 @@
     }
   },
   "0.3.0": {
+    "previous_stable_version": "0.2.1",
     "x86_64_linux_gnu": {
       "checksum": "4f42e0581be10b89c65007a48e4dab1f0070643498f070ea9cbd67ee92ac906e"
     },
@@ -522,6 +564,7 @@
     "version": "0.2.1"
   },
   "0.2.1": {
+    "previous_stable_version": "0.2.0",
     "x86_64_linux_musl": {
       "checksum": "342b1b5de4b6039b0c73220b5c03f12075d005f4f44276507b9afd64e7f5e06e"
     },
@@ -530,6 +573,7 @@
     }
   },
   "0.2.0": {
+    "previous_stable_version": "0.1.8",
     "x86_64_linux_gnu": {
       "checksum": "bff39ef5c9cbdbfe03b5294bbc72d30d3c3e4acc350b3551799dcf62bbc79351"
     },
@@ -541,6 +585,7 @@
     "version": "0.1.8"
   },
   "0.1.8": {
+    "previous_stable_version": "0.1.7",
     "x86_64_linux_gnu": {
       "checksum": "fbe6ec7bfb38289aae0a31c9aed6ba561c512b8f3c3dca700ccf0f3a28222e6e"
     },
@@ -549,6 +594,7 @@
     }
   },
   "0.1.7": {
+    "previous_stable_version": "0.1.6",
     "x86_64_linux_gnu": {
       "checksum": "7d290787fabded0363c8218fba24f8b0837937266b533ad90777170066d0738d"
     },
@@ -557,6 +603,7 @@
     }
   },
   "0.1.6": {
+    "previous_stable_version": "0.1.5",
     "x86_64_linux_gnu": {
       "checksum": "76edbb107106df2b9e8f50b77531a46779c46f99e2c13b1cf35b819144bb3716"
     },
@@ -565,6 +612,7 @@
     }
   },
   "0.1.5": {
+    "previous_stable_version": "0.1.4",
     "x86_64_linux_musl": {
       "checksum": "7d473fb329d11a0b1bcdc50559a8558a512b099a5543f405e11199203389d682"
     },
@@ -573,6 +621,7 @@
     }
   },
   "0.1.4": {
+    "previous_stable_version": "0.1.3",
     "x86_64_linux_musl": {
       "checksum": "b1cd74ece0ab57ce9617fdc5748acae2d45e24585ce348786c9aae18c49c391a"
     },
@@ -581,6 +630,7 @@
     }
   },
   "0.1.3": {
+    "previous_stable_version": "0.1.2",
     "x86_64_linux_musl": {
       "checksum": "d5304bd023d6ddcbf75a72a32fb9c76ef71ec6007bee6ebd30416245d6c39d51"
     },
@@ -589,6 +639,7 @@
     }
   },
   "0.1.2": {
+    "previous_stable_version": "0.1.1",
     "x86_64_linux_musl": {
       "checksum": "6b078ffe764992df44f42653bf5a4b3ce019072290d51ecbcb11ccf9c18b03a8"
     },
@@ -597,6 +648,7 @@
     }
   },
   "0.1.1": {
+    "previous_stable_version": "0.1.0",
     "x86_64_linux_musl": {
       "checksum": "3c4056df1b416a9cef1f5cdb5eab25c0af91933a575e4baeb960fbc6276c5b40"
     },

--- a/manifests/parse-changelog.json
+++ b/manifests/parse-changelog.json
@@ -30,6 +30,7 @@
     "version": "0.6.1"
   },
   "0.6.1": {
+    "previous_stable_version": "0.6.0",
     "x86_64_linux_musl": {
       "checksum": "852a84c345787f959b5838958cd9d2f322059cce59fb5b005070b84182231a98"
     },
@@ -50,6 +51,7 @@
     }
   },
   "0.6.0": {
+    "previous_stable_version": "0.5.4",
     "x86_64_linux_musl": {
       "checksum": "80e57ee43411646c8b3adf0f4417c6155418385e1755f26a1dcc92069ef26bfc"
     },
@@ -73,6 +75,7 @@
     "version": "0.5.4"
   },
   "0.5.4": {
+    "previous_stable_version": "0.5.3",
     "x86_64_linux_musl": {
       "checksum": "b2a430ebd0d23a3608258446d9f93162ca324fd2ca691ca3baa11625c9d7fec3"
     },
@@ -93,6 +96,7 @@
     }
   },
   "0.5.3": {
+    "previous_stable_version": "0.5.2",
     "x86_64_linux_musl": {
       "checksum": "7ec427621565a6bb67d7e46397471b374435bc4622339595afa42d74d2f2a2cf"
     },
@@ -113,6 +117,7 @@
     }
   },
   "0.5.2": {
+    "previous_stable_version": "0.5.1",
     "x86_64_linux_musl": {
       "checksum": "bcaa72cf77aac0b897a8f6380106acb44b1dd28e53feefdd8f91bb4becbf355f"
     },
@@ -133,6 +138,7 @@
     }
   },
   "0.5.1": {
+    "previous_stable_version": "0.5.0",
     "x86_64_linux_musl": {
       "checksum": "c2591b7921d548f628cb2ce59cd6c0fab1fab44dac62d98a23c75b84d2f2b935"
     },
@@ -150,6 +156,7 @@
     }
   },
   "0.5.0": {
+    "previous_stable_version": "0.4.9",
     "x86_64_linux_musl": {
       "checksum": "ea5a58854c97bb1be800831bd9d0253cc9c78d7f8df2e3593fd899b587d5f4cf"
     },
@@ -170,6 +177,7 @@
     "version": "0.4.9"
   },
   "0.4.9": {
+    "previous_stable_version": "0.4.8",
     "x86_64_linux_musl": {
       "checksum": "097ff59514f84cbc9b43406c9e8ff656fcfcbb821251eef538654e1cd0aac624"
     },
@@ -187,6 +195,7 @@
     }
   },
   "0.4.8": {
+    "previous_stable_version": "0.4.7",
     "x86_64_linux_musl": {
       "checksum": "41bc030a00e13a83faf6021b7be3ab50af7479f5c6ca6ca0a00ae29a0d71bcc8"
     },
@@ -204,6 +213,7 @@
     }
   },
   "0.4.7": {
+    "previous_stable_version": "0.4.6",
     "x86_64_linux_musl": {
       "checksum": "b9869865ea79e3bf4931cca16a82f7226c84ffca9b508d2279b626e1c63e5151"
     },
@@ -218,6 +228,7 @@
     }
   },
   "0.4.6": {
+    "previous_stable_version": "0.4.5",
     "x86_64_linux_musl": {
       "checksum": "976d47ff81eafeda2d8d7bd4ed7bb13e466c46fe701e6ad9e6386ee615ea65a6"
     },
@@ -229,6 +240,7 @@
     }
   },
   "0.4.5": {
+    "previous_stable_version": "0.4.4",
     "x86_64_linux_musl": {
       "checksum": "0da8fab497c50ee139e6595649fa532d18d37e0db72ef7974f38671ac4449432"
     },
@@ -240,6 +252,7 @@
     }
   },
   "0.4.4": {
+    "previous_stable_version": "0.4.3",
     "x86_64_linux_musl": {
       "checksum": "6092da0f65f9853220d96bce57d0bed1dbe904f594f66f6e546ce765a202d8cb"
     },
@@ -251,6 +264,7 @@
     }
   },
   "0.4.3": {
+    "previous_stable_version": "0.4.2",
     "x86_64_linux_musl": {
       "checksum": "f4120023ad79b68e3287e775c4e55773db8a298e7c995fde67c99c31ab1d38c6"
     },
@@ -262,6 +276,7 @@
     }
   },
   "0.4.2": {
+    "previous_stable_version": "0.4.1",
     "x86_64_linux_musl": {
       "checksum": "6bbe76fb0d634b5a84017ccc80bf97bb8af81a44b5c44fc5f08954671d4f63ef"
     },
@@ -273,6 +288,7 @@
     }
   },
   "0.4.1": {
+    "previous_stable_version": "0.4.0",
     "x86_64_linux_musl": {
       "checksum": "95b904b065cc246de7e7b82d7aa3d6ee4a96dd9d2f2e195237c234d3e3395500"
     },
@@ -284,6 +300,7 @@
     }
   },
   "0.4.0": {
+    "previous_stable_version": "0.3.0",
     "x86_64_linux_musl": {
       "checksum": "53a655b0763b12d421d625c7a53c08220883b6f081d9463d1b1dbf4aa5ad1d23"
     },
@@ -298,6 +315,7 @@
     "version": "0.3.0"
   },
   "0.3.0": {
+    "previous_stable_version": "0.2.2",
     "x86_64_linux_musl": {
       "checksum": "2d9c383127227c2544ef57a9bcaff0b2db7598adc12fcdbfd6c8187cae6d52eb"
     },
@@ -312,6 +330,7 @@
     "version": "0.2.2"
   },
   "0.2.2": {
+    "previous_stable_version": "0.2.1",
     "x86_64_linux_musl": {
       "checksum": "c1ec7ce2f2eff915e5803106d02b4eac2a31eb80a88d86d4713d984004037e52"
     },
@@ -323,6 +342,7 @@
     }
   },
   "0.2.1": {
+    "previous_stable_version": "0.2.0",
     "x86_64_linux_musl": {
       "checksum": "18f567e99bb588bab69a8c33c3e9c6d58bdede0eddde14b9d08f7ba9f6b00868"
     },
@@ -334,6 +354,7 @@
     }
   },
   "0.2.0": {
+    "previous_stable_version": "0.1.0",
     "x86_64_linux_gnu": {
       "checksum": "7fcb2a7a99d08b544ba7950558514a741edc023e689748f1045aa7f0f3cde10a"
     },

--- a/manifests/wasm-pack.json
+++ b/manifests/wasm-pack.json
@@ -25,6 +25,7 @@
     "version": "0.12.1"
   },
   "0.12.1": {
+    "previous_stable_version": "0.12.0",
     "x86_64_linux_musl": {
       "checksum": "7339ba3ad776bd5fc04dd5d6b9babe952648050a54226c08206fab4ffeec621f"
     },
@@ -39,6 +40,7 @@
     }
   },
   "0.12.0": {
+    "previous_stable_version": "0.11.1",
     "x86_64_linux_musl": {
       "checksum": "60d7c5b082c408b9c201aa81813d87d5df23db4b1fa9c4a88302144e69bd3152"
     },
@@ -56,6 +58,7 @@
     "version": "0.11.1"
   },
   "0.11.1": {
+    "previous_stable_version": "0.11.0",
     "x86_64_linux_musl": {
       "checksum": "cfe60a2e5d1641b9a09ec6d95787068ac24e03c67b9e36de7036714f71185a2d"
     },
@@ -70,6 +73,7 @@
     }
   },
   "0.11.0": {
+    "previous_stable_version": "0.10.3",
     "x86_64_linux_musl": {
       "checksum": "f3041ac5fda684d09b28ca23555c2f24cac9d6eef57ee4ef3f29fdab1c19fe24"
     },
@@ -87,6 +91,7 @@
     "version": "0.10.3"
   },
   "0.10.3": {
+    "previous_stable_version": "0.10.2",
     "x86_64_linux_musl": {
       "checksum": "9e4e7b4436d6fd914aa75f91f81bdedc31a3f2b8b94fb17578cff2c3aaa83bb3"
     },
@@ -101,6 +106,7 @@
     }
   },
   "0.10.2": {
+    "previous_stable_version": "0.10.1",
     "x86_64_linux_musl": {
       "checksum": "ddf59a454fbee8712932803583d01756204c32fbfb13defa69f08c3e7afb6ac5"
     },
@@ -115,6 +121,7 @@
     }
   },
   "0.10.1": {
+    "previous_stable_version": "0.10.0",
     "x86_64_linux_musl": {
       "checksum": "524f8333e69c7157239c14c3140ee485b8cb4000d530344d62984e544f27c67f"
     },
@@ -126,6 +133,7 @@
     }
   },
   "0.10.0": {
+    "previous_stable_version": "0.9.1",
     "x86_64_linux_musl": {
       "checksum": "8b5a40add554891888de25ea974b4d096a37614c91c982a383d3eca97aa17e68"
     },
@@ -140,6 +148,7 @@
     "version": "0.9.1"
   },
   "0.9.1": {
+    "previous_stable_version": "0.9.0",
     "x86_64_linux_musl": {
       "checksum": "d478bd20811067566bfc88141afcc857e7713b5385c684f6d50e7c2d549847f7"
     },
@@ -151,6 +160,7 @@
     }
   },
   "0.9.0": {
+    "previous_stable_version": "0.8.1",
     "x86_64_linux_musl": {
       "checksum": "b12dcf60d8cf54470e64661eb917722a452ecafbc8678b6ae814b5494d745a70"
     },
@@ -165,6 +175,7 @@
     "version": "0.8.1"
   },
   "0.8.1": {
+    "previous_stable_version": "0.8.0",
     "x86_64_linux_musl": {
       "checksum": "623f2274e2fe96f5c9e0cb6fd3464ca7cc5b563025d105da79b827e02eb9a665"
     },
@@ -176,6 +187,7 @@
     }
   },
   "0.8.0": {
+    "previous_stable_version": "0.7.0",
     "x86_64_linux_musl": {
       "checksum": "a28eea9d8d607495778322f8e28bc523621b3feefca185f6b1947d0bfa949eae"
     },
@@ -190,6 +202,7 @@
     "version": "0.7.0"
   },
   "0.7.0": {
+    "previous_stable_version": "0.6.0",
     "x86_64_linux_musl": {
       "checksum": "e29446206ef47c2c7aab659387d66a8bf5018b8c55d91dec485f6415d90edafa"
     },
@@ -204,6 +217,7 @@
     "version": "0.6.0"
   },
   "0.6.0": {
+    "previous_stable_version": "0.5.1",
     "x86_64_linux_musl": {
       "checksum": "b575bb48f101926342339036705f21d94ca56266568be4076c6e1a6f3afba290"
     },
@@ -218,6 +232,7 @@
     "version": "0.5.1"
   },
   "0.5.1": {
+    "previous_stable_version": "0.5.0",
     "x86_64_linux_musl": {
       "checksum": "2908d56fc3d94db02b02f07271c0a9926f7060dae2ba684d66e7023ca173bfb3"
     },
@@ -229,6 +244,7 @@
     }
   },
   "0.5.0": {
+    "previous_stable_version": "0.4.2",
     "x86_64_linux_musl": {
       "checksum": "194f29ce4fc246cb1d1df95ce39605d561da84e1098f890bfb9e5094d616b86f"
     },
@@ -243,6 +259,7 @@
     "version": "0.4.2"
   },
   "0.4.2": {
+    "previous_stable_version": "0.4.1",
     "x86_64_linux_musl": {
       "checksum": "531906b0f1bb2e06c542dbbd6bd56671a59762299a01498e94c62534dc548c65"
     },
@@ -251,6 +268,7 @@
     }
   },
   "0.4.1": {
+    "previous_stable_version": "0.4.0",
     "x86_64_linux_musl": {
       "checksum": "38f247a8e94bbefc7e7ccdf4b064286d8843c736792c36dfc9d471a0aefc1514"
     },
@@ -259,6 +277,7 @@
     }
   },
   "0.4.0": {
+    "previous_stable_version": "0.3.1",
     "x86_64_linux_musl": {
       "checksum": "7680cc96560b3e76aa542c51c68cb4ef054f6495875c852931a3a8680bdf6890"
     },
@@ -270,6 +289,7 @@
     "version": "0.3.1"
   },
   "0.3.1": {
+    "previous_stable_version": "0.3.0",
     "x86_64_linux_musl": {
       "checksum": "eab14fbe5b585c865c7ec24f68820e0d6da0215272058fa3ccf2bffc95dfb464"
     },

--- a/manifests/wasmtime.json
+++ b/manifests/wasmtime.json
@@ -11,6 +11,7 @@
     "version": "11.0.1"
   },
   "11.0.1": {
+    "previous_stable_version": "11.0.0",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v11.0.1/wasmtime-v11.0.1-x86_64-linux.tar.xz",
       "checksum": "90bdbe4c650c7b45f96579f9026cff3071f1fa3ea7cf31fad5a3559c3318e23c",
@@ -38,6 +39,7 @@
     }
   },
   "11.0.0": {
+    "previous_stable_version": "10.0.1",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v11.0.0/wasmtime-v11.0.0-x86_64-linux.tar.xz",
       "checksum": "8723d437ff07b02ee3bc8885c8624bb34a52d96e70477f81e87d1936d2b84556",
@@ -71,6 +73,7 @@
     "version": "10.0.1"
   },
   "10.0.1": {
+    "previous_stable_version": "10.0.0",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v10.0.1/wasmtime-v10.0.1-x86_64-linux.tar.xz",
       "checksum": "ea7a96e7d30ff6d64d0e212900f9a2c4f1d009266e014d62cb5edb16c6f1a7f6",
@@ -98,6 +101,7 @@
     }
   },
   "10.0.0": {
+    "previous_stable_version": "9.0.4",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v10.0.0/wasmtime-v10.0.0-x86_64-linux.tar.xz",
       "checksum": "6df3770c26a0c892a89980d4a7d785b7356a855a4ac79c6745f02a7f2bf914fc",
@@ -131,6 +135,7 @@
     "version": "9.0.4"
   },
   "9.0.4": {
+    "previous_stable_version": "9.0.3",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v9.0.4/wasmtime-v9.0.4-x86_64-linux.tar.xz",
       "checksum": "1e38bae33433c2c31ceefd450a6d54f938b608d48a256497239342feeb6db772",
@@ -158,6 +163,7 @@
     }
   },
   "9.0.3": {
+    "previous_stable_version": "9.0.2",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v9.0.3/wasmtime-v9.0.3-x86_64-linux.tar.xz",
       "checksum": "7089f0ab5bf4d870e79a4c61404b36562e5ad486325d5da20d9c7dfd01cbce50",
@@ -185,6 +191,7 @@
     }
   },
   "9.0.2": {
+    "previous_stable_version": "9.0.1",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v9.0.2/wasmtime-v9.0.2-x86_64-linux.tar.xz",
       "checksum": "002822c52ea3499e7a0e4033a390123c7877b6655a69ce9426e1a370f351cae6",
@@ -212,6 +219,7 @@
     }
   },
   "9.0.1": {
+    "previous_stable_version": "9.0.0",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v9.0.1/wasmtime-v9.0.1-x86_64-linux.tar.xz",
       "checksum": "f90a3f7a0fe5a7c059947c029c28a2ae65ef24335d190f82e57725d9706cb413",
@@ -239,6 +247,7 @@
     }
   },
   "9.0.0": {
+    "previous_stable_version": "8.0.1",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v9.0.0/wasmtime-v9.0.0-x86_64-linux.tar.xz",
       "checksum": "7616b94d7c30eaa4d4ddf41a58128ac73b943c21565adb12d143ea46959de4e2",
@@ -272,6 +281,7 @@
     "version": "8.0.1"
   },
   "8.0.1": {
+    "previous_stable_version": "8.0.0",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v8.0.1/wasmtime-v8.0.1-x86_64-linux.tar.xz",
       "checksum": "555985b17523269350d253c160dac601e383e1612126489daf80648571e0b8c4",
@@ -299,6 +309,7 @@
     }
   },
   "8.0.0": {
+    "previous_stable_version": "7.0.1",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v8.0.0/wasmtime-v8.0.0-x86_64-linux.tar.xz",
       "checksum": "0ba34842bbac8896dbdd860173b2c554d93d63ecc490f725fe3331db913714ad",
@@ -332,6 +343,7 @@
     "version": "7.0.1"
   },
   "7.0.1": {
+    "previous_stable_version": "7.0.0",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v7.0.1/wasmtime-v7.0.1-x86_64-linux.tar.xz",
       "checksum": "3616ece4f17435d80abe71ea9a2b40446e2a1d936b1628c3566b08473ec5758d",
@@ -359,6 +371,7 @@
     }
   },
   "7.0.0": {
+    "previous_stable_version": "6.0.2",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v7.0.0/wasmtime-v7.0.0-x86_64-linux.tar.xz",
       "checksum": "b8a1c97f9107c885ea73a5c38677d0d340a7c26879d366e8a5f3dce84cffec99",
@@ -392,6 +405,7 @@
     "version": "6.0.2"
   },
   "6.0.2": {
+    "previous_stable_version": "6.0.1",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v6.0.2/wasmtime-v6.0.2-x86_64-linux.tar.xz",
       "checksum": "270bbda1054ce0cfd537744e0697dfcdd8dc321af5973a6af13c408e4e2c9b58",
@@ -419,6 +433,7 @@
     }
   },
   "6.0.1": {
+    "previous_stable_version": "6.0.0",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v6.0.1/wasmtime-v6.0.1-x86_64-linux.tar.xz",
       "checksum": "9fdc5f4cd679d77c42f6333793cd66ecca45347e4cbbeaf06cb0300f27ac5119",
@@ -446,6 +461,7 @@
     }
   },
   "6.0.0": {
+    "previous_stable_version": "5.0.1",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v6.0.0/wasmtime-v6.0.0-x86_64-linux.tar.xz",
       "checksum": "19090d9f0b6320d69908c3a9d3915c1b8149555d971061eda462edc0e212e0d3",
@@ -479,6 +495,7 @@
     "version": "5.0.1"
   },
   "5.0.1": {
+    "previous_stable_version": "5.0.0",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v5.0.1/wasmtime-v5.0.1-x86_64-linux.tar.xz",
       "checksum": "c87e4e820ee4b605b4c6aa7dd12807da6fb9789a5906b7ad9df83e8b43dc547a",
@@ -506,6 +523,7 @@
     }
   },
   "5.0.0": {
+    "previous_stable_version": "4.0.1",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v5.0.0/wasmtime-v5.0.0-x86_64-linux.tar.xz",
       "checksum": "a627a0391c52f3543bb48bb3052038291b4bd94e1dee8e520afb7ad2d7dabbbb",
@@ -539,6 +557,7 @@
     "version": "4.0.1"
   },
   "4.0.1": {
+    "previous_stable_version": "4.0.0",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v4.0.1/wasmtime-v4.0.1-x86_64-linux.tar.xz",
       "checksum": "ef6a6c6d1025031565eaeb4510dadc72fcfd3d11f2c402fbebb3f2022e8ce466",
@@ -566,6 +585,7 @@
     }
   },
   "4.0.0": {
+    "previous_stable_version": "3.0.1",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v4.0.0/wasmtime-v4.0.0-x86_64-linux.tar.xz",
       "checksum": "3dadebe46ff415fc5c0e7245bdcead36fb0e236247be966d5c653e8b4bed3f65",
@@ -599,6 +619,7 @@
     "version": "3.0.1"
   },
   "3.0.1": {
+    "previous_stable_version": "3.0.0",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v3.0.1/wasmtime-v3.0.1-x86_64-linux.tar.xz",
       "checksum": "8798b587251a6ebc535ba94000242ac4eaf6f38ae3884ce9dcbf9550f99a7359",
@@ -626,6 +647,7 @@
     }
   },
   "3.0.0": {
+    "previous_stable_version": "2.0.2",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v3.0.0/wasmtime-v3.0.0-x86_64-linux.tar.xz",
       "checksum": "f10556b2a3e4780032bc95955a5fa77411ce5d3c23c8af07f5306d0ed57794d8",
@@ -659,6 +681,7 @@
     "version": "2.0.2"
   },
   "2.0.2": {
+    "previous_stable_version": "2.0.1",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v2.0.2/wasmtime-v2.0.2-x86_64-linux.tar.xz",
       "checksum": "c49daee342399f6f2396db71b1042e81c5e5ab24d16306d99481c209cf0abb38",
@@ -686,6 +709,7 @@
     }
   },
   "2.0.1": {
+    "previous_stable_version": "2.0.0",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v2.0.1/wasmtime-v2.0.1-x86_64-linux.tar.xz",
       "checksum": "da92a4370c363ac583176c264bcc7f90a802af8832f6723106431885c1fab3eb",
@@ -713,6 +737,7 @@
     }
   },
   "2.0.0": {
+    "previous_stable_version": "1.0.2",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v2.0.0/wasmtime-v2.0.0-x86_64-linux.tar.xz",
       "checksum": "e641b35d3e3e4535d75ff89ba2db16d14c018051f923e80376faefe615b9391a",
@@ -746,6 +771,7 @@
     "version": "1.0.2"
   },
   "1.0.2": {
+    "previous_stable_version": "1.0.1",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v1.0.2/wasmtime-v1.0.2-x86_64-linux.tar.xz",
       "checksum": "8be5fc770235bc61b023f1e0f586c7abfb7a38ed9c4e4e8530e73387cb0c6314",
@@ -773,6 +799,7 @@
     }
   },
   "1.0.1": {
+    "previous_stable_version": "1.0.0",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v1.0.1/wasmtime-v1.0.1-x86_64-linux.tar.xz",
       "checksum": "8d539b8a62b4a4934a6d91b94e6f50ba797c81a3370b217da6e23827428150b1",
@@ -800,6 +827,7 @@
     }
   },
   "1.0.0": {
+    "previous_stable_version": "0.40.1",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v1.0.0/wasmtime-v1.0.0-x86_64-linux.tar.xz",
       "checksum": "e7e379b98b89440e381401dcf845a1325169df2bf5a38604ae5d6213ca819936",
@@ -830,6 +858,7 @@
     "version": "0.40.1"
   },
   "0.40.1": {
+    "previous_stable_version": "0.40.0",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v0.40.1/wasmtime-v0.40.1-x86_64-linux.tar.xz",
       "checksum": "328e37d1ca84899ac561ba162777f055cf738e54dcf884ac70bb9d9614bd7094",
@@ -857,6 +886,7 @@
     }
   },
   "0.40.0": {
+    "previous_stable_version": "0.39.1",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v0.40.0/wasmtime-v0.40.0-x86_64-linux.tar.xz",
       "checksum": "30fc4b130c0c1ea94ffc7c6ab9cf37db792938117f6db5c0e7cc689672423ea8",
@@ -887,6 +917,7 @@
     "version": "0.39.1"
   },
   "0.39.1": {
+    "previous_stable_version": "0.39.0",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v0.39.1/wasmtime-v0.39.1-x86_64-linux.tar.xz",
       "checksum": "5f4f48ca335a066b478de9c0f3c009b6f7484f4261d292c1eedae3ce5dd02061",
@@ -914,6 +945,7 @@
     }
   },
   "0.39.0": {
+    "previous_stable_version": "0.38.3",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v0.39.0/wasmtime-v0.39.0-x86_64-linux.tar.xz",
       "checksum": "1f03d94dc7fe2fbc4ab21a82a058e0ccad1eb7ead17b39647ff482f2dcf91901",
@@ -944,6 +976,7 @@
     "version": "0.38.3"
   },
   "0.38.3": {
+    "previous_stable_version": "0.38.2",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v0.38.3/wasmtime-v0.38.3-x86_64-linux.tar.xz",
       "checksum": "6db7ddff5d3a0f9a60154db9441c4f4c46fff82c75d52aa01a44c9f266ca38bd",
@@ -971,6 +1004,7 @@
     }
   },
   "0.38.2": {
+    "previous_stable_version": "0.38.1",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v0.38.2/wasmtime-v0.38.2-x86_64-linux.tar.xz",
       "checksum": "5a922d2f15a79da624e17f41ce3c5bbdd048e6cce395d85cd7d1d159bfa965b2",
@@ -998,6 +1032,7 @@
     }
   },
   "0.38.1": {
+    "previous_stable_version": "0.38.0",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v0.38.1/wasmtime-v0.38.1-x86_64-linux.tar.xz",
       "checksum": "a8805d626b660dc62a5d526cfcd657d41a67522725ff2810f61892ba5519e700",
@@ -1025,6 +1060,7 @@
     }
   },
   "0.38.0": {
+    "previous_stable_version": "0.37.0",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v0.38.0/wasmtime-v0.38.0-x86_64-linux.tar.xz",
       "checksum": "caf0a64aa3aef0e1cb5f7889384a2718d239f0f62f91a067b367ca8a45296758",
@@ -1055,6 +1091,7 @@
     "version": "0.37.0"
   },
   "0.37.0": {
+    "previous_stable_version": "0.36.0",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v0.37.0/wasmtime-v0.37.0-x86_64-linux.tar.xz",
       "checksum": "96e0068905c55bf24e84913f0d60ca91202eb3ea2b928fe236c63e64c3118fe8",
@@ -1085,6 +1122,7 @@
     "version": "0.36.0"
   },
   "0.36.0": {
+    "previous_stable_version": "0.35.3",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v0.36.0/wasmtime-v0.36.0-x86_64-linux.tar.xz",
       "checksum": "97ba12da1f96e40197998d843afb4e08a1d61cd844b721dfa0d1fa044a38b35a",
@@ -1110,6 +1148,7 @@
     "version": "0.35.3"
   },
   "0.35.3": {
+    "previous_stable_version": "0.35.2",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v0.35.3/wasmtime-v0.35.3-x86_64-linux.tar.xz",
       "checksum": "7519ef0e08716416cc44167ec838ff1362054c43c8bf6fc56056282c9107840a",
@@ -1132,6 +1171,7 @@
     }
   },
   "0.35.2": {
+    "previous_stable_version": "0.35.1",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v0.35.2/wasmtime-v0.35.2-x86_64-linux.tar.xz",
       "checksum": "9fac8bf1027238c9295896851c08c3d4b76f61bc9b3db5d3a607a092f5d13369",
@@ -1154,6 +1194,7 @@
     }
   },
   "0.35.1": {
+    "previous_stable_version": "0.35.0",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v0.35.1/wasmtime-v0.35.1-x86_64-linux.tar.xz",
       "checksum": "c7c22cd0aada9636f99f203aa0b14bc99a48518272270dd4dce277d4a51f07e6",
@@ -1176,6 +1217,7 @@
     }
   },
   "0.35.0": {
+    "previous_stable_version": "0.34.2",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v0.35.0/wasmtime-v0.35.0-x86_64-linux.tar.xz",
       "checksum": "c068fe467973b2dcf5a37ab3926ee8ee363a180b8b42796c8a25efa35b13e397",
@@ -1201,6 +1243,7 @@
     "version": "0.34.2"
   },
   "0.34.2": {
+    "previous_stable_version": "0.34.1",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v0.34.2/wasmtime-v0.34.2-x86_64-linux.tar.xz",
       "checksum": "211666ef45a651a6fe885dd456e3098fc9be57573146e56e8ae7684ae4d8a9ec",
@@ -1223,6 +1266,7 @@
     }
   },
   "0.34.1": {
+    "previous_stable_version": "0.34.0",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v0.34.1/wasmtime-v0.34.1-x86_64-linux.tar.xz",
       "checksum": "6e707170e8dc1d8279b698ce2a1ed7a50c7d986c91012ddc890589439515a9e5",
@@ -1240,6 +1284,7 @@
     }
   },
   "0.34.0": {
+    "previous_stable_version": "0.33.1",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v0.34.0/wasmtime-v0.34.0-x86_64-linux.tar.xz",
       "checksum": "8937edc3a940a92323a9405510110cb0dddbce25a5bd866e4a5af088da560ef0",
@@ -1265,6 +1310,7 @@
     "version": "0.33.1"
   },
   "0.33.1": {
+    "previous_stable_version": "0.33.0",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v0.33.1/wasmtime-v0.33.1-x86_64-linux.tar.xz",
       "checksum": "e7b4c30451dde8f79d2aec2112b68929e7603ff93d59e46cc3a1bee13d28cf30",
@@ -1287,6 +1333,7 @@
     }
   },
   "0.33.0": {
+    "previous_stable_version": "0.32.1",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v0.33.0/wasmtime-v0.33.0-x86_64-linux.tar.xz",
       "checksum": "c4c9f2ed9187c97e0ded9004dcaaeba1459d27f62f28797cc28d68be36276294",
@@ -1312,6 +1359,7 @@
     "version": "0.32.1"
   },
   "0.32.1": {
+    "previous_stable_version": "0.32.0",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v0.32.1/wasmtime-v0.32.1-x86_64-linux.tar.xz",
       "checksum": "278b30dedfd02b788822fe73ab96a86ff9b13c9df2efd9847dbba6164884d54d",
@@ -1334,6 +1382,7 @@
     }
   },
   "0.32.0": {
+    "previous_stable_version": "0.31.0",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v0.32.0/wasmtime-v0.32.0-x86_64-linux.tar.xz",
       "checksum": "24d7bf11bccc21e71b724c90cf35ca232a8a9dba62ab766bd30e0ccc928fc83b",
@@ -1359,6 +1408,7 @@
     "version": "0.31.0"
   },
   "0.31.0": {
+    "previous_stable_version": "0.30.0",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v0.31.0/wasmtime-v0.31.0-x86_64-linux.tar.xz",
       "checksum": "8d6f3f3b9691a6a36cec3c18227cb7bf1f62e95390083577a3f207f60afb39ea",
@@ -1384,6 +1434,7 @@
     "version": "0.30.0"
   },
   "0.30.0": {
+    "previous_stable_version": "0.29.0",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v0.30.0/wasmtime-v0.30.0-x86_64-linux.tar.xz",
       "checksum": "5cbf1193df60f441eb54a247daab18680357cfa24ad320a590b364e9342632f8",
@@ -1409,6 +1460,7 @@
     "version": "0.29.0"
   },
   "0.29.0": {
+    "previous_stable_version": "0.28.0",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v0.29.0/wasmtime-v0.29.0-x86_64-linux.tar.xz",
       "checksum": "623f2ca8074aeeba5d9bb69b3f60c55c773ddc2b4d564c52f9454ab0d45d012e",
@@ -1434,6 +1486,7 @@
     "version": "0.28.0"
   },
   "0.28.0": {
+    "previous_stable_version": "0.27.0",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v0.28.0/wasmtime-v0.28.0-x86_64-linux.tar.xz",
       "checksum": "714b3fcfd37621e2bd59c786208ebe7e2542cf88f0cef192e4eed2aefbecaa53",
@@ -1459,6 +1512,7 @@
     "version": "0.27.0"
   },
   "0.27.0": {
+    "previous_stable_version": "0.26.1",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v0.27.0/wasmtime-v0.27.0-x86_64-linux.tar.xz",
       "checksum": "2a9d3f09198e63c2e39cb8cd59c4a4cf196daa0111514e355304575f590c3f4a",
@@ -1484,6 +1538,7 @@
     "version": "0.26.1"
   },
   "0.26.1": {
+    "previous_stable_version": "0.26.0",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v0.26.1/wasmtime-v0.26.1-x86_64-linux.tar.xz",
       "checksum": "ff0785c3528e8f1471a3a23858c46414924733c91f604871fc84e401e51b7ec0",
@@ -1506,6 +1561,7 @@
     }
   },
   "0.26.0": {
+    "previous_stable_version": "0.25.0",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v0.26.0/wasmtime-v0.26.0-x86_64-linux.tar.xz",
       "checksum": "8a83ef7c6592200e86800e5f119bca5dbe4f30ab0d0ef56829a7e266e036c3f7",
@@ -1531,6 +1587,7 @@
     "version": "0.25.0"
   },
   "0.25.0": {
+    "previous_stable_version": "0.24.0",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v0.25.0/wasmtime-v0.25.0-x86_64-linux.tar.xz",
       "checksum": "33458447d9499bc560c6a74887607e02732214435c49ea3d86573ff755581821",
@@ -1556,6 +1613,7 @@
     "version": "0.24.0"
   },
   "0.24.0": {
+    "previous_stable_version": "0.23.0",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v0.24.0/wasmtime-v0.24.0-x86_64-linux.tar.xz",
       "checksum": "ab69f137d1843a075aa9b732557add70939bb45d67e95d233ad6f101c7607c69",
@@ -1581,6 +1639,7 @@
     "version": "0.23.0"
   },
   "0.23.0": {
+    "previous_stable_version": "0.22.1",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v0.23.0/wasmtime-v0.23.0-x86_64-linux.tar.xz",
       "checksum": "d410a78cb8820d1106edb49d296da80bc05420f17a04b8a6ec5e005da3bf5883",
@@ -1606,6 +1665,7 @@
     "version": "0.22.1"
   },
   "0.22.1": {
+    "previous_stable_version": "0.22.0",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v0.22.1/wasmtime-v0.22.1-x86_64-linux.tar.xz",
       "checksum": "09f050372070084b3fc7096ae0974aaa6a2651d1278dd71e8eab55244b157e2c",
@@ -1628,6 +1688,7 @@
     }
   },
   "0.22.0": {
+    "previous_stable_version": "0.21.0",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v0.22.0/wasmtime-v0.22.0-x86_64-linux.tar.xz",
       "checksum": "bb700bb4896a7190c4472b82cdc565518ad335b829538d5d0295dc4afcac70a7",
@@ -1653,6 +1714,7 @@
     "version": "0.21.0"
   },
   "0.21.0": {
+    "previous_stable_version": "0.20.0",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v0.21.0/wasmtime-v0.21.0-x86_64-linux.tar.xz",
       "checksum": "d3af5fa02091baaf637026c5d8fe1b5011f9f7de257dd838639c2916f929aa4e",
@@ -1678,6 +1740,7 @@
     "version": "0.20.0"
   },
   "0.20.0": {
+    "previous_stable_version": "0.19.0",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v0.20.0/wasmtime-v0.20.0-x86_64-linux.tar.xz",
       "checksum": "e32ad7d1e7bb70f5e9ad3128967fba6b32ebcc003332ba6c5276558ab2e4a864",
@@ -1703,6 +1766,7 @@
     "version": "0.19.0"
   },
   "0.19.0": {
+    "previous_stable_version": "0.18.0",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v0.19.0/wasmtime-v0.19.0-x86_64-linux.tar.xz",
       "checksum": "1b69df2a18c21effce127b7dc56b4ff0cf0ea7274cd28f2a314d07a99d8da928",
@@ -1728,6 +1792,7 @@
     "version": "0.18.0"
   },
   "0.18.0": {
+    "previous_stable_version": "0.16.0",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v0.18.0/wasmtime-v0.18.0-x86_64-linux.tar.xz",
       "checksum": "3475760b68382237d396157f9593da5febdfed1bebdb36f688c5d06f9ca28ca4",
@@ -1753,6 +1818,7 @@
     "version": "0.16.0"
   },
   "0.16.0": {
+    "previous_stable_version": "0.15.0",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v0.16.0/wasmtime-v0.16.0-x86_64-linux.tar.xz",
       "checksum": "834c0719a263f04ad8273e8568a9b96d12ebfe26711895f47abf774b6a7f5809",
@@ -1778,6 +1844,7 @@
     "version": "0.15.0"
   },
   "0.15.0": {
+    "previous_stable_version": "0.12.0",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v0.15.0/wasmtime-v0.15.0-x86_64-linux.tar.xz",
       "checksum": "3ffe31010c1363648cf4d2a145b0b1efbd9f09c3869372fb38fd88e7e84dee50",
@@ -1798,6 +1865,7 @@
     "version": "0.12.0"
   },
   "0.12.0": {
+    "previous_stable_version": "0.8.0",
     "x86_64_linux_gnu": {
       "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v0.12.0/wasmtime-v0.12.0-x86_64-linux.tar.xz",
       "checksum": "16fe9964a21ae57661cea5971d5d8d2dba796195c2952420a66865123caad2b0",

--- a/manifests/zola.json
+++ b/manifests/zola.json
@@ -18,6 +18,7 @@
     "version": "0.17.2"
   },
   "0.17.2": {
+    "previous_stable_version": "0.17.1",
     "x86_64_linux_gnu": {
       "checksum": "48742322fc0660afb22a4ce194e9b2bd610b5bd36f43abe121e56eb8a704b464"
     },
@@ -29,6 +30,7 @@
     }
   },
   "0.17.1": {
+    "previous_stable_version": "0.17.0",
     "x86_64_linux_gnu": {
       "checksum": "f1ddbe0c1b0672da6eeb959eeb3f311b915ecc18719963934bcbc0c62783b711"
     },
@@ -40,6 +42,7 @@
     }
   },
   "0.17.0": {
+    "previous_stable_version": "0.16.1",
     "x86_64_linux_gnu": {
       "checksum": "41f8a78b85d4a138581dff468fa5a01378c7f7afeaf2d81524c45a9fba8988ad"
     },
@@ -54,6 +57,7 @@
     "version": "0.16.1"
   },
   "0.16.1": {
+    "previous_stable_version": "0.16.0",
     "x86_64_linux_gnu": {
       "checksum": "a8a4205b7fdd817d9866d1a4b4b8d53c206177bd7e95b37e35cb5f830b0e6234"
     },
@@ -65,6 +69,7 @@
     }
   },
   "0.16.0": {
+    "previous_stable_version": "0.15.3",
     "x86_64_linux_gnu": {
       "checksum": "88cde8f1edfe609a9ae8a7a95226d3ae9bb62279c5c5254d9f5984ab843529a1"
     },
@@ -79,6 +84,7 @@
     "version": "0.15.3"
   },
   "0.15.3": {
+    "previous_stable_version": "0.15.2",
     "x86_64_linux_gnu": {
       "checksum": "7952bf166f29caeec595a299d94bc7da6ad5ba9ae71ea8bae142e2322faf821d"
     },
@@ -90,6 +96,7 @@
     }
   },
   "0.15.2": {
+    "previous_stable_version": "0.15.1",
     "x86_64_linux_gnu": {
       "checksum": "d067e8261f0a9121ea0388616f74fcba4b1ed87df8ea78ca20a577424c15fa20"
     },
@@ -101,6 +108,7 @@
     }
   },
   "0.15.1": {
+    "previous_stable_version": "0.15.0",
     "x86_64_linux_gnu": {
       "checksum": "57c69a4f651567a9507b73ced6ec3c04f3ec20487877657502a04be93748f204"
     },
@@ -112,6 +120,7 @@
     }
   },
   "0.15.0": {
+    "previous_stable_version": "0.14.1",
     "x86_64_linux_gnu": {
       "checksum": "901a330100d5f265c7a00821bef564dd7353b2b0884b80996ba4592b635a7ad3"
     },
@@ -126,6 +135,7 @@
     "version": "0.14.1"
   },
   "0.14.1": {
+    "previous_stable_version": "0.14.0",
     "x86_64_linux_gnu": {
       "checksum": "4223f57d9b60ad7217c44a815fa975b2229f692b7ef3de4b7ce61f1634e8dc33"
     },
@@ -137,6 +147,7 @@
     }
   },
   "0.14.0": {
+    "previous_stable_version": "0.13.0",
     "x86_64_linux_gnu": {
       "checksum": "4b68ec636b858178095873c038f21d24640220295f70b7a9f2e82109aa451926"
     },
@@ -151,6 +162,7 @@
     "version": "0.13.0"
   },
   "0.13.0": {
+    "previous_stable_version": "0.12.2",
     "x86_64_linux_gnu": {
       "checksum": "1a919e00cce61e30c31cd8d0979349ecd3f7c1666d32fa77314cbfbb89447adb"
     },
@@ -165,6 +177,7 @@
     "version": "0.12.2"
   },
   "0.12.2": {
+    "previous_stable_version": "0.12.1",
     "x86_64_linux_gnu": {
       "checksum": "572e34c4c2b874f9704fb8512abea84532623f7567996bac456291a21c1b2595"
     },
@@ -176,6 +189,7 @@
     }
   },
   "0.12.1": {
+    "previous_stable_version": "0.12.0",
     "x86_64_linux_gnu": {
       "checksum": "fdca646be87e05213b7306d04247c4226c1d514aee96ef390935545aee84a074"
     },
@@ -187,6 +201,7 @@
     }
   },
   "0.12.0": {
+    "previous_stable_version": "0.11.0",
     "x86_64_linux_gnu": {
       "checksum": "c955228d468b9233bd66417b0f39c078f510f8adf1a6138bbe7e80423198224b"
     },
@@ -201,6 +216,7 @@
     "version": "0.11.0"
   },
   "0.11.0": {
+    "previous_stable_version": "0.10.1",
     "x86_64_linux_gnu": {
       "checksum": "8afe40edff5e995afdc132e02442d24eb633ef4b6e81913d69cf97f17905b9c3"
     },
@@ -215,6 +231,7 @@
     "version": "0.10.1"
   },
   "0.10.1": {
+    "previous_stable_version": "0.10.0",
     "x86_64_linux_gnu": {
       "checksum": "7bce21ad56d0cab213b5b9188076b93d9d130b9b046cd118305dc2b9b43b84b8"
     },
@@ -226,6 +243,7 @@
     }
   },
   "0.10.0": {
+    "previous_stable_version": "0.9.0",
     "x86_64_linux_gnu": {
       "checksum": "5ae166ff105359c87f3d6c57ef6f1a3dd14b266b68dc8059dee88f8916818d6c"
     },
@@ -240,6 +258,7 @@
     "version": "0.9.0"
   },
   "0.9.0": {
+    "previous_stable_version": "0.8.0",
     "x86_64_linux_gnu": {
       "checksum": "c06b5406fd6cddf346fac448e95780e5b161f3d560a7df86a202d7f6c20d3f72"
     },
@@ -254,6 +273,7 @@
     "version": "0.8.0"
   },
   "0.8.0": {
+    "previous_stable_version": "0.7.0",
     "x86_64_linux_gnu": {
       "checksum": "bcdb334b47c34b0b35ffbba8400ca29df0d85377020c6468d2657a74dbef117e"
     },
@@ -268,6 +288,7 @@
     "version": "0.7.0"
   },
   "0.7.0": {
+    "previous_stable_version": "0.6.0",
     "x86_64_linux_gnu": {
       "checksum": "fd9bb11a80a4246bc3415d2ce7e09029f4b1a609f89ba82d23d61971f54d1c2d"
     },
@@ -282,6 +303,7 @@
     "version": "0.6.0"
   },
   "0.6.0": {
+    "previous_stable_version": "0.5.1",
     "x86_64_linux_gnu": {
       "checksum": "7f8837cd354aa16a334d3877fe0dfb6e0d063e5a268f6e6c21422f4ce6566ec5"
     },
@@ -296,6 +318,7 @@
     "version": "0.5.1"
   },
   "0.5.1": {
+    "previous_stable_version": "0.5.0",
     "x86_64_linux_gnu": {
       "checksum": "f0c6a433f217d123da7d89b744c0cdf277a3ef5c3973f424c784f33a74c535a9"
     },


### PR DESCRIPTION
Implement the second one in https://github.com/taiki-e/install-action/issues/178#issuecomment-1663273376

> I think it is also possible to fetch the crates.io API during installation and install the older version if the version is yanked (unless that version is explicitly specified). This could be implemented by adding a field to the manifest that makes fetching the older version easier, such as "previous_stable_version", and a field that indicates whether we want to fetch crates.io's API, such as "is_rust_crate", and code on the action side to fetch crates.io's API and select the version.

The first one is already implemented in #180.

cc @sunshowers