### PR TITLE
Add fallback input option to ensure that fallback is not used

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         run: just --version & shfmt --version & protoc --version
         shell: cmd
         if: startsWith(matrix.os, 'windows')
-      # We use the version output to check the version of binstall, but they
+      # We use the version output to check the version of cargo-binstall, but they
       # several times change the version output format in the past so we need to
       # check it with CI. (e.g., 0.14.0->0.16.0 update change it
       # from "cargo-binstall <version>" to "<version>")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Add `fallback: none` input option to ensure that fallback is not used. ([#517](https://github.com/taiki-e/install-action/pull/517))
+
 - `cargo-nextest` installation no longer use `cargo-binstall`.
   This improves security, performance, robustness of installation. See [#487](https://github.com/taiki-e/install-action/issues/487) for more.
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,18 @@ See [TOOLS.md](TOOLS.md) for the list of tools that are installed from manifests
 
 If a tool not included in the list above is specified, this action uses [cargo-binstall] as a fallback.
 
+If you want to ensure that fallback is not used, use `fallback: none`.
+
+```yaml
+- uses: taiki-e/install-action@v2
+  with:
+    tool: cargo-hack
+    # Possible values:
+    # - none: disable all fallback
+    # - cargo-binstall (default): cargo-binstall (includes quickinstall)
+    fallback: none
+```
+
 ### Add support for new tool
 
 See the [development guide](DEVELOPMENT.md) for how to add support for new tool.
@@ -92,6 +104,8 @@ Additionally, this action will also verify SHA256 checksums for downloaded files
 Additionally, we also verify signature if the tool distributes signed archives. Signature verification is done at the stage of getting the checksum, so disabling the checksum will also disable signature verification.
 
 See the linked documentation for information on security when installed using [snap](https://snapcraft.io/docs) or [cargo-binstall](https://github.com/cargo-bins/cargo-binstall#faq).
+
+See the [Supported tools section](#supported-tools) for how to ensure that fallback is not used.
 
 ## Compatibility
 

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -4,6 +4,8 @@ This is a list of tools that are installed from manifests managed in this action
 
 If a tool not included in the list below is specified, this action uses [cargo-binstall] as a fallback.
 
+See the [Supported tools section in README.md](README.md#supported-tools) for how to ensure that fallback is not used.
+
 > If `$CARGO_HOME/bin` is not available, Rust-related binaries will be installed to `$HOME/.cargo/bin`.<br>
 > If `$HOME/.cargo/bin` is not available, Rust-related binaries will be installed to `/usr/local/bin`.<br>
 > If `/usr/local/bin` is not available, binaries will be installed to `$HOME/.install-action/bin`.<br>

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: Whether to enable checksums
     required: false
     default: 'true'
+  fallback:
+    description: Whether to use fallback (none or cargo-binstall)
+    required: false
+    default: 'cargo-binstall'
 
 # Note:
 # - inputs.* should be manually mapped to INPUT_* due to https://github.com/actions/runner/issues/665
@@ -22,3 +26,4 @@ runs:
       env:
         INPUT_TOOL: ${{ inputs.tool }}
         INPUT_CHECKSUM: ${{ inputs.checksum }}
+        INPUT_FALLBACK: ${{ inputs.fallback }}

--- a/main.sh
+++ b/main.sh
@@ -439,6 +439,12 @@ case "${enable_checksum}" in
     *) bail "'checksum' input option must be 'true' or 'false': '${enable_checksum}'" ;;
 esac
 
+fallback="${INPUT_FALLBACK:-}"
+case "${fallback}" in
+    none | cargo-binstall) ;;
+    *) bail "'fallback' input option must be 'none' or 'cargo-binstall': '${fallback}'" ;;
+esac
+
 # Refs: https://github.com/rust-lang/rustup/blob/HEAD/rustup-init.sh
 base_distro=""
 exe=""
@@ -791,6 +797,9 @@ done
 
 if [[ ${#unsupported_tools[@]} -gt 0 ]]; then
     IFS=','
+    case "${fallback}" in
+        none) bail "install-action does not support ${unsupported_tools[*]} (fallback is disabled by 'fallback: none' input option)" ;;
+    esac
     info "install-action does not support ${unsupported_tools[*]}; fallback to cargo-binstall"
     IFS=$'\n\t'
     install_cargo_binstall


### PR DESCRIPTION
Add an option to prevent accidentally installing tools that use fallback for installation.

```yaml
- uses: taiki-e/install-action@v2
  with:
    tool: <tool>
    # Possible values:
    # - none: disable all fallback
    # - cargo-binstall (default): cargo-binstall (includes quickinstall)
    fallback: none
```

<img width="1001" alt="ss" src="https://github.com/taiki-e/install-action/assets/43724913/28d97e1f-062a-4e4a-ae93-5677f2c1552f">

We could add an option to use cargo-binstall without quickinstall in the future if someone actually wants to use that.

Related discussion: https://github.com/taiki-e/install-action/pull/514

cc @jayvdb
