### PR TITLE
Use asset etag to avoid fetches

### DIFF
--- a/.github/.cspell/project-dictionary.txt
+++ b/.github/.cspell/project-dictionary.txt
@@ -14,6 +14,7 @@ enablerepo
 endgroup
 epel
 espup
+etag
 grcov
 linkcheck
 mdbook

--- a/manifests/biome.json
+++ b/manifests/biome.json
@@ -46,61 +46,79 @@
   },
   "1.8.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC91152144C6E2",
       "checksum": "0971bc636e1abc6d06ea03b219f6c78488b209f8a623de081a04ce610ae47f10"
     },
     "x86_64_macos": {
+      "etag": "0x8DC9115211CD268",
       "checksum": "17b1ecae7751c4519135fd4f6d9b7d8cdcf5dbdaa7d586da8776e05ad05209d3"
     },
     "x86_64_windows": {
+      "etag": "0x8DC9115213FEA5A",
       "checksum": "cffd0c862eb02b0c574a550ac47c213e0d48121fee23ffcaee4098de08cbdab8"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC91152115FC4A",
       "checksum": "4467475395c09442c23efca6bc800f8db14f21791ffc77594f71c11ec9c85aa3"
     },
     "aarch64_macos": {
+      "etag": "0x8DC91152112F276",
       "checksum": "659db94f30b4a5ef80995d494c7e7ec9a7fe820d4ef5b07b0684f2a44fe22140"
     },
     "aarch64_windows": {
+      "etag": "0x8DC9115212F8215",
       "checksum": "ea3c0de73e3f7aa1b95cf5e26694a5427914771e2f47f7b5e5742a16c19088e1"
     }
   },
   "1.8.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC8953657ABA34",
       "checksum": "344a08e4300074612dbf71d417e54816234175e7095f58ce7f10559349d9bc82"
     },
     "x86_64_macos": {
+      "etag": "0x8DC89536571C3D7",
       "checksum": "777cf17639d33ee9a4272176dfec3aa74a0860b46a33f1b8e7e2a4f2266027a0"
     },
     "x86_64_windows": {
+      "etag": "0x8DC89536579354B",
       "checksum": "ae12100af43da3c188b59889baf2f7a9748dc62fb3eff15f48feb082351e288c"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC8953655CA5B2",
       "checksum": "c0dfd1bb4cef5ca36c9aec8b4c7ae478ba81331f013a74f23807f20232988008"
     },
     "aarch64_macos": {
+      "etag": "0x8DC89536569B65C",
       "checksum": "2433998fcf918069b217d7f379e7adbaa5a758a8aec0a1cdbf626778f3f873e7"
     },
     "aarch64_windows": {
+      "etag": "0x8DC8953656EE0B3",
       "checksum": "e865748ffeee8c81f4556a60d389c631eb6c93d29875006524f422024f3a174a"
     }
   },
   "1.8.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC848BE5B22BF7",
       "checksum": "02130f183b65583da5eb4cb8ca023c8565b5e8613904f65a8dd7f02755d66ee2"
     },
     "x86_64_macos": {
+      "etag": "0x8DC848BE592E053",
       "checksum": "a42d7dc5642d15561b96bffd4a95ee8f644a90ba1d654fdeb1c7040e6d52d2ae"
     },
     "x86_64_windows": {
+      "etag": "0x8DC848BE5B88D67",
       "checksum": "087de9c67effdf9d99ca9700d1a9b7fbefc0d493b5d328322524b4fbddda4a10"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC848BE595757B",
       "checksum": "806bce8f838139011f97942e0cb3dfe385858c7bdbbbbac4a2c128b4d7239a41"
     },
     "aarch64_macos": {
+      "etag": "0x8DC848BE5913483",
       "checksum": "3ed5faee598c576b306d968f3da442e56e5710e05f146ca74182649ed1c94dd0"
     },
     "aarch64_windows": {
+      "etag": "0x8DC848BE5B6BAC2",
       "checksum": "7f11c2bab3412e06b3c12232e1df3e68dbc5be104f889f1f2bba3aba9bb4db67"
     }
   },
@@ -109,81 +127,105 @@
   },
   "1.7.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC6DB4E071BAB9",
       "checksum": "f4c2db816081527e18f4219d4c2ee97f3613f9b04aa2c2480b97f85fd0b1c744"
     },
     "x86_64_macos": {
+      "etag": "0x8DC6DB4E08112CC",
       "checksum": "97541273ec677c3dc90cd43989a10f1437e9ca61c8ecc1340706a56b1490ca77"
     },
     "x86_64_windows": {
+      "etag": "0x8DC6DB4E087E8F5",
       "checksum": "a44a6787eb664cd8977da4cfcbc58092c3b8b7e44419895944858dd1eae13855"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC6DB4E0784311",
       "checksum": "8495ff8f76a19a12779c43e49811f5eecb1c88e79e82de7bd61ab968062eca20"
     },
     "aarch64_macos": {
+      "etag": "0x8DC6DB4E0874D5D",
       "checksum": "6c9ff5223173b71aaa12693451369c287e8f4e5625803a9ceefd815a9bb8a0c6"
     },
     "aarch64_windows": {
+      "etag": "0x8DC6DB4E1036C0D",
       "checksum": "6f545f42e3b47f5489f75f30f309611e3ae470dd92e568e44311d2ee3ffdb3f9"
     }
   },
   "1.7.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC6913EF8AAC1F",
       "checksum": "1bad2fd02d9dc2d38800bb20d6222d0b6a3092e707ac8e0ec0f51134ea2525ae"
     },
     "x86_64_macos": {
+      "etag": "0x8DC6913EF9F7C40",
       "checksum": "568377bb375af65a9d6205365708a38fe1ac30105f7d1137248d7c343d69e8fa"
     },
     "x86_64_windows": {
+      "etag": "0x8DC6913EFBEEEE2",
       "checksum": "5ebcab7d65c98268b199fcfe6e6732f46f2b41aeea77716a59110a380560d307"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC6913EFA872DE",
       "checksum": "bdfe7c9fe1b3118c88190e0e5fbc8b1e3cb6dde08b0510a326f3f962f09a7f67"
     },
     "aarch64_macos": {
+      "etag": "0x8DC6913EF97BCC8",
       "checksum": "c0c20ca8f6f9f2441e2aacfca9e1625793195f54224ba0358dc84e85bdee58f0"
     },
     "aarch64_windows": {
+      "etag": "0x8DC6913EF9F555C",
       "checksum": "e48a8de12448ba6b7d5b274ced53ebddf98a3bfabf676c45c8b60a8b7ad2572b"
     }
   },
   "1.7.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC62E3975861FE",
       "checksum": "1b2115fdab03dba4c59cb3d512822e11ceb16f294519343b2e373f9b7aa1a074"
     },
     "x86_64_macos": {
+      "etag": "0x8DC62E3971B768C",
       "checksum": "9b25832f3686399aaee8fd3db611178ea5529c4ed3c3a275e05d0cbabe642530"
     },
     "x86_64_windows": {
+      "etag": "0x8DC62E39782C4A1",
       "checksum": "6bb7ab5f7b88fd7ae8e66abe6558d5ba7ee27939fc6d27dcd8e950540f0d7760"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC62E3973C470A",
       "checksum": "02e41aa2eb4994db7316913f58a38b5c7c7876f7d8320625d0c12ccdbc62d0fa"
     },
     "aarch64_macos": {
+      "etag": "0x8DC62E39722E82E",
       "checksum": "6a5c9f7fcab3dfb4723c23c66ab58ed345e082a66a5406b7d30e1c50d990c89f"
     },
     "aarch64_windows": {
+      "etag": "0x8DC62E39A52DDC4",
       "checksum": "076c15a8a314ba151118295da7f182630dfab160bde22f50b3c87e482912f337"
     }
   },
   "1.7.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC5D49038A16A6",
       "checksum": "9e8df2e263bd1a3c057a661682b280edf73c40a288f0c3267d11fcde2553cb87"
     },
     "x86_64_macos": {
+      "etag": "0x8DC5D49196F2C50",
       "checksum": "2586beedcefa5ad6c5f2ae43148bf4c4e266eab3718e8b0355deb3b388e03358"
     },
     "x86_64_windows": {
+      "etag": "0x8DC5D490CC94DF6",
       "checksum": "a305a0e39b54301c97ab72c40db3409cc7d452096eee659c2402338402126f24"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC5D4905588856",
       "checksum": "a042bf5ee40e0b84ee7860a58af69d0766db719eec5a103e9f09b2eef08cf663"
     },
     "aarch64_macos": {
+      "etag": "0x8DC5D49032D6AD4",
       "checksum": "3ea37facceb5f565bd6ec5e343ed7aa4257ae78f42671dd68d9af06a1018803b"
     },
     "aarch64_windows": {
+      "etag": "0x8DC5D49034937F3",
       "checksum": "89d972f4d3e41475802b9d3f0e1dc6ed9d31079e8902813f9e4a5600fd814a81"
     }
   },
@@ -192,101 +234,131 @@
   },
   "1.6.4": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC53CCEF1D6F77",
       "checksum": "b4b9ac0fb6ce7f28c77430b07139ca54794a7e5fbcd94cacc91cdd15bbeb08a2"
     },
     "x86_64_macos": {
+      "etag": "0x8DC53CCEE9E209B",
       "checksum": "c871c17346a965a31bfeb0ed4f5046b2ea64940c703cb7ae460d001c788de2ea"
     },
     "x86_64_windows": {
+      "etag": "0x8DC53CCEE8D917B",
       "checksum": "df7a3f2c256b666a05d6c5eeb72a3fc0d836a836566d918f8fa619abb2c7ccf4"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC53CCEE78E841",
       "checksum": "1cb7a0e478f6d1148d79c685af685c1033f4a361417cf9bf25a7ab05c075149a"
     },
     "aarch64_macos": {
+      "etag": "0x8DC53CCEFE83F45",
       "checksum": "e62a09a4943be949ff7e5b75af76ea9efa02dc0d2e772fd0f7338b94ebe06163"
     },
     "aarch64_windows": {
+      "etag": "0x8DC53CCEF8448DA",
       "checksum": "13566c0cdf892cf8e67256f56e7de6a07c8e9f5b78c6494c49a0f7a7752a6aa1"
     }
   },
   "1.6.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC4CEFF0AC8CC4",
       "checksum": "55792cdf4299d51ef357f7a6933f0cd98b573cc8f8c7883a0deef3f1b2a287c3"
     },
     "x86_64_macos": {
+      "etag": "0x8DC4CEFF06D80EB",
       "checksum": "ab5e8ba4579c80e4819eb55ad1447898165915963918c03a44695905d0a8bf0c"
     },
     "x86_64_windows": {
+      "etag": "0x8DC4CEFF1034BC1",
       "checksum": "fd2ba0e350d5e0a764924a50e0aec1d6648a00a90b7cfe04d093f313ff813f9f"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC4CEFF4316E29",
       "checksum": "94531e86898a52ecb6b59e02e52ea637383b564155117b1e1a9d972ad3dc51c0"
     },
     "aarch64_macos": {
+      "etag": "0x8DC4CEFF06E4367",
       "checksum": "4583613e1c9b6c4dc65d1b9b79d199f205dd7e823e315bf07883656d3f9cc6b0"
     },
     "aarch64_windows": {
+      "etag": "0x8DC4CEFF1039982",
       "checksum": "9627c0550da0002244c1cb0ee94e24ab6522738d996d9a594c0cb14ce77cf12e"
     }
   },
   "1.6.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC4A4E1075B49E",
       "checksum": "2edac9e3f9b811632a5c177885a464dfe047d33f8dd00934e63d09fdb9b4629a"
     },
     "x86_64_macos": {
+      "etag": "0x8DC4A4E0CFAD818",
       "checksum": "2ddbb5c9c30aae6a5575f6725f38f80778c76325b52a252cff09ec2c70102b38"
     },
     "x86_64_windows": {
+      "etag": "0x8DC4A4E0CEA96AA",
       "checksum": "1a0c8eab84c965c88c3a1d5e57cb00bc160362420719207b301cbd7060ed5491"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC4A4E29D2534E",
       "checksum": "03dc64013c3f478748e0a2e5519d654d8896eb8f0112d6510752c918f5c69c35"
     },
     "aarch64_macos": {
+      "etag": "0x8DC4A4E0D3921A4",
       "checksum": "d0393790c7a3adb1ea9a8870e3f6f63707014cc8d14ca3c09562d6816b91cd22"
     },
     "aarch64_windows": {
+      "etag": "0x8DC4A4E111979CA",
       "checksum": "bddef88ae0614f2c527f67eb3d9c70a2393629f6bebf0207337498164bbb6155"
     }
   },
   "1.6.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC428A67E9A283",
       "checksum": "698249d598ba196ab32c2a383b4b00e429cdbb5a24c2b11ea6aa80c4ca0dd15c"
     },
     "x86_64_macos": {
+      "etag": "0x8DC428A6E8A6FD8",
       "checksum": "49f776fca81c8b3ac6b8051429bb240c38a41949fbf8d55713df6b3ff4797a91"
     },
     "x86_64_windows": {
+      "etag": "0x8DC428A6FC16B1F",
       "checksum": "f3dcf3669f630b6017ce6e23c1d8a8424295b5c504922c6dfab029d9ecacea3c"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC428A6BE55395",
       "checksum": "dcf867dfa1541670d0eb2bde117f1f01f5dcfe66ea30cd97adf1dd96a1a73f70"
     },
     "aarch64_macos": {
+      "etag": "0x8DC428A69DF1FFE",
       "checksum": "6373cbc2c9dce3aa1fd3af2b2293a792e13e374b0c503d43a80e9fc35f100502"
     },
     "aarch64_windows": {
+      "etag": "0x8DC428A68FDFA84",
       "checksum": "97e4b7d0c1256e51028ea496c665fca8e53237ff44434ccd27a477d38167ad43"
     }
   },
   "1.6.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC3F7C7709C13B",
       "checksum": "4a76d09b1c06c3b7c486e99c899076d4f60f8b34d0bb9b41a61abee16345a99c"
     },
     "x86_64_macos": {
+      "etag": "0x8DC3F7C738C9DEC",
       "checksum": "4cf6468c39e3eb45a5bfc4d65365d1b748470d0f97235471263ef7dd66b2bae5"
     },
     "x86_64_windows": {
+      "etag": "0x8DC3F7C73D5D79A",
       "checksum": "43a2df63d8bc3c1afe3560d9a2c4629d6961d31b99d251446ce359e1ce7844dd"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC3F7C735E47F5",
       "checksum": "7897c55191a8c500107764102c0cc5e29f5817829cd4eda6d9e1236aec95cdf7"
     },
     "aarch64_macos": {
+      "etag": "0x8DC3F7C73AC851B",
       "checksum": "396602d624fe1a68a6ea59a4d75bd43d2643f9283c543e240a86fbd3d21192b6"
     },
     "aarch64_windows": {
+      "etag": "0x8DC3F7C738C293D",
       "checksum": "04e5fb6d337f468ab50fae1d2586dd210a8d6adb2cf4879011119b1dcb8446a1"
     }
   },
@@ -295,81 +367,105 @@
   },
   "1.5.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC1B3CAEE94024",
       "checksum": "33fde68516a1a170832e702cf9938720322462bdb3b74648a51cd89c476eac30"
     },
     "x86_64_macos": {
+      "etag": "0x8DC1B3CABDBA091",
       "checksum": "c89bbe62cefbec56c7352020ca78f2e5053390ab4d8128730b19c6911496016c"
     },
     "x86_64_windows": {
+      "etag": "0x8DC1B3CAC17A29B",
       "checksum": "01c0f14c0a0a2e6bbf5e6db1e00a024a9128017eee1e3d2f795fc4f36ab0584c"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC1B3CABCBD3F5",
       "checksum": "38333783bd266148fed4df958d5a7442cb1612f8f8314f014a343a400b62270d"
     },
     "aarch64_macos": {
+      "etag": "0x8DC1B3CABD36C75",
       "checksum": "ed663bc33191beea63a68352a68233079bd3a537c25365bd3160e9284f894c98"
     },
     "aarch64_windows": {
+      "etag": "0x8DC1B3CAC3D4FA1",
       "checksum": "04261e136529a5714504c27a6c0b580a5f52b40d1e8b31bfbb2126b00d4331d9"
     }
   },
   "1.5.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC15B2855D0FF9",
       "checksum": "b58f8c921e0c8d7bbec0f0c5f8429a8fa5bba97e87ccd694f0dc51933f2814fe"
     },
     "x86_64_macos": {
+      "etag": "0x8DC15B285461F56",
       "checksum": "72bb359a689bfe8ca3d703cb6c356f9ee26c0171f8f0fa6d08ed1385b17e2e97"
     },
     "x86_64_windows": {
+      "etag": "0x8DC15B285837F97",
       "checksum": "1a36467f1f46d371e42750781614d980dd7662e2f959ecad7b693f14506a91e7"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC15B2853A1EE5",
       "checksum": "4df84c2711fe55b28703ec9165158dd8cf5310f706b7d944e9220b0954a7c1f5"
     },
     "aarch64_macos": {
+      "etag": "0x8DC15B2855B8B0F",
       "checksum": "5f46174abc25cb088cdd4b1ed560b35581afce8bbb0709b6c7a4ede3f7533732"
     },
     "aarch64_windows": {
+      "etag": "0x8DC15B2854FB183",
       "checksum": "daf09110425463fd4d72bc13404e2f406bd1c8afd38ee0b7225c4b26fb3ea8c1"
     }
   },
   "1.5.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC11E023489B2E",
       "checksum": "a69e6cf8c34fbdd61c584d0dfc25c1bb0f913e9ae141244790e21f94b64cab88"
     },
     "x86_64_macos": {
+      "etag": "0x8DC11E023505AA7",
       "checksum": "2e7e55efdfdd971ae001f2be314b471fbd227571d2d52da799e4e517f731563a"
     },
     "x86_64_windows": {
+      "etag": "0x8DC11E024341538",
       "checksum": "6f2412b34a988c076558f60acbdde020dc41e1fb699061763b545a3a4469a97b"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC11E023297662",
       "checksum": "7fa919de065dc234724032e78de19fded1c10a99450bd0f4e1b330a94d794644"
     },
     "aarch64_macos": {
+      "etag": "0x8DC11E023765590",
       "checksum": "d188409cb501e7292d1ded87a239483a9fedf886765fc5a33602a673c1fdd3af"
     },
     "aarch64_windows": {
+      "etag": "0x8DC11E026F9188F",
       "checksum": "6adab1ad668a0b94c502f2bb2d9c261ad6ec7bdc472630b28a2884b6fd8ce256"
     }
   },
   "1.5.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC1058C4739728",
       "checksum": "036dec97756554e343a35e0d8b56e8b6d92a4347c133274a9e420525dec63816"
     },
     "x86_64_macos": {
+      "etag": "0x8DC1058C34B0A85",
       "checksum": "c82f7f76379f1e8a3750370a4ca0b9295aa64c12a5d76ce88bef7b687fe823b2"
     },
     "x86_64_windows": {
+      "etag": "0x8DC1058C2FBBD09",
       "checksum": "d475f4267e5247e32f3d412367a8916d2b21fc0eab058cf5e60cef040934ac33"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC1058C2823397",
       "checksum": "5d595a8db117bbbb7968a09111f8fed2e418dc615c7a49553b04f06f364013db"
     },
     "aarch64_macos": {
+      "etag": "0x8DC1058C2922738",
       "checksum": "2176799b0ef60820374e180cbf6d3b14aac9fc49080329e49abbb78d37bfdcfa"
     },
     "aarch64_windows": {
+      "etag": "0x8DC1058C2F61E0B",
       "checksum": "b1fefa6fe489ca50bed539931b71c208198e38793097957549474c961c110300"
     }
   },
@@ -378,41 +474,53 @@
   },
   "1.4.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBF1DD53ADD488",
       "checksum": "37aff9d2fb5699306d8ed7b9858af7fa8536d23e49ef1f327f5652b19c6b7125"
     },
     "x86_64_macos": {
+      "etag": "0x8DBF1DD539585D5",
       "checksum": "7e40b33cf4553d32a9eb2ebf021ebfebcf84690b4a195a97cdd4a73ffaa60daa"
     },
     "x86_64_windows": {
+      "etag": "0x8DBF1DD566358B6",
       "checksum": "53af2ef1a14f73f506b516545eedd73880d1a382ca1e031aa38cc016947e6f9f"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBF1DD539D931C",
       "checksum": "4ab6d66ae272d65ef5843eddefaff8bb10cd2d16b313a145877bd6a8120f8c02"
     },
     "aarch64_macos": {
+      "etag": "0x8DBF1DD5388007C",
       "checksum": "edd8b651084058977988fa3b5cbfc0c6a87175fa7ad3b4554636530b9ea84178"
     },
     "aarch64_windows": {
+      "etag": "0x8DBF1DD53A0EAB3",
       "checksum": "1c591c0566d2b09cfa7a5bfbac4c958784fe9a81b0d2b4df241e999c7f201ed9"
     }
   },
   "1.4.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBEF68526539A1",
       "checksum": "5ddd6b0d46770e3dbb3269818613354a67bd2a25dba1f781f66c1c68e9736a6d"
     },
     "x86_64_macos": {
+      "etag": "0x8DBEF68529C3856",
       "checksum": "577a8351104676269103652d0815872e8ec14271c71b68b4e56fab45367217ce"
     },
     "x86_64_windows": {
+      "etag": "0x8DBEF6852DE4E25",
       "checksum": "5980f3956f51cf570c5830cd86534b4e11743e08967dbee3f755ecfd77d04d30"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBEF6852750655",
       "checksum": "82b764b2528306c661a16bef8fe254002691a8a6649a18b0160f3fc96d3244de"
     },
     "aarch64_macos": {
+      "etag": "0x8DBEF68524C2887",
       "checksum": "fbd1852338ba02c832a3a9b95818e516e2327a82620fd2d159eed77a960a3e23"
     },
     "aarch64_windows": {
+      "etag": "0x8DBEF6852F407D3",
       "checksum": "1dfbf844a312e40c1f16e4b1e8486ff4c93281087b2ee1c50ea9ca34b76da8b2"
     }
   },
@@ -421,61 +529,79 @@
   },
   "1.3.3": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DBD9EA3FFDB826",
       "checksum": "f15e955a935ec1e255a626c4501048612a271539483f76d8d392b0cc7e80b42a"
     },
     "x86_64_macos": {
+      "etag": "0x8DBD9EA3FC8B2DF",
       "checksum": "7b5a6f7a480b371f99889b86b1dab83459100078f76e5764c2344d14e20e9cc5"
     },
     "x86_64_windows": {
+      "etag": "0x8DBD9EA3FF9028F",
       "checksum": "55cc372816ae1b08a87ec33508f031852e78f5e4e6c183e3049d9886b91fe8ea"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBD9EA3FE62BEF",
       "checksum": "3eac5c42c21f330a77f194ad10fd9cfa3e627512d999124405fb9e033223b6eb"
     },
     "aarch64_macos": {
+      "etag": "0x8DBD9EA3FAF7ACF",
       "checksum": "7cc8ed3b20a936a7c739554742dfb9529b045a372af45a5e21e311013140930c"
     },
     "aarch64_windows": {
+      "etag": "0x8DBD9EA3FD5011B",
       "checksum": "fd913acca6a1e81aa3a916cde92003c377458e302946614f0ccd503c815e0a46"
     }
   },
   "1.3.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DBD15B6192A54E",
       "checksum": "9c31d33b32a42e01d6efc6e0fb12bbbe8e0c6a1a261c2a80b92d1735cb54f4a8"
     },
     "x86_64_macos": {
+      "etag": "0x8DBD15B615E6288",
       "checksum": "ffe128ae63c561e2461da0576b33b4b9c535565a40f8d6c82476d8d64306a7d8"
     },
     "x86_64_windows": {
+      "etag": "0x8DBD15B619D9580",
       "checksum": "4cc2782680fb9b925950314d63a1eb30e09604adf50ec20577eb13ca5dd86821"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBD15B61684280",
       "checksum": "c33847309aba05d14191e1144119343b3219bdfc24a601242cc99f131c8d67e6"
     },
     "aarch64_macos": {
+      "etag": "0x8DBD15B66E5AE40",
       "checksum": "64fbd948e2c94f3a1fa2746dc57b5c02e42d1a97482ca5c32209492a877296c0"
     },
     "aarch64_windows": {
+      "etag": "0x8DBD15B618BF614",
       "checksum": "ea180385adedde4c0db59d2ae4efd910306ed46f08f3b91c060df9c45c4cdaa9"
     }
   },
   "1.3.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DBD0825F15F435",
       "checksum": "6b6d971d3a74944fcd1613068c6148908a7a5b71ca2ffd3b44a8cdb65c11f417"
     },
     "x86_64_macos": {
+      "etag": "0x8DBD0825EFF9F24",
       "checksum": "2b607e7a15a023e3c1be05e1262b6197914a81752ba076fa7bf22b753ed3da4b"
     },
     "x86_64_windows": {
+      "etag": "0x8DBD0826059D970",
       "checksum": "ff0e25ab793db80346c8ae042b28e7f634ebbc8eff94712297a660c152817696"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBD0825F07FA35",
       "checksum": "b08ee12f4e167a4529ecb0056faeb88fa4d1cecfc17a48f9a4b57ce95a6cc6e5"
     },
     "aarch64_macos": {
+      "etag": "0x8DBD0825EF2B55A",
       "checksum": "178cffd9ef1d7461f3826068612aff297aa3b23aa49e0b3766b498fc268cac2a"
     },
     "aarch64_windows": {
+      "etag": "0x8DBD08260A926E5",
       "checksum": "488208b985e5ed068a700426b0142d5435bdd9d57b11e866ad31d8367f0aa8b6"
     }
   },
@@ -484,61 +610,79 @@
   },
   "1.2.2": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DBB697A001DF61",
       "checksum": "4748cc070d114faa357a75cc18d99d3062b3468862ca6eb973fcfe4c07bf9d8b"
     },
     "x86_64_macos": {
+      "etag": "0x8DBB697A02B31D8",
       "checksum": "8f5f78b8c3c5e0dcff2531f6b847ff860b8d9c007f9f7564890f52a307284f7a"
     },
     "x86_64_windows": {
+      "etag": "0x8DBB697A04469C9",
       "checksum": "b7fa90a8bfa76331f9764ea4e661c98819899e715ab5b45f34bced2a889f424d"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBB697A02434CD",
       "checksum": "17f05345d1b6642da3ec88592612cf8af7ccbb09a011cee32d956dffe5fd920a"
     },
     "aarch64_macos": {
+      "etag": "0x8DBB697A018CFF4",
       "checksum": "04aee13d57fff780d0ff05a6817a1da20745a5e6827f3701a039a15a40620ca9"
     },
     "aarch64_windows": {
+      "etag": "0x8DBB697A01661B5",
       "checksum": "fbf56fbfd9925d5350e543a532456f631c2f2b22ef04c8fb9154cf0721755039"
     }
   },
   "1.2.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DBB60E66D53B0D",
       "checksum": "0bc45bc0eb9b103897f1ffd71758a161820b6aad8a71e3117b9ec396647d3196"
     },
     "x86_64_macos": {
+      "etag": "0x8DBB60E66B160A7",
       "checksum": "60737d7a98e79677b9330f552be78faa46405ff311aefc56e6035dc604049d20"
     },
     "x86_64_windows": {
+      "etag": "0x8DBB60E66DA6552",
       "checksum": "f75b997ba1ef9ba6202f267751bf01ccd17a0e1c9235b38e06f40e08a173bb70"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBB60E668BB3A1",
       "checksum": "a9d825eef0583e30e0f8faf719fdc251b03cb0295b6470fedf47cd6e17902673"
     },
     "aarch64_macos": {
+      "etag": "0x8DBB60E66A49DCE",
       "checksum": "3084cdecb80b6386517058ab042edc4ffa9a5059432ea5561742eabf2dd6dbee"
     },
     "aarch64_windows": {
+      "etag": "0x8DBB60E66AECB8B",
       "checksum": "5375840c49c673eae1fc4fb463e8f004a396fe3a7445206859f369b6fb491c28"
     }
   },
   "1.2.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DBB5F610771A25",
       "checksum": "7e68da797fe3835be8c798ecdc77ad9c0b0f4d54c941df0381a660dd8690a238"
     },
     "x86_64_macos": {
+      "etag": "0x8DBB5F600301C18",
       "checksum": "1937b276f44f5f1088d68243b6fd5e842aebac4718bb7698f671080856df9a5b"
     },
     "x86_64_windows": {
+      "etag": "0x8DBB5F600502A2B",
       "checksum": "14b4c413c431b60d290ed371731f8949a3a97f063f59897374fd8f640d7fc8b5"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBB5F610C13D26",
       "checksum": "0837588c59ebd4a089a56206bacce198f08d0e0ebe9ba04a03eaf5c2e5188cd9"
     },
     "aarch64_macos": {
+      "etag": "0x8DBB5F6001D1EAD",
       "checksum": "fb3e874fc681238ff763ddf087d919babe12d184e9ea00b04389ee6b69418543"
     },
     "aarch64_windows": {
+      "etag": "0x8DBB5F600291F21",
       "checksum": "76786255d8f7d8c5af20d9ef4252d10f4be26e51d07754ce64480dca1a3806fd"
     }
   },
@@ -547,61 +691,79 @@
   },
   "1.1.2": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DBAFD7C142AF33",
       "checksum": "884666dca1c7c43c15da0a15b685a0afbd5b2a6420e727cd38f449dc16237b50"
     },
     "x86_64_macos": {
+      "etag": "0x8DBAFD7C0D6F921",
       "checksum": "46841266267ef9b7f4aa9b0160781bcabf2e9c6210b115604f578ed5748a0e43"
     },
     "x86_64_windows": {
+      "etag": "0x8DBAFD7C0ED2752",
       "checksum": "a5126aebb4366bb69ab32a3ae119b950ebba739feace6f68f4309cfaf7156063"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBAFD7C10A04A9",
       "checksum": "71769a2fc037a00af217443651d52226f672d03443aa13aa701bd7edfbf545b1"
     },
     "aarch64_macos": {
+      "etag": "0x8DBAFD7C0E6C5DD",
       "checksum": "e28e4b153a17b79b5cccb72bb65383a8042db8baa127f3a84059f817a2383dad"
     },
     "aarch64_windows": {
+      "etag": "0x8DBAFD7C0FB4832",
       "checksum": "32da1639cf2c8d71b37084b872d258a17583e33a0880edd2e0efceb29a4a5165"
     }
   },
   "1.1.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DBAF88B9AF9EE3",
       "checksum": "638dc53c0f2b0dccec2d1e6d66a5a51dee83c8a6e571d948ec1f022261d005e1"
     },
     "x86_64_macos": {
+      "etag": "0x8DBAF88B9A57133",
       "checksum": "0a939082ede936985adbc181fce24c63b98304ab1e2032aa23bdaf4c8854901e"
     },
     "x86_64_windows": {
+      "etag": "0x8DBAF88B9C6DD4D",
       "checksum": "4f3fb1fbf05eed77bca7f15a25f39f5364027249c2d2ed4ac8e85ad1818c5200"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBAF88B9E4F1CB",
       "checksum": "47c0aff5a94754952996d9e31d8ebfb55e8b844d8a524eee5dc44e29f49632b3"
     },
     "aarch64_macos": {
+      "etag": "0x8DBAF88B99383FA",
       "checksum": "3112b086c1a205c95ca491ca2920b962cc8fbc7113881deb584001495a52e343"
     },
     "aarch64_windows": {
+      "etag": "0x8DBAF88B98ADB32",
       "checksum": "d18c3939fc9bc72c4ed61d3f78de3256fb968cb55e103698a601de8c70f74648"
     }
   },
   "1.1.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DBAF0CFF72CB65",
       "checksum": "e761e0f0d6975890ae6200eb0761e830a488b6f140e1c31ef9df54b4b6077bff"
     },
     "x86_64_macos": {
+      "etag": "0x8DBAF0CFF35DFD6",
       "checksum": "fe652ef62c3df8baa5f4be44c63f11c96ff26c635dfead8eb192ca1438cc7e07"
     },
     "x86_64_windows": {
+      "etag": "0x8DBAF0CFF2BFFE5",
       "checksum": "33e4ccf95fa48f0d7e8edee6fc4926dd2c30d8604843c53d52d9e9a3bc9f503b"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBAF0CFF3E3AE0",
       "checksum": "358bd0935867144ba336035b5fe15031d7350b7c8806438d38ba1e8a12eebe60"
     },
     "aarch64_macos": {
+      "etag": "0x8DBAF0CFF39AC21",
       "checksum": "6d0a5f556f34b408992fd9cceff09f810a844c1ed82372caf0cc3f659145439b"
     },
     "aarch64_windows": {
+      "etag": "0x8DBAF0CFF308EA1",
       "checksum": "f8e221f704125d3bbcf3200d5e32a12bfb6e04975fea042fdba38496c93224a2"
     }
   },
@@ -610,21 +772,27 @@
   },
   "1.0.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DBA794500C0636",
       "checksum": "c5aab82e7c18b706826238f4c1178de67479a004e72682afaa16f03f95864038"
     },
     "x86_64_macos": {
+      "etag": "0x8DBA7944FE3C3F3",
       "checksum": "a6d36e1b54020d8bfcca0659ebbc0f1810d187adb7cae906d3693a3b8a19a14b"
     },
     "x86_64_windows": {
+      "etag": "0x8DBA79450231DAE",
       "checksum": "09c7e30ebd00da2ba26de88d4a3c404932b84838fb441a1fe9ba725e481c78b4"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBA794501CE324",
       "checksum": "debedada2fdb265020c986fce38fad4eb0dcd2ca09fb4d5d387bdb90bba2044a"
     },
     "aarch64_macos": {
+      "etag": "0x8DBA79450501588",
       "checksum": "ee72998255a928bb01c8e9b74dc6935b09a5da3eb872b3245dc23e9359b1f0a9"
     },
     "aarch64_windows": {
+      "etag": "0x8DBA7945014D5E4",
       "checksum": "31edc423a5845a58581a94ec3a4713c8e8273ce45b31cee6410466b6387a51d9"
     }
   },
@@ -633,41 +801,53 @@
   },
   "0.2.3": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DBA4E58DABD0B6",
       "checksum": "b27600adec7d56b82035638ca482da4d40893f6654aad1f396a574319a8eb0fc"
     },
     "x86_64_macos": {
+      "etag": "0x8DBA4E58D78EC14",
       "checksum": "f4875c6e9367739b0d6a0b8d82719ff085fd369076d979ca213373217615c670"
     },
     "x86_64_windows": {
+      "etag": "0x8DBA4E58DFAF749",
       "checksum": "6b672adac1b810127e707b9473fb88adcf69808d2f7b92642be7b9c31e65b9dc"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBA4E58DB27FF4",
       "checksum": "8725206a9c700560e680e26b50da256aae5aef85265e5379af572121c52a10c7"
     },
     "aarch64_macos": {
+      "etag": "0x8DBA4E58D69BAD9",
       "checksum": "f12db446febaf05f1e85d487714ce9003d13aeead50ec99e456d7bf9fd7374dd"
     },
     "aarch64_windows": {
+      "etag": "0x8DBA4E58D946B68",
       "checksum": "9cb8d6220009b3b7491412fc2cdc44700ffa4f3840c9db5878e7cbc0fe980b2a"
     }
   },
   "0.2.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DBA1B65590C4F8",
       "checksum": "697b90197156036b75b9b665dc2695b6043ec5fdb09f667e9cca3fa48beb4a83"
     },
     "x86_64_macos": {
+      "etag": "0x8DBA1B655456ABD",
       "checksum": "f98e91544bfea5117827c5c02892a0c238e0b78db9f77d76a88aa0e889c098fc"
     },
     "x86_64_windows": {
+      "etag": "0x8DBA1B6553308DA",
       "checksum": "0d433349c1c88d8ff1b880020cca0502b684d32f37c9282edd6bbfd2f17562c5"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBA1B655408E39",
       "checksum": "7fffabe46e103c47ec4417a5bd35dcf7fc3cae562911367d63b938a12fd62b45"
     },
     "aarch64_macos": {
+      "etag": "0x8DBA1B6551F48F1",
       "checksum": "76e78a752014297b715cab6bea23767783e277a3b0c32d7bceb58deee2c0183b"
     },
     "aarch64_windows": {
+      "etag": "0x8DBA1B658811426",
       "checksum": "cd9e1701a23669ac3846942f8749c7e87c46a7dfa7ca6af94c7af9c9fa60572c"
     }
   },
@@ -676,21 +856,27 @@
   },
   "0.1.2": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DBA0001F5796D8",
       "checksum": "1fb3cd314badb6b5b0605ae41119c3b72717d966412e341368d8867afe2201fa"
     },
     "x86_64_macos": {
+      "etag": "0x8DBA0001F45A99C",
       "checksum": "c4cae46daecae6565e71c430e2feab4181a56e25301bc6c24e203155f738a5d1"
     },
     "x86_64_windows": {
+      "etag": "0x8DBA0002132303A",
       "checksum": "a81ecf9f074f68775fad58621211aa53e727932bb0c70e682e98ca49902112c9"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBA0001F2CE63F",
       "checksum": "f8facf000564b0537c7d4dddd993d0def82e66b8c21e0ab8c1fd4b9aa36f4d76"
     },
     "aarch64_macos": {
+      "etag": "0x8DBA0001F4FB06D",
       "checksum": "f5d32bae49b7186075b924c9fdae806fdea8ecdc03108b71542127eac93e183d"
     },
     "aarch64_windows": {
+      "etag": "0x8DBA0001F70CED8",
       "checksum": "227f7f9ecb1a27e4397675b3a2575dffa217343b1e5155c0f617408e05996d87"
     }
   }

--- a/manifests/cargo-audit.json
+++ b/manifests/cargo-audit.json
@@ -27,15 +27,19 @@
   },
   "0.20.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC2E91E9960B2A",
       "checksum": "c8bb83967f74734a5a4b23b0136c26db3fcc81570eb389cffda4d67ea6d8ad9a"
     },
     "x86_64_macos": {
+      "etag": "0x8DC2E91F7376884",
       "checksum": "3f4022fd3010e0e9ffa8b8a75b80ab365c9ab1c3f3d2dd6af6385bb803778f9f"
     },
     "x86_64_windows": {
+      "etag": "0x8DC2E924FCC97C6",
       "checksum": "ec8d3b6e722b01bf51efc1b56dbaf542f4d4101e70f3f45ae4dda52e6f71d2b0"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DC2E91E8770F94",
       "checksum": "fb2fbd1f5d36aa131451115183d24605e3ca7f656c6994ec03dfc3b7c581cf4a"
     }
   },
@@ -44,15 +48,19 @@
   },
   "0.19.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC24F5D027FC0F",
       "checksum": "5f27032694119fd990ac92ec093b78c192631c36200d67f5eeb4cb1d42316bae"
     },
     "x86_64_macos": {
+      "etag": "0x8DC24F5C0EF40C1",
       "checksum": "371c2f464bb6152307318dede563c8fb8ecdc456224b21bdf018af58be739068"
     },
     "x86_64_windows": {
+      "etag": "0x8DC24F62F6FF95E",
       "checksum": "ab2cd04392480becd704a48bc70485310e4f029431f87303fa9aeb485fd463bd"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DC24F5CB42CD4D",
       "checksum": "a5b27ba8fdde75814d96a501c564f10cd4a553c0e8a19f4f1746283a7fda5296"
     }
   },
@@ -61,15 +69,19 @@
   },
   "0.18.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBD4A05733B7C4",
       "checksum": "2cc37ceefda1d8fc4be45363639e696f31d5bae12c47ce05146a06c432f37290"
     },
     "x86_64_macos": {
+      "etag": "0x8DBD4A05D6DD0AD",
       "checksum": "2dbf9a0861a83bef081f5a864b0d1d3464164146a9d230a0f4beb64be5e93eb4"
     },
     "x86_64_windows": {
+      "etag": "0x8DBD4A0AA768DBC",
       "checksum": "6d7111be9b30683ae6fb558ba8a5e3b0ed3153f645e2e1549122af69625c478e"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBD4A052372232",
       "checksum": "9655a1b5d8b4bde20eeceb2ee0701149eb954b008a3711a207014fadb9623753"
     }
   },
@@ -78,85 +90,109 @@
   },
   "0.17.6": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB5187527EB84E",
       "checksum": "62272b41f946c77193e47a96ef8a891df0ec9af6cbefa1e373b42f42a9f99b7e"
     },
     "x86_64_macos": {
+      "etag": "0x8DB5187908359D1",
       "checksum": "a0ec73e774d187a704f3410337f8a878cc49bd2872eccb152ccaf6500fb177cf"
     },
     "x86_64_windows": {
+      "etag": "0x8DB51962A8DD0CF",
       "checksum": "a9c7427725b137a6eec66cc36b673024af34870f4193ec33b293db32826a28bc"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB51875B93B162",
       "checksum": "84821b0a3ec175a13fd499d22214a02e0df84944d5a44414fda92cdb21ef26a1"
     }
   },
   "0.17.5": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB2D554F62A383",
       "checksum": "6124641659a333285d9002e4f3e46a58782ad6e0bd54aa001747bb3cbe8d4af9"
     },
     "x86_64_macos": {
+      "etag": "0x8DB2D5554039295",
       "checksum": "61daf860ca51e5f4da236cc0d5fef94b0ef89bcefa950a7f8ede4101e150250b"
     },
     "x86_64_windows": {
+      "etag": "0x8DB2D558B04C35E",
       "checksum": "a1a8905406a50d63293410fe424c67232337fefadff9d7507a09bb803f1cbc6d"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB2D5547BC8642",
       "checksum": "8ee364de52f333da580c678b3804a579ef2d7beecef3647e2c19c823baa10390"
     }
   },
   "0.17.4": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAC1D09F469DA0",
       "checksum": "7787092990768eb44e12ea489fbf94c46efdf1e74209d6eed3da39a770c0ab61"
     },
     "x86_64_macos": {
+      "etag": "0x8DAC1D0E9C00253",
       "checksum": "e0b0a432f45e6951a0eb45124697eaed5e01ce0a3452d1f2b1bb0e8baad266cb"
     },
     "x86_64_windows": {
+      "etag": "0x8DAC1D049E726C8",
       "checksum": "7faa864c7474e9df44ea04d5757b1b6c600df09d28e48825a160d1d7271de2f7"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DAC1D01EA52D25",
       "checksum": "418e8212e79d7a9d3241a6bc8b7cca9016d59d7e3a680cf0d1a36d34e853f98b"
     }
   },
   "0.17.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8DABC3C9F7F80AE",
       "checksum": "a46d436e83eb4e220dcf6a1fc91dbeae6cd549b5809c070b958e4871e0c49f39"
     },
     "x86_64_macos": {
+      "etag": "0x8DABC3CA818A429",
       "checksum": "20daa15f351d7f44ff256e9b7deb588b2cc37254b3410cf3b02be60db1eb2eb4"
     },
     "x86_64_windows": {
+      "etag": "0x8DABC3D51D036C4",
       "checksum": "51ca34dd3c0f3ba69b369e3b97ac6b8efd19ae27b65e78708c437596c597dbb5"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DABC3C9585F1AE",
       "checksum": "f8495db7044f804fc9d0adddae000cc25bbe145fc4e69922c91326ba20850c2f"
     }
   },
   "0.17.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAA7EFC1EE56B9",
       "checksum": "c22e29bd95092e0681716c55cd2c5993aa8f85e1d602bec57a018c1690e07bf9"
     },
     "x86_64_macos": {
+      "etag": "0x8DAA7F0BFA33266",
       "checksum": "ccc0e0b742020a2aa524d0902557af6ef0ca55e2f36a054fd7f2ecb3b154c42c"
     },
     "x86_64_windows": {
+      "etag": "0x8DAA7F02AA22FB4",
       "checksum": "71130a0cabe200944b325bd38e64dde80f8756c333f619b1a88a5860e045e055"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DAA7F0014C43A8",
       "checksum": "b0ade081038ea20fa0943aa6b9b1ce586c4be1eaf69b8897d2495792eac7648c"
     }
   },
   "0.17.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA3CC8C31E8286",
       "checksum": "552bec2dc3de9913c2783624dce3022ea305bfd4b79994a3c0879ac509c765f0"
     },
     "x86_64_macos": {
+      "etag": "0x8DA3CC952C2314A",
       "checksum": "a54ca8139a8c3e4680a4a3009971fc47aca7a2fe5684399888d03934bfba51d3"
     },
     "x86_64_windows": {
+      "etag": "0x8DA3CC9C3C9A467",
       "checksum": "4ae4919ab5e2f7e212272e84d3d54b231e534aa8c7fc7d4dfc08c2c9cad4f679"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DA3CC9172EEBE5",
       "checksum": "525a3ab948836ae04a9af680a754c4a05222fd6beb145e08f8a8e0b80089422b"
     }
   },
@@ -165,15 +201,19 @@
   },
   "0.16.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA1AF966A141",
       "checksum": "c8abe5afdba8fc206dcd1d18a6b3ba68378e07172ecbfe66576672d247eeb794"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA1B03A9E6B7",
       "checksum": "247eebba6e55efc629dab78cb9322505201288b23905a858e9791e576ade483f"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA1AFF137F82",
       "checksum": "f6c1c4a3e6d25b9d42e5c19055cfb26351ae732a65aa23dfedbbff32028aa3cd"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8D9BA1AFD92486D",
       "checksum": "64c62fb185036e3838426b9271f36f283e77a2fc60d1c08583113977f29d4f0f"
     }
   }

--- a/manifests/cargo-binstall.json
+++ b/manifests/cargo-binstall.json
@@ -26,21 +26,27 @@
   },
   "1.7.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC9117B0D35BB5",
       "checksum": "08b6969c86471ecd1b9b6fbbd6508014d22dadda29fdd47ffb871d297ac49a8b"
     },
     "x86_64_macos": {
+      "etag": "0x8DC911760808EC8",
       "checksum": "7fa85fd3fda3c9e4962f16f8b9400e97ff2773e0481fc63a9cb882fe80115b7f"
     },
     "x86_64_windows": {
+      "etag": "0x8DC9118FAF6A549",
       "checksum": "ee4da8bfaf25c84f0b67d5fd8e96f1243df4379f8dad64ffe2f82416198b7b35"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC9117827C4F23",
       "checksum": "4342cfa8dc1033d2942270e8c4f7a63ef6953632ec3dbfacd7bebd4894e2ece8"
     },
     "aarch64_macos": {
+      "etag": "0x8DC9117A4F64EA0",
       "checksum": "68157004ca95c2c3d4fae16246751317d2d6be32911cbdb04a06580d0c3aa43e"
     },
     "aarch64_windows": {
+      "etag": "0x8DC9118BFC4D5AC",
       "checksum": "baf1c6d5729b629015e199e7739a4f76bd40d9c4a90883ecb1d2c33c16240190"
     }
   }

--- a/manifests/cargo-careful.json
+++ b/manifests/cargo-careful.json
@@ -20,34 +20,43 @@
   },
   "0.4.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC77FF17EF35B7",
       "checksum": "ee14c5796acab604714e358de11bf5204055410ae8fd4891df7f5d62461402c3"
     },
     "x86_64_macos": {
+      "etag": "0x8DC77FF17F769E4",
       "checksum": "480efaf0a577161332b27ea13c8703ead1b6355b5c6541f5bd61d440440b4bde"
     },
     "x86_64_windows": {
+      "etag": "0x8DC77FF17F3EB5D",
       "checksum": "ac374b7799a37e3ef21c6bfe409583c3acbc57242fbb32e8534269b5e97b8ee9"
     }
   },
   "0.4.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC0FA12501A132",
       "checksum": "ea403df41ca913e536f97b8a039343173abae399436570a16d271908af989808"
     },
     "x86_64_macos": {
+      "etag": "0x8DC0FA124F8F869",
       "checksum": "ccbee4b5a0f5bf235c038b89d6046c08b2bff405ffa7289f4194f5402ea96c15"
     },
     "x86_64_windows": {
+      "etag": "0x8DC0FA124FEBE49",
       "checksum": "655ac5c504b2f54f11807edc6d9a19cea668bfb119ea086c5848504f7d09071c"
     }
   },
   "0.4.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBBB2F3DD23635",
       "checksum": "54cd7e1972e9faf085e3d0798c02054d064bc72de051a2636ece6f5b0ce0176d"
     },
     "x86_64_macos": {
+      "etag": "0x8DBBB2F3D8053BA",
       "checksum": "70d92ad8adf84192caa2066ba981780df926c8aa6cbd398fe489f87af336fe61"
     },
     "x86_64_windows": {
+      "etag": "0x8DBBB2F40025764",
       "checksum": "01ebcae79d9ba0cbb56e5c6bb5757d9cd074a3635704d15b0ef62a000c5d03a8"
     }
   },
@@ -56,23 +65,29 @@
   },
   "0.3.4": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB4E18D54BDD62",
       "checksum": "a9cfc7775546bd646a9e9252527c5caa56c429d854c6d8664ab4d63ed87827bd"
     },
     "x86_64_macos": {
+      "etag": "0x8DB4E18D554FADC",
       "checksum": "b29d263648fc287250a413ebf53ddb37310564ac44bfd71c5a35ca8eaddac22f"
     },
     "x86_64_windows": {
+      "etag": "0x8DB4E18D5625959",
       "checksum": "50cebcb95cda4fa3b4d5010ed6252be92de2748d3f5c00aff3bc6fe5f39c0906"
     }
   },
   "0.3.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB44A8B737767B",
       "checksum": "bb2b06f4df62110c8ae89a006b548a10a4da36d0f8f3ff67f7417fb51ed96b0a"
     },
     "x86_64_macos": {
+      "etag": "0x8DB44A8B749B17A",
       "checksum": "c396bae85ad4b414976ea6943bdb6fb666e56735ad51255ab615399e40641fec"
     },
     "x86_64_windows": {
+      "etag": "0x8DB44A8B7333585",
       "checksum": "87b35993b38fc60c069c45d58e79bae6c8f5253ce2459dff6a6b0b629c7aeb4c"
     }
   }

--- a/manifests/cargo-cyclonedx.json
+++ b/manifests/cargo-cyclonedx.json
@@ -20,12 +20,15 @@
   },
   "0.5.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DC3A43C920B085",
       "checksum": "7daa885e9b6f59bf7674a2972bf1f37d9e21ab7461c3e2f9c59e99a966ab6026"
     },
     "x86_64_macos": {
+      "etag": "0x8DC3A43C9165BEA",
       "checksum": "70b197f8095fe2473baef1d96dd4409abb1aef20aeeea00f8a0cbebc25528ddb"
     },
     "x86_64_windows": {
+      "etag": "0x8DC3A43C95B54A5",
       "checksum": "11e063c29bdd85ceb061b30aa11073238a8c93302b1ff3f5ac37e91ac90b425a"
     }
   }

--- a/manifests/cargo-deny.json
+++ b/manifests/cargo-deny.json
@@ -31,357 +31,459 @@
   },
   "0.14.24": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC7BCEAA2314E6",
       "checksum": "df57dd1ccbc44c4445cb72974562ed934637d982fb0f6d62105dddc290beaaad"
     },
     "x86_64_macos": {
+      "etag": "0x8DC7BCE8DDB24EF",
       "checksum": "47b7b07fb210b871027adb3a08fe85fa1a54e4403b523feaa844f3db029e96c8"
     },
     "x86_64_windows": {
+      "etag": "0x8DC7BCF17247F5E",
       "checksum": "35e6709107c13d35b9c2a9ee6d9db4cdf52f008e84334597e796305b95a72bdd"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC7BCEAC5336AE",
       "checksum": "8b1142bc6b7968169781a0ce01c74dc553468d968eda931c0a9e7420ae82e20d"
     },
     "aarch64_macos": {
+      "etag": "0x8DC7BCE9C737BF3",
       "checksum": "636f9e6e509bc43fab9ab6c2f2470dc027d05badce47b075bd27d9b05ffb162f"
     }
   },
   "0.14.23": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC6B7FD1E1354A",
       "checksum": "05d6cb0cd61350d3227e1f0af9252fce7a66f6b109a8850bb0af83507892c4da"
     },
     "x86_64_macos": {
+      "etag": "0x8DC6B7FD128A063",
       "checksum": "d8d3e97d95521dcc2e95a4293b3e774aeee5591cad9994ad49b5d177ca98bf8e"
     },
     "x86_64_windows": {
+      "etag": "0x8DC6B8049FC4064",
       "checksum": "5da19ca3efc6d207d075fdc29e22dc74bcb5476ec33eabfba9d788fc23513858"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC6B7FDCC64A43",
       "checksum": "027f050ba79720645e1c7c8239ee0c8896485c961152b8d025756be88266b302"
     },
     "aarch64_macos": {
+      "etag": "0x8DC6B7FCCFC071B",
       "checksum": "95562322593b203ffdf4d209a3781069c268fd6a4b3267b0a6b67919ff672225"
     }
   },
   "0.14.22": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC636A73A3998F",
       "checksum": "e35f4fec1016106a3acee949a9eedc70f5aeca1d85a911db6d43f071797a85ce"
     },
     "x86_64_macos": {
+      "etag": "0x8DC636A52DD80FD",
       "checksum": "2a753c46a9848229c7fb63be6b00f50a76b132f9a051df7bbcb4717604b8842e"
     },
     "x86_64_windows": {
+      "etag": "0x8DC636AF558F249",
       "checksum": "0a82e22cdc054e0d5da72d6961bf12b3e6f1cd812f993ea219eb75244422e038"
     },
     "aarch64_macos": {
+      "etag": "0x8DC636A52774336",
       "checksum": "b569c772ed3146e8a8019ef0b03d6ea191af0e2a51b62274018906b5e9eb48fb"
     }
   },
   "0.14.21": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC5ADB53A25DBE",
       "checksum": "a44734086a42d7b93715da545c2423684718d89d4855cd776384444a366813fd"
     },
     "x86_64_macos": {
+      "etag": "0x8DC5ADB3D0E38DC",
       "checksum": "9bf07f9348aee79a0ed18caa399e12eb91f5397333b5b46ecd8f966bc1c657d5"
     },
     "x86_64_windows": {
+      "etag": "0x8DC5ADBB6FA3920",
       "checksum": "231f24cfa8ef1e517b3dea37d90a5d8c4ad297276d4133852c1b2a8d084a1720"
     },
     "aarch64_macos": {
+      "etag": "0x8DC5ADB408C950E",
       "checksum": "60cd49d30f5fbe63d7d20c4c2d90253f932cb4e9f9468d20a7bf152da959c3e4"
     }
   },
   "0.14.20": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC4B3779EB2519",
       "checksum": "1c9f8cfc23647346f1aa7ba0ed3167191f3198aba3dc5a957fda6f85a82fc424"
     },
     "x86_64_macos": {
+      "etag": "0x8DC4B37631EAC09",
       "checksum": "4e3cdb8237fd1287aa101d8c4f66acbe201e7c71fa6068646b8effee703bf8e5"
     },
     "x86_64_windows": {
+      "etag": "0x8DC4B37D631AF19",
       "checksum": "89f0296f5340141d11fef72a5a129be4abf0bab98660c91572116fc16b43762b"
     },
     "aarch64_macos": {
+      "etag": "0x8DC4B37629BB76D",
       "checksum": "dee26e05bcca6ab27d8b00b167425fab26638eb59efb785cdfe0b57d84a06234"
     }
   },
   "0.14.19": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC49D602618967",
       "checksum": "dfb7893226470ab5bd7f6c7b91b40c461ff5736e9ac504f233102a66ab1fa934"
     },
     "x86_64_macos": {
+      "etag": "0x8DC49D5F1F4D6DE",
       "checksum": "f93fe56901820f9077a53d69047486e693d21c392692e9d9a60fdbc6d641761d"
     },
     "x86_64_windows": {
+      "etag": "0x8DC49D6634347EB",
       "checksum": "2755ba2fa41079f51ce0bcf984c4a440c9e0ecf88b7df6a36aeb02b0a8449bd8"
     },
     "aarch64_macos": {
+      "etag": "0x8DC49D5F86A3013",
       "checksum": "fb172c520aa24de1a4b9ee3aa68231d7a635f9ac7795c1f4c3602feeab6ed5d0"
     }
   },
   "0.14.18": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC499ACD27FFF2",
       "checksum": "b2edd818de5169128e23480bfece4c70ae9d4402e5a1748ae548fc29347b82b3"
     },
     "x86_64_macos": {
+      "etag": "0x8DC499AD6FC1A70",
       "checksum": "3aee99abb5761866b1e83e790394a024dc78bffb6987263b428082102d069eec"
     },
     "x86_64_windows": {
+      "etag": "0x8DC499B30E4C8BE",
       "checksum": "fdf5e89d7438d02434fc9d700bd547cdfa2401ccbe3a808ff24f1565686d1432"
     },
     "aarch64_macos": {
+      "etag": "0x8DC499ABAC22ADC",
       "checksum": "010b9143d9347218a9a88bdd5b0616349191f015ce9b125f6ac1018bd96944c2"
     }
   },
   "0.14.17": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC466D346D582E",
       "checksum": "d678a3d16a42795264882f90a09bf603c7403395b20254ab2dfd9c5e256d439f"
     },
     "x86_64_macos": {
+      "etag": "0x8DC466D252D72FE",
       "checksum": "4295788546977b45b67044ae8f7cc857a3e6674ea2b2d73afb467f2824fea288"
     },
     "x86_64_windows": {
+      "etag": "0x8DC466DC29170AB",
       "checksum": "f755e9915167f943ca7b4e008412e2ee32a265d2f5f1f4951815ac58da81fbda"
     },
     "aarch64_macos": {
+      "etag": "0x8DC466D433428BC",
       "checksum": "e25d594a60820e52132cf9c8ae172821c97c1e889cfe0dfbde51946dad53a350"
     }
   },
   "0.14.16": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC3DC6F99D560C",
       "checksum": "7b09aafdc42eeae5d67e523469a69e5b5dc65edb87d87fa68b3c014c9a27d780"
     },
     "x86_64_macos": {
+      "etag": "0x8DC3DC6F60F2F22",
       "checksum": "fa2efa5be935d684ba62c64950041eda7ed81af6b49608c6c8bad3c6f140eb2d"
     },
     "x86_64_windows": {
+      "etag": "0x8DC3DC783AE3D65",
       "checksum": "7d977cb7f37064bda9711adb5d6574f07634aa50b3eaf612ab134b07727e2e6d"
     },
     "aarch64_macos": {
+      "etag": "0x8DC3DC705C73D04",
       "checksum": "285cf6fb30341652e07135fd2fdb083455211527985c8cb2f889804a4068cd3e"
     }
   },
   "0.14.15": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC38398EB6C999",
       "checksum": "701e4c44a141896a0004bc1ab4e8d5ee4f0f7c7a2de33c40bdf85e89be46b016"
     },
     "x86_64_macos": {
+      "etag": "0x8DC3839A231E30B",
       "checksum": "7afb5672ad70c6a6926991824eac208990c4ca954bda0a813422aeab48aa488e"
     },
     "x86_64_windows": {
+      "etag": "0x8DC383A2884192E",
       "checksum": "5470fba9a52f51a065944973902156b70dfd50bd0faffe6b3ed41429afd2ffcb"
     },
     "aarch64_macos": {
+      "etag": "0x8DC38397E99D6E4",
       "checksum": "ce1ad18a668f7329d35840de296e41a20c0153043ff26cccd0376ebce5323236"
     }
   },
   "0.14.14": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC36BF86CBCBE5",
       "checksum": "fdd45d15a514a953b6f5dbbc16187fee3786ebe61f8da95728aec65e63a622a6"
     },
     "x86_64_macos": {
+      "etag": "0x8DC36BF86F0B678",
       "checksum": "b665b02f3fc99391d88464937713182e5781da8bd0e56a80cea425a1856d4688"
     },
     "x86_64_windows": {
+      "etag": "0x8DC36C01944A9E1",
       "checksum": "358dffea748f829f3eec3f5b3ac9fabd44638f1efe10dd399ef4b66e9b1f8bb3"
     },
     "aarch64_macos": {
+      "etag": "0x8DC36BF73E0EC82",
       "checksum": "a799cb6ac6c469b8cc4ffd16214d5970557af481c1818712d6c4130db35feb24"
     }
   },
   "0.14.13": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC3536F44AFE33",
       "checksum": "d87515bea48fc7a6f7b23fdc7c9a85c5428b9d31666e110852216f6ec2c4596b"
     },
     "x86_64_macos": {
+      "etag": "0x8DC3536DD6765D9",
       "checksum": "ff8f75ad330f82f58670ea7de1d49f657ad82b5e54f57c31584e37764fe232c7"
     },
     "x86_64_windows": {
+      "etag": "0x8DC353785241D49",
       "checksum": "6ef0f6b3d1b31c26affea703ebe3578e1206dbd1b02672d1f4ffb0f541faad0e"
     },
     "aarch64_macos": {
+      "etag": "0x8DC3536D8BC151D",
       "checksum": "a511e16cbee10e22fa2826586194572707c077ff9e3240dd1822443d86892c00"
     }
   },
   "0.14.12": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC34815E053D81",
       "checksum": "946986e05b1f031043ef104cf719006d1b1a1b9fdf16487f88d1a20a83d13903"
     },
     "x86_64_macos": {
+      "etag": "0x8DC3481F7F9AD9C",
       "checksum": "e80c0499a802c20476ce2908b8e020bc39b562010be08e558e1a2e0f800dd501"
     },
     "x86_64_windows": {
+      "etag": "0x8DC3481FA7E94C0",
       "checksum": "f67455423ef56bc936e3526d8a35b62102c353be2fdb91d49d55ee4517ee3cd6"
     },
     "aarch64_macos": {
+      "etag": "0x8DC3481DF74EE04",
       "checksum": "8bd1cca96a45a01da2db45cca12636c749b78c327c5a04b9d576e4c39d36e88a"
     }
   },
   "0.14.11": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC2621539EA8CD",
       "checksum": "081c69a65d59d6b1a033f051f9a8f0fdd824f6ca69d77ee8c575747ca6fd7fc7"
     },
     "x86_64_macos": {
+      "etag": "0x8DC2621D991DCE6",
       "checksum": "68662d271818b20fa33debfd5e8654ec06cbcc9ab33453983cacaca60aba1c87"
     },
     "x86_64_windows": {
+      "etag": "0x8DC2621FF0F178A",
       "checksum": "c3677a78efdbbbecabb16e6c70925f224891ff4cf79368ecf6310db45705c22c"
     },
     "aarch64_macos": {
+      "etag": "0x8DC2621E477B7DC",
       "checksum": "c266875533d3d92647a2f1ffda5f6a04c911dd9092025a556bf217b2e3d90bdc"
     }
   },
   "0.14.10": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC1CF853B3930C",
       "checksum": "c1a7965beda028ed2e74393eda64b735680b626826d68099d615a1f76d045948"
     },
     "x86_64_macos": {
+      "etag": "0x8DC1CF8EC0056E9",
       "checksum": "174ba853832b126cd653659e32d7b532f403d337c2a844072ba70c36f94c9d26"
     },
     "x86_64_windows": {
+      "etag": "0x8DC1CF8E42F3F93",
       "checksum": "3d5363734549f9f5cb4334120262356fc14f4ce11a3db10bc3bd6b8ed3ed851a"
     },
     "aarch64_macos": {
+      "etag": "0x8DC1CF8D4E9BCCB",
       "checksum": "40dfb728e059dd4e0acd96bd87aff0670fd45e02197fd072b9de2f72f573513b"
     }
   },
   "0.14.9": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC1CB2B8A1CCB3",
       "checksum": "39c05967ad5e15f1dcc5b0add184d5fa05de717daaf7cc7dfe222f92021c5364"
     },
     "x86_64_macos": {
+      "etag": "0x8DC1CB3313730CE",
       "checksum": "ccaf3dc020d0b30b4b85f11631f8a5184b1a4f9912ed0e14174f73f4e06ee4e3"
     },
     "x86_64_windows": {
+      "etag": "0x8DC1CB35D7CE280",
       "checksum": "30f58453447249c994c8943204616ea58b8fad5654718dddd6a12ec8cb004956"
     },
     "aarch64_macos": {
+      "etag": "0x8DC1CB33DF2C96D",
       "checksum": "8d2c0c305502158be6351561c6d358a97f7c273a7898e2a5c5690910a823f467"
     }
   },
   "0.14.8": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC1B696E1B5752",
       "checksum": "d6544fc7f3fd3aad1a3e40cb2ddc725266a11a9005d011000b9eda566669446f"
     },
     "x86_64_macos": {
+      "etag": "0x8DC1B69DBBAA06E",
       "checksum": "6c18e6e3f369e42596ac0a6e9db83b3b40538d9eff9ede7b9fd0070bf2393708"
     },
     "x86_64_windows": {
+      "etag": "0x8DC1B69FA9A1C0C",
       "checksum": "ebc5aeef9c4856f726cf5c59c8dfd1d7f3f57244119ddd6a7ba1dfdf6dda4c3b"
     },
     "aarch64_macos": {
+      "etag": "0x8DC1B6A07C72FEE",
       "checksum": "802189bf886d8e4ab08ed500563958b3f22ede51478b921c3f6896822711e7af"
     }
   },
   "0.14.7": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC1B374962BDF2",
       "checksum": "407cf9f3aa2b873aa10a3a2d2c53d575acd5c78b36ead5b1169cbb30d2da9829"
     },
     "x86_64_macos": {
+      "etag": "0x8DC1B37DCC4D6AD",
       "checksum": "6fb7dab8b5b40109bdd85e18a7b42cf7e8d70f22344f02d6c45a56c4a15262c9"
     },
     "x86_64_windows": {
+      "etag": "0x8DC1B37F05EC039",
       "checksum": "72da40f3ab0be6d47c44459a1f9f1755559cbdbcfa683a6a25d1cc19ef332b0c"
     },
     "aarch64_macos": {
+      "etag": "0x8DC1B37D6AF3454",
       "checksum": "6bc68a67cc0ba1ae7f4ffa674d28ad4c94563b98e231075f9c098403b07a60a9"
     }
   },
   "0.14.6": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC1A997E7D9E2B",
       "checksum": "a08f5999dc54ee35d7f279e40827fd80d4b2a08ebe724ec757cb3a73fddb5599"
     },
     "x86_64_macos": {
+      "etag": "0x8DC1A99F68CBDDE",
       "checksum": "59e801455777b0b7f65a0884acd81a18e39b84658dc15c14f6984561aa48c0fe"
     },
     "x86_64_windows": {
+      "etag": "0x8DC1A99F862C88A",
       "checksum": "b3375f982b4b4e757feae2017cd60aa811a1714d4c16c64ff24a1cfbba74c6c3"
     },
     "aarch64_macos": {
+      "etag": "0x8DC1A99FF03E2AA",
       "checksum": "bdee5ab684097d32439fdd6df430124aaa736e3e3eaa7a6e546954b448735c1a"
     }
   },
   "0.14.5": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC1982EA55900D",
       "checksum": "f76ea3b2c9e35059596a5c785b5552928499c1bc8db954fa23466062376b79ba"
     },
     "x86_64_macos": {
+      "etag": "0x8DC19835EF59C42",
       "checksum": "98c8505bafa938af6c8365318c224faa75393efc2479ce64271377a0a7ebcef4"
     },
     "x86_64_windows": {
+      "etag": "0x8DC1983731CF4D5",
       "checksum": "ca60bdba711e369073cd099847beb8e6bdf2e3e05c4086fed1b187347d8c598b"
     },
     "aarch64_macos": {
+      "etag": "0x8DC1983643729DA",
       "checksum": "bc0d018514cb6a969ac159106d24a28d1c374f9e6339eb9cae1bec890e7f97fe"
     }
   },
   "0.14.4": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC1934E5D17D48",
       "checksum": "b6ba5fceca5c4b42e0d6b31875fdd27a3b0c4aee58efc05f0c4d984a15ac2a36"
     },
     "x86_64_macos": {
+      "etag": "0x8DC19356C731766",
       "checksum": "ad3d91f1bee0e07a43bb40896706554e9135ed11d0ee77cd924afb3c8ff8cb27"
     },
     "x86_64_windows": {
+      "etag": "0x8DC193589279EDB",
       "checksum": "e31ecc6e4fcd5500a60e06e25bee9c023d5ef8b68ea8dbf6fd808872726a1d29"
     },
     "aarch64_macos": {
+      "etag": "0x8DC19359825BB6A",
       "checksum": "8f40a62ef604707c0c5e448beee5f32588efdc2ab027229da76e170e977ca922"
     }
   },
   "0.14.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBC0F3DFE7C142",
       "checksum": "7a8b4ccaa6cadda7feea6c125a08f4b63f644fc4e42b09f0e4cdffc42f33f1c3"
     },
     "x86_64_macos": {
+      "etag": "0x8DBC0F406701344",
       "checksum": "68543cdbb1b33cc42ca744e7914d33bde7eb117a26645e09ef3959992396a4c1"
     },
     "x86_64_windows": {
+      "etag": "0x8DBC0F4C78FE727",
       "checksum": "92c27d586f1929598e3adc09f8737011b0072817bc18e64c6d612627805aa93a"
     },
     "aarch64_macos": {
+      "etag": "0x8DBC0F3E2B56CF1",
       "checksum": "1890410b05c898233cc0025109d383dad412efe2d80ab05f7476e0db5fe721de"
     }
   },
   "0.14.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBAD2DB098B97C",
       "checksum": "5a4913ae3ce1298bd96d29b794ed245b0394f5ec0e2802f19d41fedc70bb5c3c"
     },
     "x86_64_macos": {
+      "etag": "0x8DBAD2E0FEE27CE",
       "checksum": "89c80839cfbb87bb8b0e4a1d55d638b79d0d9cac8fa53c0cbbe8fe271c8abcf4"
     },
     "x86_64_windows": {
+      "etag": "0x8DBAD2EB3AD7B6D",
       "checksum": "25e59c4916a4e28d507185c6783051d0e0824d6e5af5737560be7bcfb1fc7af3"
     },
     "aarch64_macos": {
+      "etag": "0x8DBAD2E5393ED2E",
       "checksum": "c1af65dac2330777744513430200d52cb615de9bef2fdb88cfec1a2e9f87c5f9"
     }
   },
   "0.14.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB936FF08EB5C2",
       "checksum": "913928cabbf80d2a237de6ffe47bdcba49434f8f08f9680f8a3a27b4ebc30832"
     },
     "x86_64_macos": {
+      "etag": "0x8DB936FFB9DE047",
       "checksum": "ea59c1045d05f0afe9d53cb5677cbbedd858e02132fc4414f92a5f81e943a5dc"
     },
     "x86_64_windows": {
+      "etag": "0x8DB9370606DC16B",
       "checksum": "15e59617863b89040b52d67b79eaaa137fe7fe73eacab2ef01aef1cdb45195f9"
     },
     "aarch64_macos": {
+      "etag": "0x8DB93700BF82951",
       "checksum": "f1651d37cb991c96cd9cc96c00cee2ddb470e7dd490a83896664ce50b2238e59"
     }
   },
   "0.14.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB8F8D09B5C413",
       "checksum": "85dee04c86104c84f83b344f29ba3f9e0b57b64da011c478e1e4a677cd59baa0"
     },
     "x86_64_macos": {
+      "etag": "0x8DB8F8D3CAAA065",
       "checksum": "3d03a6a5764b81bd3e4f00bc70974f48bf44fe8346788397ff1a680d7304e755"
     },
     "x86_64_windows": {
+      "etag": "0x8DB8F8D9962A23B",
       "checksum": "4956fe0a296cee572b878512953f562bd5afdd568efe76131d8ecf72b1740cc3"
     },
     "aarch64_macos": {
+      "etag": "0x8DB8F8D55DEDE8F",
       "checksum": "2fc95e449d086694aa76c1306e9e5a1762491f99d14a1d46a6b524bed20a94b7"
     }
   },
@@ -390,141 +492,181 @@
   },
   "0.13.9": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB3B6147DFFEFB",
       "checksum": "77f6b3feab12afc82638cd4c6197c983d249d1afa4180a6b9c933efbf8bff427"
     },
     "x86_64_macos": {
+      "etag": "0x8DB3B61BF9BE978",
       "checksum": "7b790f7e15dc6bb79dc0a737310f62fc7a4653749e40ec4fa7419ee627a014ed"
     },
     "x86_64_windows": {
+      "etag": "0x8DB3B61F4A2FF01",
       "checksum": "6f6a69d1dbabf98a1d826dd2dbc0bbfd378336ec891b3e7fd8c570744ea6efa3"
     },
     "aarch64_macos": {
+      "etag": "0x8DB3B617EFE241E",
       "checksum": "7d4cc49030262296c96076519deefc740e70fbc338ccd9179d4bc9d3be373512"
     }
   },
   "0.13.8": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB368D41DDE346",
       "checksum": "95b2b7eacc1e93b918969e8d9f25dad49ce079511401308b548f5fceeafeb896"
     },
     "x86_64_macos": {
+      "etag": "0x8DB368DE1221DC9",
       "checksum": "950f36ddbb08c0686305f97196b450a99efd3bbea3553746b4f1b9942a5ab2b7"
     },
     "x86_64_windows": {
+      "etag": "0x8DB368DAB991CD0",
       "checksum": "5cae60df4ab5a9c949a59f56cf101562b7a962fb2750b5e6aeb47e0d8799e962"
     },
     "aarch64_macos": {
+      "etag": "0x8DB368D9C184EB1",
       "checksum": "6eeedd852be234c5b27359e7ce6c7da665511afb5d643c7ce8db660e08ca7bc1"
     }
   },
   "0.13.7": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAF3E4E82E21E3",
       "checksum": "0e20f4302c1054a3f1a8e0e22eb15cfa3173c0e2dcbb62cfe7d6fe40dc27abd9"
     },
     "x86_64_macos": {
+      "etag": "0x8DAF3E55A7AF537",
       "checksum": "b0c1ed8ac67b1c12060b46d190a52f3aaa182a430968ce25addff1556e1bd391"
     },
     "x86_64_windows": {
+      "etag": "0x8DAF3E4FBD9FE8B",
       "checksum": "fbe4e7b01b69fcbf7ab82b61a8ff8545dbd9f2cccfadc6b6c7c0e0d38b28f26b"
     },
     "aarch64_macos": {
+      "etag": "0x8DAF3E53A8049F4",
       "checksum": "ab2400539b4eb2d6756a2cdb841f6e3b5862f54d6212d0c015509f6c72718e4c"
     }
   },
   "0.13.6": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAF3C333834B6A",
       "checksum": "400142c52fa30b5718bd260c27937c66709bc3d1d7dcf152131e00c625be67ce"
     },
     "x86_64_macos": {
+      "etag": "0x8DAF3C48074F115",
       "checksum": "cc93c0fe0c76352d7e5b4e972963c9104108c646bafc2fd04ceb8cbd6fae31d7"
     },
     "x86_64_windows": {
+      "etag": "0x8DAF3C35BE4FAA5",
       "checksum": "d957cd4af23a34cc0a4ce49bda8c7657eac1b2124b1fbbb196f91cbbcb430252"
     },
     "aarch64_macos": {
+      "etag": "0x8DAF3C39E02FAAC",
       "checksum": "3401ee901e8817e52088de2ad4afdf061b445fd95fd0a2ef81eeddac9244ceb8"
     }
   },
   "0.13.5": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAC1B537D9D3F4",
       "checksum": "339014366d1ea1137fe425b35b7c0fb3b3c8a54f9bfb2b470f52cbb1a7904e17"
     },
     "x86_64_macos": {
+      "etag": "0x8DAC1B676942359",
       "checksum": "b4377c2464d10a9c5b6edc90db53b29f1e0854e9e9a5df4058328d72de1f9d9c"
     },
     "x86_64_windows": {
+      "etag": "0x8DAC1B5E33E2628",
       "checksum": "28b7821cfeba8dcdb7f7e5eba9a1246afeed5d27fe143c7bf863eb01e76c1fd0"
     },
     "aarch64_macos": {
+      "etag": "0x8DAC1B5CC22E29E",
       "checksum": "02808cb1d7bc99b2e868583f5e2d9073fa1c8fb1110a24f7c1476d09e7b2983b"
     }
   },
   "0.13.4": {
     "x86_64_linux_musl": {
+      "etag": "0x8DABDA419883674",
       "checksum": "85a1a30f9d337bff504b6530c2328e01a96484d48494c9dec8352516229bfd1d"
     },
     "x86_64_macos": {
+      "etag": "0x8DABDA4E085CF7B",
       "checksum": "8106e9ad601dcfc3a0cc790955a8d9b24b684c2f09fac293af7b469d7f24643b"
     },
     "x86_64_windows": {
+      "etag": "0x8DABDA4A984D283",
       "checksum": "7c2a63f74bd7905c8e3ad75293c94fbc2c3560f46a7617627a256560c821af07"
     },
     "aarch64_macos": {
+      "etag": "0x8DABDA4ADF51A9C",
       "checksum": "2cb301c52c0a592b4039fb0e7d723c7ac9ae4eb6740d425666b08be6773ea6c1"
     }
   },
   "0.13.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8DABCE856F7FD00",
       "checksum": "54988b975f7b914e6178031fa55ebb59dc1f25008c7b3ddebc4494456d538f18"
     },
     "x86_64_macos": {
+      "etag": "0x8DABCE8F964F76C",
       "checksum": "38a9e6340971cdddb756c5cce4045c4def8ddf47f72d32426d384a8fa12022be"
     },
     "x86_64_windows": {
+      "etag": "0x8DABCE8F7674F32",
       "checksum": "78216dc4655b06f84bd9782340cf3971034009af798bffaa38efe58fb7ff714b"
     },
     "aarch64_macos": {
+      "etag": "0x8DABCE9BDE175A1",
       "checksum": "5ca6961a5c4ca7afab70e238fbb885e44d6bca3fc6c51200d76ee42bdd84c2a9"
     }
   },
   "0.13.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DABC1C0A1EF240",
       "checksum": "cbdd95a6d5b2e308d0189210e02152153bf2181b045c73058e4db842ae02162d"
     },
     "x86_64_macos": {
+      "etag": "0x8DABC1CD36F9B54",
       "checksum": "bf0a2cd106c9b916300cf894819147c29cb4609d4ea7b890821ba4b85fd1feeb"
     },
     "x86_64_windows": {
+      "etag": "0x8DABC1C6CA57A95",
       "checksum": "4d91451522fe35b60c13fe450c03307d8ff19701d546a1bf24af84d0e9a62fbe"
     },
     "aarch64_macos": {
+      "etag": "0x8DABC1D7E8D18AF",
       "checksum": "3a2fb492233066a48a144acb02d7afca890a81b0517c9f426a35c46194f0d639"
     }
   },
   "0.13.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAB8E3AD5AA208",
       "checksum": "55fd1cea05b91f53e373352f168d8bd4ed8523bde70aa5e60a039c589e491eac"
     },
     "x86_64_macos": {
+      "etag": "0x8DAB8E4F37C1263",
       "checksum": "7eff3b88990bab708fa29a6d0f993f2ffff4847c3c3cf5e9cec5442952511443"
     },
     "x86_64_windows": {
+      "etag": "0x8DAB8E437BDC799",
       "checksum": "9b6747af4f11f061974c75bbb7e9e19c599515d919cab8f12e1c6187afa96176"
     },
     "aarch64_macos": {
+      "etag": "0x8DAB8E4997F759F",
       "checksum": "7a8edef71593e0548802813c25a6b5b2eda0dc88cf1076b2ef4e54835d28866e"
     }
   },
   "0.13.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAB757CEF5FCA6",
       "checksum": "bb9139a7c9d01bd5de3c389563edc20bf562decdb54dd1bf57e5370a25400938"
     },
     "x86_64_macos": {
+      "etag": "0x8DAB7580A6FA4E9",
       "checksum": "4c945a5306af1957382287b1040f78d7f4e0fc093da3f2ce4b5f3bca162055c7"
     },
     "x86_64_windows": {
+      "etag": "0x8DAB757E5C3B569",
       "checksum": "7cd22fee03fce4237a8a4017bfedae9730339a4090caffd27585eb79e1adaf81"
     },
     "aarch64_macos": {
+      "etag": "0x8DAB7580C46B7EE",
       "checksum": "78d6e0e009c22497cf67d14cd5380c942abca36cbddabf31ba8176792d29c55f"
     }
   },
@@ -533,43 +675,55 @@
   },
   "0.12.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA76B803A3189A",
       "checksum": "2f5d9da751bfe291495e51937c74473850e101c26e52c3ab667b0d1a5d5e8d65"
     },
     "x86_64_macos": {
+      "etag": "0x8DA76B857A04455",
       "checksum": "f00f50ea60650c700c0d0c43ec4e1bd400ab40453c7dc0ce0b4b69fb6299e04e"
     },
     "x86_64_windows": {
+      "etag": "0x8DA76B899BE62EF",
       "checksum": "4c295c3c3fe15b56ff30aa6f6fe692636496b0b036ccc0c3fd4a82123e2263dc"
     },
     "aarch64_macos": {
+      "etag": "0x8DA76B84BCF905C",
       "checksum": "b0974bb392de4bd7e6cd73c7a00bda290903e934f15610ca6ad42e09772feea5"
     }
   },
   "0.12.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA3965EA0FC0A9",
       "checksum": "fd6b38cf813bd112916f01e7b13169a03c29b46fe044e9360f84c0adbc301bed"
     },
     "x86_64_macos": {
+      "etag": "0x8DA396613AC22A1",
       "checksum": "93084e74c656ee21911772e89c4606432b9a8a478af07ea0964efff63af09bae"
     },
     "x86_64_windows": {
+      "etag": "0x8DA39663172A0E0",
       "checksum": "a178d5f1afff6553fd2f7854398776338b8fe3cee282d3fb24dd3b9f1c05b3b6"
     },
     "aarch64_macos": {
+      "etag": "0x8DA396615D54256",
       "checksum": "5b58c9190345370ffa76240b38519fe9b04d1cd786e9796d933cb05e2cee7b06"
     }
   },
   "0.12.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA383B29396236",
       "checksum": "38eb55610be0408996e2f36b24aadaaa0ec8fc27ddbeab137774dc3c78d42267"
     },
     "x86_64_macos": {
+      "etag": "0x8DA383B1FA3CA1F",
       "checksum": "60e2b82d03f2441972909c52eaa3ca81a71648cac0efb69d89a67319f0dee941"
     },
     "x86_64_windows": {
+      "etag": "0x8DA383B9FA12909",
       "checksum": "039cd24a5fd076b12e69b25c7660e6c72948d25c2f2dfbb6fc4b9b02ea0163cf"
     },
     "aarch64_macos": {
+      "etag": "0x8DA383B213F63F5",
       "checksum": "ad420b10561780c50adff854baf70dd5ff6f6ac5f4e64c748c6a6dab8757ed1f"
     }
   },
@@ -578,71 +732,91 @@
   },
   "0.11.4": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA1BAC1820F6FD",
       "checksum": "868d7b4ff4e0aa900896626fddc5dbbb0df84c5a61beb1a3e1dd5b8457d3b413"
     },
     "x86_64_macos": {
+      "etag": "0x8DA1BAC54361AA5",
       "checksum": "0fa26ab298ce5b0001a3c471ac364711012141064bba8f3e672f342d0608d4a3"
     },
     "x86_64_windows": {
+      "etag": "0x8DA1BACBA65C925",
       "checksum": "5549b40f18c849c668edd20da94390b0fa1ca931047bf2674771e6e81e4c0363"
     },
     "aarch64_macos": {
+      "etag": "0x8DA1BAC5AE8820F",
       "checksum": "3fef8dfefc6a5f737865a1562459f05279ea17711f7d795cc47bdf617a1700d1"
     }
   },
   "0.11.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9EFC0FB1E1BA7",
       "checksum": "ffed77d73b5f76b6a7b200a939b6215bde55b0e59ab3294ad8518ddb01c49f09"
     },
     "x86_64_macos": {
+      "etag": "0x8D9EFC164372393",
       "checksum": "2cda272063d9d9d89c3f32c4adb2446603ddaf82b79b6057e31869333dad2a57"
     },
     "x86_64_windows": {
+      "etag": "0x8D9EFC1C8186EFA",
       "checksum": "8f01377a42966f8d79696e01eb839516d10af56fff96188c47b093723246291d"
     },
     "aarch64_macos": {
+      "etag": "0x8D9EFC1447A5FDB",
       "checksum": "fd5da73cad2fa01b3e65aaa24d3f0f349f73dee90992eda39f941d217ed14b60"
     }
   },
   "0.11.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9EA35EFABAC87",
       "checksum": "125b7df67dd25a4a3d9c012c036030d62d022a0b73a83b79c3f6fdc0d464288c"
     },
     "x86_64_macos": {
+      "etag": "0x8D9EA36340CC74D",
       "checksum": "755a823a6948a2fe52ca6e29179b05689408a1bab741ddf93d302dec3fdbc90e"
     },
     "x86_64_windows": {
+      "etag": "0x8D9EA36A01C438F",
       "checksum": "7db640d5930a4432243f578af8cf19d4056a9c26545f347a3b6c0eff5c2a2fcc"
     },
     "aarch64_macos": {
+      "etag": "0x8D9EA3633594906",
       "checksum": "e0d9ef27d8f92bd2c867ac36ce7a55b8c819b15d43f5e765222f123caa275c84"
     }
   },
   "0.11.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9E24290D8F70E",
       "checksum": "caefe6e981ebe842af69a0338a3e1fe80bc3bb0be6199720a039429477778f70"
     },
     "x86_64_macos": {
+      "etag": "0x8D9E242F2E2395F",
       "checksum": "68ee2c1759b24ea8f502b528021fe88927684f25cac933a0906758e9c8477578"
     },
     "x86_64_windows": {
+      "etag": "0x8D9E242A5EC24A2",
       "checksum": "271cd14ade4d6844dd2317be8c03a57fecf156a18e3e3c32fa2c83caceed3695"
     },
     "aarch64_macos": {
+      "etag": "0x8D9E2430079D82A",
       "checksum": "9e84d252cdce7a1f5be5d5031e6460cc0d2289b4d6e8b2936ea112245b8abcb0"
     }
   },
   "0.11.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B93B90B3A632",
       "checksum": "bdac664b436fd8501b3bea5461bbf8566086ab0cf5555d83178c3209a848f9f8"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B93B8AF27E22",
       "checksum": "6ee76892b7b709bcb3af35332cccc8ef1e03ec0e557b4a14648605e324876798"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B93B80EECDDC",
       "checksum": "e1425ebd75f1817630f08f25e028fede2f063e2fbfcaa63f14bca979d42be71d"
     },
     "aarch64_macos": {
+      "etag": "0x8D9B93B950B12F1",
       "checksum": "eaa092483cdff965750009c1dca3fccdd53fd57adee38630a5b56f463bb167df"
     }
   },
@@ -651,57 +825,73 @@
   },
   "0.10.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B93B87743A92",
       "checksum": "ac31f6dc5d8379568b047ed7718bf283db76e5895283c534f1ab348533c4f0c9"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B93B872FC18B",
       "checksum": "88b77bdce26ed199fd69570bdc8eb28749e50bf8c826730b93436418b9312a22"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B93B7FAC6AEA",
       "checksum": "b04c24051cf662cb206ac2012bd959049acda26d1bbcb3e5e17d46ae019d966a"
     },
     "aarch64_macos": {
+      "etag": "0x8D9B93B90F671CE",
       "checksum": "98cc91984193e21c856067342dd8209bf00ff21a559735c0766bf46f69e7717f"
     }
   },
   "0.10.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B93B9A7463E1",
       "checksum": "9c27bb092ad67c7ca86c8585801e9fe48f2b273d5730b9f1188d3720aa4e4642"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B93B83324E7B",
       "checksum": "519e315a651e768f3b0236169bd27871932225366da43665f4fca8e6d9590994"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B93B83CA8095",
       "checksum": "5b16a6e7abcbac1a8fa35692f1f975603095fe3c06193844a424852d5787bfa9"
     },
     "aarch64_macos": {
+      "etag": "0x8D9B93B90F64ABA",
       "checksum": "d431998154bd78d3b8f7f399e76e5eaadbd8f90a7ef6ff97cfdf05190368f3c6"
     }
   },
   "0.10.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B93B8A7C750A",
       "checksum": "66d60ca20e0bcfcfcb55ac157853f92526c268445f5f673c2aa2345a8e09ece4"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B93B7F2F36EE",
       "checksum": "7dc1814ab9d364142e894632f9fbac17a99a3230adcee5ab440938f92e283aa4"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B93B99F7A503",
       "checksum": "6f24517c534d9d97448870100bad56378465e8db3dc0279a9cd407aebe2fccda"
     },
     "aarch64_macos": {
+      "etag": "0x8D9B93B81B053D7",
       "checksum": "e3d91f86d662d50569e5610e41569c0136c1405d9fcfe7e0a046df98255330c9"
     }
   },
   "0.10.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B93B8FB372AF",
       "checksum": "77d50bea7f20961dccb7133e61a3e2d75411870c1c377f56f6b01f6e9e1139ef"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B93B8FD65EE6",
       "checksum": "0c18c3f64ea1f5c805ad07b6c11664f294227620c4962c219dd998e4290a5b71"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B93B8031B407",
       "checksum": "9ed8c0be0fb103bdf2f57db24958aa50ecd08e046247ad608878d96e40c1ad6f"
     },
     "aarch64_macos": {
+      "etag": "0x8D9B93B7E76D75B",
       "checksum": "88f43fd6d154a80bb5d0aab79e1065651e40da771a97f994d5e416cd15404971"
     }
   },
@@ -710,26 +900,33 @@
   },
   "0.9.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B93B908D8628",
       "checksum": "a2dc10ca868120f67b232d6687c60dda50f285508886b0aff26a80e9cfab524e"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B93B972DC9FD",
       "checksum": "ff3e855e9099f5ce70a343f0c9ccdab8b41f9620edb3a55d754d794520fff23a"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B93B8E262F18",
       "checksum": "84ea63f40471b66003b6832c32f6fd3a0a5bcc860c3a37493c28cae64a8c2640"
     },
     "aarch64_macos": {
+      "etag": "0x8D9B93B81BD714A",
       "checksum": "f42231700f083d0d4418e54ad07b4ec0da87c309901665d6e45df0f5148c5829"
     }
   },
   "0.9.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B93B8EEC2139",
       "checksum": "f52840198cdc9d62875f475ecfdf92feba94de12442c71f77c3a9d5681bf269d"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B93B8C277586",
       "checksum": "a10bbe9199058a729ef35d13b817ed1d139dea405e6c5e79e2a274ce5b94e83a"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B93B90BE5301",
       "checksum": "a42135c2750567643d4f6bb1faf0c9f636c4c9cf330904a89d581facac258cf3"
     }
   },
@@ -738,100 +935,127 @@
   },
   "0.8.9": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B93B8EA66FD7",
       "checksum": "d618d65652765872e8a4448f16e706fafeb47e9fc021dc059eed52a0f5aba6f4"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B93B943DA7E9",
       "checksum": "f803487f0036f0635cf82f148812274b3b2c6e5453e85ed00e96f4e225e64c68"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B93B83FEF666",
       "checksum": "11acdd040c5661b4153f6829effc342fe521fb706e187a4609fca379e7cc01af"
     }
   },
   "0.8.8": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B93B8CF6B51D",
       "checksum": "1b3a2c8caabfc60c59f2e93361574dd583374ff73bf9b866d5680156c2cb3783"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B93B9088CBEC",
       "checksum": "cdad0ee3d4f8863ffd33a10dd8604fc8e75cb4fe9c6580b4d90084a2e4f6843c"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B93B83A941CE",
       "checksum": "8ce8cc4f57a3d063d5b228c3a0dc1e432cfd1ab55f3727a161abfbf97c0105f3"
     }
   },
   "0.8.7": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B93B918CF67C",
       "checksum": "38186e163b1428aa2bd6c2a2000de280f5f401d653a461f278b2856ac86340a1"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B93B961AFB9C",
       "checksum": "f6d51e1f7758ed4900432d7f6d017f42413b295c40a4446bb7276c925f9813ef"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B93B7E13B73B",
       "checksum": "bab4522de64477890bb8576503a928964c989fb6e3477d9f10c6be2b317c4640"
     }
   },
   "0.8.5": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B93B92AA4A94",
       "checksum": "87f4f80d313ce5115862ca4f73cdefad085df71d99522a3d4a6de6dd3d4f787d"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B93B8F695533",
       "checksum": "38d2a17fd79c726176e4d1c6f7aac24708069f1e0f50006f9cd65c0f0825589e"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B93B8E3D8436",
       "checksum": "7298962557aef5bcd4d762b03f240581f6cfff192adfe8ee03b75126d2fa9968"
     }
   },
   "0.8.4": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B93B9A3E67A2",
       "checksum": "aa1cab0ab3687b05dd76fa003e0134171704b0019626ef6d70f1c0dbd5524be1"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B93B8951DC67",
       "checksum": "6eb103e722951aeabc097f48e2ee2a43b2f2d615e8f80b00ed499e2059a1e110"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B93B948D69DD",
       "checksum": "aba979a426b088f193e3e5ecf81c1a2d449a1079faeb6347e8b47815ce4bbbe4"
     }
   },
   "0.8.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B93B88D80351",
       "checksum": "a0a54ae2a7003565de31fd1d434ef969f05f36e51975275430feda88612158c3"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B93B8E1D08AB",
       "checksum": "3a55abf1e84c10538600d3abbde7f5d0732392cf981cd0449bfad7eddd500a9d"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B93B94E6C76A",
       "checksum": "4b15d9069754a2da37a73e0688b824ce80a31fe53ac00491f4027a5489ddbef7"
     }
   },
   "0.8.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B93B8E3FCDD0",
       "checksum": "8258c8bc6d6a1b9e45daab7edb4ec2f876c201e2f5263f09f0f6d81a0de98fa8"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B93B97EDA282",
       "checksum": "e58716496d6b48e2abab0bf841cf3c4d30c98ec61d61e7b9fcdcad08ae9b0307"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B93B982C9E1B",
       "checksum": "d3b273ba80ae8eb9224357c180278c11c7b3a88f489633f8699c95f4eead1f42"
     }
   },
   "0.8.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B93B8D4B3168",
       "checksum": "f4e17311f684d8908460c3267afae40156b3c76e0acf54416b21915a7431eb8a"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B93B96D72B24",
       "checksum": "9bdbd45724b622bddac6502440154fe0e86317f7ab63f3da94a645f792782a8d"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B93B89E2958A",
       "checksum": "8c31138c1c1ae82cd3607211e8b89b619b832eebf6e64e995ab7d8f2bf583ee9"
     }
   },
   "0.8.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B93B806A20E3",
       "checksum": "82865e614a278b17cde1e171ce03bb2e97f4039b0f3098c9daa4d303dc738dcb"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B93B938DD283",
       "checksum": "cdb30f4bc0466f3686b8c44130757dade347f99790a4f3c756862e1731f34670"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B93B7E591A87",
       "checksum": "27479a63ff7733a818c3fcc6a86fc988a9406031baff14689ab3b4f19e5d8052"
     }
   },
@@ -840,45 +1064,57 @@
   },
   "0.7.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B93B82209163",
       "checksum": "5456fed7c90f8658c085fac6a602f495fbb6107b62c9f8f54e90cad4ea33a61b"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B93B859BA116",
       "checksum": "bc4eb7caf1e86b0fc77372d07b3f3b214f322c497865b3cff3ab97f9f851be70"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B93B7E69E0F2",
       "checksum": "fca4a6a66342d763e4efd2c2c0e8e16f5c48b907abe2318ac58cf8082d5cc7c7"
     }
   },
   "0.7.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B93B86BEE7D9",
       "checksum": "0a3c009e0e6776da40ad0bbf362ed08d048e21e6275b04bc8163f5cbc5b6f3c9"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B93B8EDCBA2E",
       "checksum": "a9a5c19497113db9fbe7fd3cbc23e0c8e7d4edc826f1bcf03dd7e47bdef43295"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B93B8DBEC9D6",
       "checksum": "169b44a1bf06508cf07bffdde278eed0deea253e97496ab0ae5d5b98ac0cf4bc"
     }
   },
   "0.7.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B93B91B427C6",
       "checksum": "a1a6e388f101fc1063e2b70bcf631f7d3e736a46bbdf58a1078a847504d2e484"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B93B87FABC03",
       "checksum": "ea680649a7a791215390f1a0f97b62fa45b37e9de0222993c469f8489236d46b"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B93B83FE5A38",
       "checksum": "36904d9325f86c3edab0979bee37aa0ad340cb1c0d94397aeb150485e0139069"
     }
   },
   "0.7.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B93B9154628C",
       "checksum": "5c9a61652c167ab41f1ef137450dfa2d690c110b1d464be145b50849ed43ae4a"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B93B81ACD1DF",
       "checksum": "3ffb94e8a7930a85a433e1b92569eeff5afaba15fe33a6d62cbdc445bbfbd23d"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B93B8C5B4F3F",
       "checksum": "28fc82549fdd75d8e58e058e51be997e5457a8bca0df0d638e0030e8d1cadb32"
     }
   },
@@ -887,97 +1123,123 @@
   },
   "0.6.8": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B93B8220DF7B",
       "checksum": "c68bc8346f0da424beff7c49f63b3383a2828c5fbe6c4be72a34e7a8c4eeb69e"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B93B9662816F",
       "checksum": "914b2b8b92f74c63a8c97a9f4b5ac6c54c8b8a15e2fbbaf1dc432aef00702927"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B93B7DEC5EE5",
       "checksum": "18738e285b2fcb89ffc186e3728479438a44bd9ba0d8e976872c9ad4b7b25b0d"
     }
   },
   "0.6.7": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B93B8EFA76F9",
       "checksum": "09ca45edf08d2973f11a82ee646c6a06043a573a7b3b790ee3d810776c58d694"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B93B95E12F5E",
       "checksum": "367011af5880a1715f27f593bc253ef633466d5c05212ee1c1e5a9fa0422ab35"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B93B95357822",
       "checksum": "0d251e5fe92815221812929620b5a1bcb33d0b6cbbf6cba453e1086b92074814"
     }
   },
   "0.6.6": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B93B94F8ED2B",
       "checksum": "41e2e71b7b07cd68e1275d694b1646c0c2873e40f4f809f29d88467b6a1e3c21"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B93B8F5903E7",
       "checksum": "1ad690986bb122e43aff02e8987c88747f7136a58e99d7f409ca67f20eaedabb"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B93B93F3FF6E",
       "checksum": "c3567a3edfbdb5d44c1b61b7c97867e5abdd1e2060692926309f8fe58adef29b"
     }
   },
   "0.6.5": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B93B8BCFEC7E",
       "checksum": "c4f49b651d45f83e38b335941a204ddcae6506efef392820352f85cf989b517e"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B93B7FB3BCDA",
       "checksum": "28518733770d178a43638038f66266dfb5ccb3c190483bda06e4e4b099d1b89e"
     }
   },
   "0.6.4": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B93B929A2062",
       "checksum": "6ca1e7630895506785a6a454d054a18b2183b4b101f67e6fd4f069bc78d2ae79"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B93B8F7A90B8",
       "checksum": "474d12af81adf618de406f3c55c263fd696ef129c222939057dc4e56c99163e1"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B93B902166AE",
       "checksum": "20491cdfa9d9706b99e729e38d86bf952e27f707069dfdb6586c45254002b114"
     }
   },
   "0.6.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B93B91E0616A",
       "checksum": "75f18d80816403b5cd011886f98af1ae5bea43b1a3143e1ffdc4ef7ddfdaa568"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B93B80BFFC81",
       "checksum": "509e111d0e0cef9c6c79c845eceda63788d0eb5337e79091c2e704cda2ec7048"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B93B89FC825D",
       "checksum": "4c52ca00625ed9ca8161bcd7430214c650a43706e44d994ed40b458a6b82be62"
     }
   },
   "0.6.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B93B8B5D1736",
       "checksum": "6d83095e51090b204c8ebbc270621c97614c49d1042289d418421ec586ef3114"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B93B98BEDD9C",
       "checksum": "c09e284797955227a4126f32fa086a49fa4b7d5599ed1560560e58ae8b45cf35"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B93B900CA932",
       "checksum": "43d785a8501a49f8bc2311beb100539bf5d9acccf51d4bf8ec037294b6fa5d5e"
     }
   },
   "0.6.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B93B8A5C6EA1",
       "checksum": "3c60ca31578f980d13993183772f352491eba3b7b959fc26d31a1f817879a990"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B93B954A0E88",
       "checksum": "a5a863dea6e47fc35bc0cb371b813f7d949aa639945e5adfdedde9d17c5ba9c9"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B93B7E2CE0E2",
       "checksum": "d7f5eb6ab38a8ca41671cb4fa2e27f0a9183aaa2d72a4b2b1d3211db10547109"
     }
   },
   "0.6.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B93B94195C46",
       "checksum": "4712c9edc0a69a63a219ebeb43a4f5514239840202160f59d8445fa8f5e77683"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B93B96E5F608",
       "checksum": "f7089898781ed81dcebea500038e824cda399b4ba70cebf639365a0b7ee1a4f7"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B93B90832772",
       "checksum": "86aaf4a1141ec05e9072a7df5659f4b5aa53db92c8dc76b7c359ade929e4424d"
     }
   },
@@ -986,34 +1248,43 @@
   },
   "0.5.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B93B93449F3B",
       "checksum": "70f02a7e56c0a7c0e0602ee1b0914af94737e9abc140173dbea3124849682b60"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B93B8D6E92BB",
       "checksum": "259570c8fae47b3a241c85502a90d7043fac969fd4e29a274706433c9e0a811e"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B93B8FDC518B",
       "checksum": "c7849be7b8f6ff16b219599a2c8f59db7f3c56dcfe157b7de5c43c486a945586"
     }
   },
   "0.5.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B93B99C614F1",
       "checksum": "cd8a96b562fff40d787db6da0e3c7adc70e2af720b985ec16187b02e9de96340"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B93B94E3457B",
       "checksum": "84a615520235fff6bb062fdc2360ef4acf811fb706213b9788ded004faabb26d"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B93B7EC0F4DD",
       "checksum": "09000b9b41b51ea42530a8dceec88339f50e41bb8d10677980d39b800f3acda1"
     }
   },
   "0.5.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B93B958C16F3",
       "checksum": "4534b0b542994e940e0725bb28a43e4c3a3502b3b0df9056dc654532e3fdbcbe"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B93B8D11DA48",
       "checksum": "b6c7d980192a31788d1ce43873e56b38b581952e6db2e79ad4fd21c148514583"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B93B95134F21",
       "checksum": "2caed9bd0b75423ccfd55dc7bb75b5f72eebb2330f8dfc80a43aa42a4fcb5673"
     }
   },
@@ -1022,34 +1293,43 @@
   },
   "0.4.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B93B84671ED7",
       "checksum": "400edab6e6f66927c8f929dcab3e48a7f3017ceaeba7aee12c992ad33b84bdce"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B93B886CA704",
       "checksum": "130adcf1d9d34cc5dc9ba569628d8c86eaf467d8c77eb85b5c714902e01663d8"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B93B8A262451",
       "checksum": "2a06c56e4e9ddf137bd7c0f142c1ddaa6a31bd84c58245de2d4a3719bb78f7ba"
     }
   },
   "0.4.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B93B80277C60",
       "checksum": "edced8daedf5169ceb8ad39aa1752e738eaf7f285c88cc8807a21324f52f431c"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B93B973DA623",
       "checksum": "69a4775dd7bbeef22c2e0faef8e109f65674f0079e0845e0fa9fc32c88113180"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B93B860E765E",
       "checksum": "f1e7d0caecff784a5d9e0a84ce5e4600b1adf8b6cda9bef88810adca127e119d"
     }
   },
   "0.4.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B93B87AC0B48",
       "checksum": "c747832e99506a8dc02bb7f7ce8a00c51e9d4aa8a93087bedecc444cc5a5c8ec"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B93B95727835",
       "checksum": "d829d6cf730c7c7733563c5b7f7ef61bed7025aebb20903d979f5bd47d84cbc3"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B93B95BBF98C",
       "checksum": "dad6664979eb92bcf271e99a8d33f8fe68abf83efd2b816c8c09c165ddf6fe32"
     }
   },
@@ -1058,12 +1338,15 @@
   },
   "0.3.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B93B80097175",
       "checksum": "f0a6462663b1f92a87ecadcea96352c0aa01bcbd80e13ac3a3a1422f771d981e"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B93B8CD17F57",
       "checksum": "56e553a7efc443a13407af8893c8ea5ab10d47250104023d3baa89824223fb17"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B93B8507B421",
       "checksum": "e47b892cb0ee5d200229fcd070f58642e0baad9a81e15bfcef8f087138cf0e90"
     }
   },
@@ -1072,67 +1355,85 @@
   },
   "0.2.6": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B93B8998C61B",
       "checksum": "d4860faf38a5e47c3783c7e76deb5858e809b95de154df5ce057119bb0dd7622"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B93B7ED93447",
       "checksum": "fcd5ff24c967aedeff6ad10e86ae66ec777579c68337e5fd171019423b011805"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B93B8E92EAB5",
       "checksum": "9b75d18b8f7246928c0d33e16e580b28c29920bd0aab1dfddd5a23117a3b3e32"
     }
   },
   "0.2.5": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B93B7DF0CB12",
       "checksum": "6e0191cd70315532e87d8f326f0895521ab88b97613cbd97033385a87dd2c5c3"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B93B834FE447",
       "checksum": "4eba0fcad3403f8316c7a403e42c1405581ce8cbfa72c1f6163c0c6d4dad3b71"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B93B957536EF",
       "checksum": "98ae571a5d835eec2578a7e4bbc2aaf65cd17c6d36d3e95a0367ab2d06fbd1f3"
     }
   },
   "0.2.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B93B9787007B",
       "checksum": "cb3cf9056123bf93b1715d4c0d01d22b7cbe652204ef3e3a5e3bf24fd389c420"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B93B8ABF19A2",
       "checksum": "1044248f9d7c2b635dcb1a8cb1cc71c3f1435ebd5e9ab78e5e1c33b07e0a67d8"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B93B854AF4E4",
       "checksum": "a54069d0484509110ccfce440e776b305b2289ecae3bc8772a97ce1fa0c125b7"
     }
   },
   "0.2.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B93B8196B50D",
       "checksum": "f55ec16db6f5d41312d2352db6d6aaa43c47f24a37982c8adc52ad4997ede488"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B93B7D3AB517",
       "checksum": "008ea2694548ad0b0738ee6260aa903162a06b52edddfd3d2a98584bb26c28fd"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B93B98777ED4",
       "checksum": "0fd31f91b7248e3abccdd8b2e54455b84dd66f35089b2497e0c17ce1395832c1"
     }
   },
   "0.2.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B93B94829601",
       "checksum": "0003322bd2f1e33d8b9261ef21cf4947935d590aa1d8290a4cdec394e8c48d3a"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B93B91AC12A2",
       "checksum": "966fc19206dafe25e7b6c98e5dfb6927c36220072b733d673d2767879f1fbde8"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B93B85729B4E",
       "checksum": "115b72213ab0ddd7468711513902c08b5f3498b98a9fbd4a241a06c59515c232"
     }
   },
   "0.2.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B93B7DA96C44",
       "checksum": "63416d7e03d46f1062f48a57ebd73775863b42c8211360b0f70bb4bf8318d181"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B93B9805BAE0",
       "checksum": "16ec1ce92589770d29d97d8af90aa265b955d4bd5293b14b459cff0f2780099c"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B93B91F7DD95",
       "checksum": "45d22e26c56d426243cba34dd19929ccb69c5c707554b75762a122328aad9498"
     }
   }

--- a/manifests/cargo-dinghy.json
+++ b/manifests/cargo-dinghy.json
@@ -19,22 +19,27 @@
   },
   "0.7.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC8EE73CEDB06E",
       "checksum": "c4c4a912b358729f88ee26b10b8de36bab06d42742539bcc3e98d0533c5f4cec"
     },
     "x86_64_macos": {
+      "etag": "0x8DC8EE7531E6D99",
       "checksum": "0a4389eee9619a8afdde156eaefbae6652532549c348e1d37a1146ff3096a889"
     }
   },
   "0.7.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC5A333EC81D40",
       "checksum": "1985095f34f016900d237efc5479be3154f6fd2d168109a4c6d774d77e9eb21f"
     },
     "x86_64_macos": {
+      "etag": "0x8DC5A33D11B647E",
       "checksum": "30902c7a7834f773c56ac2bde6b58be983b13b3d4cd7077ec415ba4b06c4039b"
     }
   },
   "0.7.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC58AE78F23329",
       "checksum": "01ef6234425231a6e49b40fb0fc4df13095756a02aff61f6c3ee862cd57916e1"
     }
   },
@@ -43,73 +48,91 @@
   },
   "0.6.8": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBC0FFBC6CC1D3",
       "checksum": "732752302dbd31dda85c93fd639d72122d138e913e3e7163b57b739c32832dc5"
     },
     "x86_64_macos": {
+      "etag": "0x8DBC0FFC6BB2634",
       "checksum": "245d9ec0e0fe95f07c112375146edb6f559f7846f0b347f6632d49775e7b1fc3"
     }
   },
   "0.6.7": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBB529F1CCC2D8",
       "checksum": "d5c4b78a4e660184fd32f017efbee65015ec86c041623b320c23bb87764e37e2"
     },
     "x86_64_macos": {
+      "etag": "0x8DBB52A5991390B",
       "checksum": "ffa03e78bdc71efd53c1fcbd16d92be0a79c1092de03fd43320db2a3b3800950"
     }
   },
   "0.6.6": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBB52247FF2381",
       "checksum": "daffbfae6caf0e1c40b53cf33569074e4b1b80b8697e27f91eecd9a0a1f85809"
     },
     "x86_64_macos": {
+      "etag": "0x8DBB52262872AAE",
       "checksum": "ac0d058aab49ab751e072f1978972c22ffa195d68af43d04a9a801bffabbaa16"
     }
   },
   "0.6.5": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBB2B33CA7AA4F",
       "checksum": "250a165b843022ee5e1a356a791f832bf2051a11ba97a9de531060bb98f7bdc0"
     },
     "x86_64_macos": {
+      "etag": "0x8DBB2B39238E279",
       "checksum": "6074cd8dd9ddf553f6915a0dd2c183bf7dd233bfd78322b8db2b421fb1a89a81"
     }
   },
   "0.6.4": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB3C33E492AF7B",
       "checksum": "b1453cff8f0f65f09312e88306e64e4c55bba5fb6daec5d8df1ab0ca4acef97f"
     },
     "x86_64_macos": {
+      "etag": "0x8DB3C3427FCDA9F",
       "checksum": "4fd0f5cabbdeb6fe5728c54e888c3c6b3861d7cdb8e089caa5c1ea43f618e812"
     }
   },
   "0.6.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAC97B13BED3FB",
       "checksum": "4faa2b0ba479222284f90885f66d0afc97ecee4e2b234042912a451fbd7b8dc8"
     },
     "x86_64_macos": {
+      "etag": "0x8DAC97B419E111F",
       "checksum": "343d7e8de208a5ef2eca4b3db1653a626efa135643203a7813d0831a7eb6b7df"
     }
   },
   "0.6.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA79EC056C172F",
       "checksum": "b6cd5b91e61a14befa3260802bb387ef6b8deba78dad0fd8ab80d487319140e9"
     },
     "x86_64_macos": {
+      "etag": "0x8DA79EC2B347895",
       "checksum": "f6fd261b70844ca13dc69cdb2668e14691676e92188f82d4fcf1ade6900d6f90"
     }
   },
   "0.6.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA76292B2EC4A5",
       "checksum": "1016d349f40f54332ba7269926d4e1a56295bb54c27fc0ff5b137d68f6ffa6d4"
     },
     "x86_64_macos": {
+      "etag": "0x8DA7629B0B1C057",
       "checksum": "6b3fb17fd3117f728a41b34c1728bba35f85bbee6ad7e7402ae9ab5fefb2409f"
     }
   },
   "0.6.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA6FDBBF5F4316",
       "checksum": "3755cd6187bf8192f359809143c080618acf9777a0d7a3351ecde6f67a4cfc47"
     },
     "x86_64_macos": {
+      "etag": "0x8DA6FDBEFDF087B",
       "checksum": "907319443f0742c607773124209bf0f3c572a35b18819bfe126a487cbc1128c6"
     }
   },
@@ -118,17 +141,21 @@
   },
   "0.5.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA60C629D2CCBC",
       "checksum": "ded1f77c4514d763977eabe069fa62625745098715c54ad8427502557c412f05"
     },
     "x86_64_macos": {
+      "etag": "0x8DA60C649C9565B",
       "checksum": "ac105b5ef370a0920794c07af2b69fb33ea17e56ba55be2e189f080556f05112"
     }
   },
   "0.5.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA5F4E76EB5A8A",
       "checksum": "e1f65a240c6e3587cd661d3b004e5af3da9f2b9c4e44f465e87f3717371d05fa"
     },
     "x86_64_macos": {
+      "etag": "0x8DA5F4E8DF6A776",
       "checksum": "5bf0facc0d9864fd79026999ce8b9a8f3f56b40c15e0536aa98551d8750ad01a"
     }
   },
@@ -137,201 +164,251 @@
   },
   "0.4.71": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA0B1DAD035829",
       "checksum": "64115114488ffc8b7006d2f9f35d19baba6e3acd2292133aac2dd64d24e59d99"
     },
     "x86_64_macos": {
+      "etag": "0x8DA0B1E0B9C73E6",
       "checksum": "db8bec9f9ad41e166bc1e212d0b9bf732bd1b3a1c1e49f1862042aa2dfcfdf2f"
     }
   },
   "0.4.70": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA08B0D5378B68",
       "checksum": "880ea253cdf3b989e9b45dba36e66abf9fa358bd805cdfced57437099eb00d21"
     },
     "x86_64_macos": {
+      "etag": "0x8DA08B13CB30C9D",
       "checksum": "a0a42c3f5825be8116978083428283e92143f320c80a11a6f5133e559642984c"
     }
   },
   "0.4.69": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA07E32C2133EC",
       "checksum": "b42985472ff399a6e00e1590cbc6dbe576b6a1c23bf36e9369898ba7152c72ff"
     },
     "x86_64_macos": {
+      "etag": "0x8DA07E3F606BC4B",
       "checksum": "aff25a81d3e99a0ba677a56f16860f915749fb0fa5a3ef10bb381b9a84d1e78f"
     }
   },
   "0.4.68": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9DB6A3EFCA76D",
       "checksum": "8b17bbe806b459ac7f2692d1df9bdec5fabdc46513cb45f620b0a4124d0c8bdb"
     },
     "x86_64_macos": {
+      "etag": "0x8D9DB6B89B32B35",
       "checksum": "5883927469c45ac952a0785aea9a625dc3d158f0d03ee23e0ae7525659041453"
     }
   },
   "0.4.67": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA147C71E8B9",
       "checksum": "e4175dbcb96abacdceee60055495e315bd065cbf66a3741ef7294f1d9b944448"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA14713EE32E",
       "checksum": "2a4e0f23799335f3bcc04f5177772b3ae8178f69a1d20b1ea9a1e0a2af5d649e"
     }
   },
   "0.4.66": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA147D40DA68",
       "checksum": "10664353ce1ed10cefdf766bd9acbb9c357497011d11f281ba1d3ec24eb8a7f7"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA147C834B54",
       "checksum": "f76bd70d0f82bf31e61118eaaa5fb4912540276050f7a59d056b365614f65e5e"
     }
   },
   "0.4.63": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA146F70F620",
       "checksum": "bbd791675e71e5ba4165d0fbde08c1572fa3771f12169b29831ff43b212578b2"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA1464A75169",
       "checksum": "3b4533a3e3020836abd864ddd52aa219b2eec2081a6aa376c78ce6ba37707421"
     }
   },
   "0.4.62": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA14617AF1C8",
       "checksum": "2da0eb7a004344a845010ecbe10a92b1ea1576ea0c98cd57836fc0ce4855b675"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA1473FBA155",
       "checksum": "980a8a88b5f3e950d9af8aa6a2ce6e4dfe391fcc345a082b124db2f09af85dbc"
     }
   },
   "0.4.61": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA1478E79844",
       "checksum": "8d1db2698c9684b000e1e0df4675a5db28228c97c6b8a15240c4498af4575005"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA14770CDBCF",
       "checksum": "04fde09f40e409a6a33943bbdeb2e7a37703b6b554fa9ffe3b3d8c02139400ce"
     }
   },
   "0.4.60": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA147116C791",
       "checksum": "9881f4de90449c9251dbb9eeab85b7d73fb3c52219e0c044aa38afa6da7c0c86"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA1473542F1A",
       "checksum": "feb68d4168542f09f4672241f41edc1dd1dfff10bb7376b393f7fc42ecb60a14"
     }
   },
   "0.4.59": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA146B98B810",
       "checksum": "3d406ad00263c207ef339f570f8b2dc4a70bb040b11f81cbc4f61b8fa485d63a"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA1477587FCF",
       "checksum": "19e9981cfa7d4564161990eb3d45855feb4caade42100f7681e5151aa177a2c5"
     }
   },
   "0.4.57": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA14632333E3",
       "checksum": "a15252b2c0707c627a5b24ac3d21754046098ddbbc1b792fc981f844cbf74786"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA14713F0A3B",
       "checksum": "e1ba97310da861ef608fe2fcebb3251c2904bf4c5f059fd62a9654216ec75a31"
     }
   },
   "0.4.55": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA147A74671C",
       "checksum": "a1eb166f015cb1a07e48e2bd44ec15bd370cf9f8a3d40d243f8ec35e71df983f"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA146779903F",
       "checksum": "cb63021c7f9f415513ee8a5589b59b54dd1bce0b55eb2728c677f2e552b4a115"
     }
   },
   "0.4.51": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA147CAAA3BD",
       "checksum": "314d220264417960539db8a9cb1e8b81d010acc64e1d3e8bfcd3415608cea857"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA1472350635",
       "checksum": "cc66108a0f2fb30a016c4400af5cb9e308b1c1217c696b3412dce4069722df78"
     }
   },
   "0.4.50": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA1463ECF631",
       "checksum": "6c885144ace5e9a064d5f201b8836418ce511266335eb56e72f6cfee3377abae"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA1475B63048",
       "checksum": "36606130a6c1a9aaa398063df59749961d0bea0973740a610e157154e459dfec"
     }
   },
   "0.4.48": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA14654464E8",
       "checksum": "a5ba0ff38a074edf9b16e1d10a550b567236953c11f2f92414b56877364bf02e"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA14805C258C",
       "checksum": "d892bcc9d5976f6e0eb7ec56ce06bbb10d777fce8f2b61a494544a99dc57a8e3"
     }
   },
   "0.4.47": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA147185F3F3",
       "checksum": "3a7bad503bd2af5884acba5fd1d36a053610e4ffbf2bd2f32def3a125a388c0b"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA1481D1782E",
       "checksum": "dabd2b1e836a3ed0493fe86a51dbd64edc53bd1fe12418f23ab1241a28a4d49f"
     }
   },
   "0.4.46": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA146D54F471",
       "checksum": "5bf5c74385f8f629fc22842db9f22a017ce1161ab18695d3b673bef0767908c3"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA1478FD6701",
       "checksum": "8c7c03acda02eeaac85c58d1bc2b4eaeadc86bd001a547bd83170e5a799de9e7"
     }
   },
   "0.4.41": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA1469361ABB",
       "checksum": "30c25753544b0d7ced2341ee01b732031739f1611ee9792a900544f2330c3af6"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA146C3C8159",
       "checksum": "fb0744858e9b62c3df157806490ccb7484391d1e22d965cb395943b5ad99d047"
     }
   },
   "0.4.40": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA1475045F52",
       "checksum": "5d0348b5b6361c2654543e4fdcb4adf3138c2acabb84a4b31c0b4296420ca1bc"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA1475BD0D1A",
       "checksum": "8ec452814f1660377e6c04ef7a896dcd036421ae60804f1a6d1a2a48c38abb0b"
     }
   },
   "0.4.39": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA14810AE9B9",
       "checksum": "4d6bdd598600ea70085fdedfd425faa6527e337819f23b998cc1deb5e01a6fd5"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA147F8F085E",
       "checksum": "c03237fdf92eff3a7b5ce678684cf0b3fed7b35c5c644c5dd56dba60083d36b1"
     }
   },
   "0.4.38": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA1471EBF9F1",
       "checksum": "4bd472b5e3718d08118f08bd2ac0fbd0ce28ddbf022314b66d2a9c61a7a55615"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA147A70E52B",
       "checksum": "a38ac1de5862efc36a772234c59f002894d2c6ec1924b11a36d0ecbba59a1411"
     }
   },
   "0.4.37": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA147EE65DC3",
       "checksum": "b22e585e24363971eb925c66cb9ff3ad97612aba7264d0a27eaad871f9f3b02a"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA146D1B4F39",
       "checksum": "fa3b17fdc8615feb0633c513bde8f8ada9bca21a5aaf6c32567c850a19f1a9d7"
     }
   },
   "0.4.35": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA1473EBEC35",
       "checksum": "8d10ff10fa6d4974c71fd0804d65901a88e17c472fded202c6215bc31cbb4eac"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA1466466D21",
       "checksum": "f086fd58fba784a26db8989f85ece81df6b2c0400c1b59129f5b81279c7e0a82"
     }
   },
   "0.4.34": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA147F87DD78",
       "checksum": "b7bd211f0f6c703b9d82e11c96e6679e21989523c85349f243f385159ff0af39"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA146660CF17",
       "checksum": "ffd0a1834eff980a10d2d983db167d67300a0634ef405fb6153f98072eae1bf4"
     }
   }

--- a/manifests/cargo-export.json
+++ b/manifests/cargo-export.json
@@ -27,37 +27,47 @@
   },
   "0.2.5": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC0213DA79077D",
       "checksum": "eda03e2665396f156f32facb1ebc37e92cef359fdff25e50b0393e4e81483d65"
     },
     "x86_64_macos": {
+      "etag": "0x8DC0213DF58E69F",
       "checksum": "ed10c42a43d5d576fe48ddaad6a3531f0f3e9c4229d7b8f802c5c381054986a5"
     },
     "x86_64_windows": {
+      "etag": "0x8DC0214035BB746",
       "checksum": "79eaee7a619772cfafbfdf4ce3df689fd3db628375ad1cd7f63bc47202a4f76f"
     },
     "aarch64_macos": {
+      "etag": "0x8DC0213E0613DE8",
       "checksum": "ed4b04d2efb4913d5e354cf0563916f83fdd71aaa751b3ecb0f2ee746929be94"
     }
   },
   "0.2.4": {
     "x86_64_macos": {
+      "etag": "0x8DC0207F88643EA",
       "checksum": "f0bdca8ae6b8d4168eb3e0852049c94f77baf22a78135391e8a968edab456d95"
     },
     "x86_64_windows": {
+      "etag": "0x8DC02080939C0A0",
       "checksum": "39264472a09f21d8452204d1d5a955c4b7ad8f59c68b226653cd621a7b689c36"
     },
     "aarch64_macos": {
+      "etag": "0x8DC0207F9917E29",
       "checksum": "801fbdbcce1ab7a7cce44a0bafe15c66f43751263ae9536668c5fce911cebed8"
     }
   },
   "0.2.3": {
     "x86_64_macos": {
+      "etag": "0x8DC01F90F5D33A4",
       "checksum": "cccbf3f1df341e7a62521141f295e857ad1fbe8b81406a1666affd1659fa2244"
     },
     "x86_64_windows": {
+      "etag": "0x8DC01F9196C8D4F",
       "checksum": "96baaa1564f4e89089e1f13cc33a68c401267e63917cb8ba43be93f323d71ca8"
     },
     "aarch64_macos": {
+      "etag": "0x8DC01F9111246A2",
       "checksum": "fca4aef395fe08ad313aa06cc6a14de11a6ae3432d78511a259ff2c7e3d81b8c"
     }
   }

--- a/manifests/cargo-hack.json
+++ b/manifests/cargo-hack.json
@@ -11,754 +11,928 @@
   "0.6.28": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.28/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DC5EEBED8FBC1D",
       "checksum": "ddc2c14d114c26e21d1cfb2703a736e6ad3d85acee77cdd2df0c701e3115d778"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.28/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DC5EEC3E74A4E5",
       "checksum": "d4ed122da3a1fd43c2ae97386d945e007e9793e1bc4833703827b59166d414ed"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.28/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DC5EEC0D487CBB",
       "checksum": "e4ee6550969fb4499f6df12f472ac68562668a9e02a5ba320d0abc44a1da66e3"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.28/cargo-hack-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DC5EEBEB31B955",
       "checksum": "f2b9f9e2fd587b8bc32c5db0bc18a6e40be6fe70c83d43c1f1a5fbc69a3237a8"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.28/cargo-hack-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DC5EEC2B2DF25A",
       "checksum": "309b23964961cb78ebb47344ede27d06a8c6c1b7b7acb051208769dda7e7661e"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.28/cargo-hack-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DC5EEBFC723429",
       "checksum": "d1c21607a2f052dd14bfefd29c382f196fde6dae120e73cfb0054a457223fdbd"
     }
   },
   "0.6.27": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.27/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DC5301E0457807",
       "checksum": "7713f063bdb52abf23e8a121664bba62144c54068e746a7c5904c9f396884db2"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.27/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DC530247B0EED0",
       "checksum": "75e807f5c763a3d7a44dab7e13158299f9b9adf14247e41ded97e45ca38b799d"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.27/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DC530220AD491D",
       "checksum": "695b1a6bc887e07a52710670bbb13237276f6898446bfe2104b38df690f2d556"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.27/cargo-hack-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DC5301DE923878",
       "checksum": "904aff3154e3a981e138935f44296c007e84f464cc3da1fc96ee0a11b0511631"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.27/cargo-hack-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DC530207094B51",
       "checksum": "3a52aaa620296e0213e7e3fdd95e70f2c5677882c74a6c0a0ac8b8bae604e65f"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.27/cargo-hack-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DC53020146275D",
       "checksum": "aedeb5aeb5bc7d01ce3f854dbd5bf6e5230c0c44ffd5d527a9ee85a60ccaafdf"
     }
   },
   "0.6.26": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.26/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DC5251975F51A2",
       "checksum": "722bc8269e30ff75cfa260a3ba3a94f46fd3ad8de47a158fa2bde1d07ba3eb53"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.26/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DC52521591590F",
       "checksum": "ea2b014cf60d6fcf3d85d277fe88a7f4ec1db7238077463f56f8093acaefccaf"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.26/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DC5251B7783355",
       "checksum": "9497dcecb1f09ca2f2f0a6a2c91a1152ba56c386981315461edeba4914da6433"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.26/cargo-hack-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DC52519EEF6241",
       "checksum": "77e63cf8c52718c12a0a46749464375c992ec2b7d524f8723a32623560612fce"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.26/cargo-hack-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DC52520A1BA079",
       "checksum": "8e896ca939c669d951acf98f2493f8a8b7a7beb3e808cb5af764c8f66a1c58e8"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.26/cargo-hack-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DC5251BA54C1E6",
       "checksum": "9084bad2063b00d96237582b8623c4e13ed476585aa8461defe751fc134c77ea"
     }
   },
   "0.6.25": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.25/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DC524FCCB048BD",
       "checksum": "e90bdb19108c308af9be1104d93209ce03aa6d91f5c54b5678682d970ba1660a"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.25/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DC5250452ADE16",
       "checksum": "59636ba9a2452ebf030c654718392c950f4d0478a87c5b70a2a0cb55b6d283b5"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.25/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DC524FDC2D3C72",
       "checksum": "001102a8b6965dad68be41db1058b7e7abad4d8e9dd375912ae43ccebca7696c"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.25/cargo-hack-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DC524FBD4ED463",
       "checksum": "1307ce8db78fdf7616fb025893348eaf7e9ed77a3a3fe3fd348076a41a18f570"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.25/cargo-hack-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DC5250450D8C0C",
       "checksum": "29488347b36ee0a2d48b2d32d7b5b24addcdb2f42a52784de41de6353c62fd43"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.25/cargo-hack-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DC524FD60B4C50",
       "checksum": "5f5bbe4a544e7b923365db6c3af05bdeed865952b6cc15c9ec30b7487b4cb52d"
     }
   },
   "0.6.24": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.24/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DC51E2FE61465C",
       "checksum": "82a4a2cc134b5712df98fe36bb3b66652094f7e7c815c3559fc249671c5f0eca"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.24/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DC51E368979052",
       "checksum": "9a95d8613269ff9543bdc1f5462518375aec4a3602c3283b3e6b1ff30c43fb2a"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.24/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DC51E3182F811D",
       "checksum": "12da431e0c2775bf7b187c26d14fb4e8af7d0e38887635bdbe5d458c131a7717"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.24/cargo-hack-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DC51E302BBE8F4",
       "checksum": "73e1e998a31a96ec692044f2fc7291d6a0f5e4259515b09f25541f1e497b12b8"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.24/cargo-hack-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DC51E322A2F662",
       "checksum": "e4fccd7a5eadc80c536dcfcadb608cbd0682bfd6ebe5dfe7580e781106213e54"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.24/cargo-hack-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DC51E3256563E6",
       "checksum": "dcaf75eb059939fa8c8f942bba25b706a991af249672d6155cbae8dd15b70bfe"
     }
   },
   "0.6.23": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.23/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DC4E59758F51B1",
       "checksum": "93769457e869d0bd5ae322666cc04f2515d558bc10c7d5da872eac6aaef25c43"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.23/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DC4E59F5DE2774",
       "checksum": "c47a23a2a4e71d0a6f74344a87a38872e0b6dbc68ee86cc6c5df4d872080ef09"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.23/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DC4E59E9B98EF5",
       "checksum": "90edc889f244a17bdc1a74944b751d2a9176ae86eb40917ccc0ca24fe69192b3"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.23/cargo-hack-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DC4E5968C0BB56",
       "checksum": "82ce9c3262e5c948555c3097562ffc6c16aa284d3aabf7d6b221fada37b25f9c"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.23/cargo-hack-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DC4E59BE00F6F9",
       "checksum": "54fdf9c43aaeb5b1d40154fddc84769a78c2c8854939cd5b174c9fe1eff4f5ec"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.23/cargo-hack-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DC4E597338E7E1",
       "checksum": "11e559db60945df66521b39f3168d0381ab97d5eeb0bc6b9acd16635b1ec342b"
     }
   },
   "0.6.22": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.22/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DC40C8A160BB28",
       "checksum": "25d19166c2e3be108d815bfb15624b2ff82909a0b92bfbf56f5c3e2e44db4eb6"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.22/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DC40C9799680B1",
       "checksum": "eff3116e6c9f0ac543d3ad02960a626f1e1a82aebb0d1d5377ed1cf3c923a746"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.22/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DC40C8CA74C8CD",
       "checksum": "d4d6482e55ca7c08cddde24eb9539c0642392eef3c79a3abde26bee9a0308735"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.22/cargo-hack-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DC40C8A83B8F19",
       "checksum": "5e025b0a806ee48440dbc858f9239e45dc823ea178a1c8953eb6b36209f212e2"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.22/cargo-hack-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DC40C8F033A7B3",
       "checksum": "e0a30429c822453c0557defcffc3bb33146bf211489e6848024f60023446e897"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.22/cargo-hack-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DC40C8B670ACDD",
       "checksum": "fdd599e2327e54422b7288bc5385e1e0353a60e48376107f9bc8e659b082abc2"
     }
   },
   "0.6.21": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.21/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DC3DFBBE8EC9A0",
       "checksum": "4d1cc13c72ac620df9265506ad8dd03f84117c8c653586be3d73590e013fe9a8"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.21/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DC3DFC76CA00CE",
       "checksum": "675e3a63d6e741a53363e71b29f7babd1f685cfa14168b8914116cdb176f38e0"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.21/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DC3DFBE0BEB690",
       "checksum": "f57ea407c7a2a11c6e31102087b8689c44ecdd8f8eb7c76fe98002cc7efd2f84"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.21/cargo-hack-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DC3DFBB092A772",
       "checksum": "52159eb4d6b03441d6a696dc52dd3c46ff06b4983df8524c5d908bcd53c9425d"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.21/cargo-hack-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DC3DFC1A0CA7F9",
       "checksum": "e37a2eaa79cb04d8868d8c23f45af296433d60b75181bed0be49650cfd7c0c6e"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.21/cargo-hack-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DC3DFBB8E94630",
       "checksum": "faa6323ebb18e54038b19c61d138793c9b1e31dd64e337cbc64cc283faa62a3c"
     }
   },
   "0.6.20": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.20/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DC32811BAA42AF",
       "checksum": "dc3a790ba52a824f3faeb45bf630b35ed4cfe2ef5de24e169bd1672c40ca0ad0"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.20/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DC32815493C274",
       "checksum": "c8a6bcf8f48761da905dbb476a2c276f1b3beb4e601d895734196a7f33cb20fc"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.20/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DC3281527CB356",
       "checksum": "c49e18fbf868c2abbd86ed5f17ff1254479c79ea788dc757edd69cdfe390cdc4"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.20/cargo-hack-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DC328100F4132B",
       "checksum": "3ac4d20c14d73c5ec87ac6132f3083f419340f4f124b31f55594a9d364f1eb11"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.20/cargo-hack-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DC32814F86C6B2",
       "checksum": "59ac8f0227168a05a758e6fcdaa7fb7b91bf9d206fcf19644f4a15b864842c13"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.20/cargo-hack-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DC3281210B1A87",
       "checksum": "113c67634a4d34ff8c15d28d241f611144c55cc57dd11f28aa0d336d548813a1"
     }
   },
   "0.6.19": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.19/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DC2F490DDB2C6A",
       "checksum": "c96cbde6b2eed3ba5c3a62911bd729362dad11ee2363cefb79e7d8b44c034b25"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.19/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DC2F492AF1643E",
       "checksum": "277fdb2c362fad398cc858581cf06b1d3706cbbf883005285f3794ba5aa2f1f1"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.19/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DC2F498AE3D810",
       "checksum": "d5c86549d83d7147e1fe7de468c375a0f28c5aa45c9f8a02b819d13ee9a85e37"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.19/cargo-hack-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DC2F490D340FAA",
       "checksum": "aa24c54f97b43685979ee15f2a03b0a249cc035449a3a1955e64c61e725a9e8c"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.19/cargo-hack-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DC2F492FD33D24",
       "checksum": "5d2e027a34ab26949534e5e9a764c49130515bb4eaff7e4b1e824ace6ba10617"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.19/cargo-hack-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DC2F495E409000",
       "checksum": "8e36f556db4aef01066fc26b1d10ad9440d78b5ce9c8ff4fe68c3ffbf84e7ada"
     }
   },
   "0.6.18": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.18/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DC2A44C272823B",
       "checksum": "6833fc01b5e4fd199055b31b2fc6ec83bfc19dc78d8548716ace6211f7fbb716"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.18/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DC2A4511C9A4D1",
       "checksum": "05e85f5cfda4e7497a86eddb5d08b6ac1c4253bad03e2a648b43275db9928113"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.18/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DC2A44E1882D3B",
       "checksum": "f165300d83f0bc3c069355d89b31494496eb3058184b83f9b99fddd5363424ea"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.18/cargo-hack-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DC2A44C330DCF9",
       "checksum": "de5e9045a5c3ba3f45cfb8f8fd74ed7c6397c4b3ac2f6a6d58687e5c6a5bf8c6"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.18/cargo-hack-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DC2A44DBD8089E",
       "checksum": "6a52f6213fb3b5222fee6c33571a50dc702cbb1ef28e1c0b8c6f18ae5dcda6a3"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.18/cargo-hack-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DC2A44EDD9B5D9",
       "checksum": "09b5273f9304fa3881a4b745174e54bed6c836345b2a782dedf7e3ba7d4805e1"
     }
   },
   "0.6.17": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.17/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DC24BA299A2F82",
       "checksum": "139e31f95ee122cc6937386758491d15668c3c4e54ef7de1055e3b1b0a53be8e"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.17/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DC24BA66B61AAF",
       "checksum": "57cfa14d6de673828c03df95adf8c25a23cd3ac4f586466e09661049175dad02"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.17/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DC24BA64712A16",
       "checksum": "c0c279c240359b18d05619d5ec1cb0bec0c834c3f1700d9676675977a33b183e"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.17/cargo-hack-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DC24BA2D02A88D",
       "checksum": "b9a6a1d12e2967885276be7a548bfd00508b12648a3f1cfae08b0516b917f417"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.17/cargo-hack-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DC24BA3F863F9A",
       "checksum": "e9fe200729ceab30c30ae45104356caf867821477669270d2499ab8ea54d5770"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.17/cargo-hack-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DC24BA747A2DE4",
       "checksum": "5deff267fa443016285ca9d8846b033af089f0a49f211eaa16bcdd9e5cb65395"
     }
   },
   "0.6.16": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.16/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DC1CEAB02612B0",
       "checksum": "d41485c9c9c83ce9bedb4200ad539a716ff4759da5d960b9a4372fa5d9e49957"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.16/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DC1CEB0A6693AD",
       "checksum": "41e19b4c8c2378673c7c2845fb8aaa43f9efa99e60de60c4349487d5c9ffa346"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.16/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DC1CEB2F6B10C4",
       "checksum": "0ed75e30ad5bf9e660667d04d6d80deefc1a303454da6af5e6bca61d98ca080e"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.16/cargo-hack-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DC1CEAB5F696AA",
       "checksum": "acc1b9d1c2f8a40d7326ad6b3f3d3a278a2f76e4213dda01f7b9b79dcc78ea12"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.16/cargo-hack-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DC1CEACBC4BFDF",
       "checksum": "ff4530c90b0173ade83a34f0426cc8c50d9315b81adaaa27f210a18312e4da1a"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.16/cargo-hack-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DC1CEB0E294BC6",
       "checksum": "3dfd112824f7c80b7e82a9d53dd1133ae502618012048acbb3399cb334f5c9d3"
     }
   },
   "0.6.15": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.15/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DBFE369A7B8BC7",
       "checksum": "1d012b9239b8aaf427f217fee25aa4d18525d0bc9061db37e636f03a1fd1fee7"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.15/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DBFE37631E57B9",
       "checksum": "b4b834bf4029640272e9476b97f12fc987c8066163757e5a3e45397a10133cbb"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.15/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DBFE36B5B7C3DB",
       "checksum": "3c008dff15f81bc99a58c1b3bd436c5421cecf8260840c3865c7b705e484d48a"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.15/cargo-hack-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DBFE368174512C",
       "checksum": "71aed71dbb3260b379d4857aa6b879e6b9953d3b19c6994b42a6df6eaa3cc2c3"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.15/cargo-hack-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DBFE373C9E87F2",
       "checksum": "b9095579a25142170de956e48efa984186332ec9d957b8a6f9858eabecb444b3"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.15/cargo-hack-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DBFE369CF9C31C",
       "checksum": "d46438ac02e154c9de8ec2dc5537951ef1c1c1dfb99c4f52dee3c7f2eca2e034"
     }
   },
   "0.6.14": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.14/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DBF597DFDB326B",
       "checksum": "d07d7e98951ff243b8ab47f45b17b1b54a7cae50e39d95f55d0fc3eb98dee1ff"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.14/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DBF5984B5F9AB4",
       "checksum": "9df554f62bbf62635829940668d10280d726da86d8eba03a57c6b2fbd9680f11"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.14/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DBF59825CB94B5",
       "checksum": "fc71362f47361f4079b12960caebf8a58aae499420ab49234a7e9250a8a0d1ca"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.14/cargo-hack-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DBF597E30A6679",
       "checksum": "2e55ca53580b30c6b674eeb0bfb1e7c6648cbc4289f8c52e720ebaabb93b0fd9"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.14/cargo-hack-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DBF5980F0165F5",
       "checksum": "273c15582d811d4040bd85246bf89eed75a01d04542e409f04b25e1060cd128e"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.14/cargo-hack-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DBF5981F21F9CF",
       "checksum": "47aeb67c6f4335e343d4f71a09d09c85e921fe9e49484dd603e168d482a93a1d"
     }
   },
   "0.6.13": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.13/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DBD2BB0B25C4D1",
       "checksum": "35f66efdefe9c598e7a12a9db3904d3e78032b84005f04b51ab5d5c5ba3c9405"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.13/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DBD2BB5A81850B",
       "checksum": "57d606eea43182e86f2958f13a04d806968fcf56f0bc46b0d1a5e0fd7dd3b426"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.13/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DBD2BB57BB24F4",
       "checksum": "a85f4ca5b79fb166a81c4332b80f5b771d2811afbefef713cf4687ce93a9ddab"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.13/cargo-hack-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DBD2BB06C1B6D5",
       "checksum": "2422d0fec3cfb0cecb4208e67489a500f00a4ca368838747355845ae95a85406"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.13/cargo-hack-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DBD2BB17D77BE7",
       "checksum": "47350212d5b80855958ae7354c48f7c7a69c6ff14652f07ddc1d00ef859a3eb2"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.13/cargo-hack-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DBD2BB613D3295",
       "checksum": "e1c2c3e155f60b6c4ccc98f027ee29da0352a61dceb53294dc57e32e49856c91"
     }
   },
   "0.6.12": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.12/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DBD01558341915",
       "checksum": "e5eacdd5e420ec79c9490c8e4b8868ff84c3818cd9f7c93795dae8ac88fa60ba"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.12/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DBD015A43B0A4E",
       "checksum": "9558afab9b0c311635e27acc86e21e791ee5cedb44292ce5a7261082aef1d1d2"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.12/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DBD015C7627BFA",
       "checksum": "8817a2fcb5442d84001a18c615c37162d89b539005ebc1497df263c39a450592"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.12/cargo-hack-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DBD01559A67AB4",
       "checksum": "466382fabb571dd71d4229eee35e4da2ecb3b3a3c2e28a05972f27129a472bab"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.12/cargo-hack-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DBD0156EFC769E",
       "checksum": "2c03d4418382599670772df4b8063ce9d0882c7fbf03a9d7eff68cc172b1b88a"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.12/cargo-hack-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DBD015ADFFF2FC",
       "checksum": "9e15a18977c5f71a8162282f1b5dd9a7ae4c9ba8222640a567ef757bb8e317e8"
     }
   },
   "0.6.11": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.11/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DBCFCDC182ACB0",
       "checksum": "b1caecd3cdb0aa2ecf5981bd3ca7736fc9931fa8500674b49ca9d816e416cf7a"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.11/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DBCFCDFDEA2AF0",
       "checksum": "6819242f22bb219b9955dccc2075b4edf3b11b28b362e9c219789ff829878524"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.11/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DBCFCE037CD979",
       "checksum": "8cb102297aecad58454ac6f70773908ab68e89a0585c2fbf23bb103c44466bdb"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.11/cargo-hack-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DBCFCDCE607463",
       "checksum": "dcd8d5b7e8baa1a449beef0dd43c6c9fb724c950febb5a3f0ffa3bb326f18918"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.11/cargo-hack-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DBCFCDD6DC9BC5",
       "checksum": "c30a4842af20ff8edff34a5d72e1f8b193156f6625840e0a8451af2a6995ffaf"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.11/cargo-hack-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DBCFCE4480E9ED",
       "checksum": "a8ff741f14968ec74f518b9ce427c3c3ae78e97b87f7d5ef3d76bb61aefd8cd3"
     }
   },
   "0.6.10": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.10/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DBCF34E540849D",
       "checksum": "61396b1c1b96faecccdf2af78e91a0f015c161573debbd3a92f36452cf0736bf"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.10/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DBCF352BB709DC",
       "checksum": "44564f6deec6e514d30e6b18e0c5ac5d8c444a5cfce6216d747ef0b1ca57fea1"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.10/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DBCF352992E94B",
       "checksum": "ac37e52f6bd0e55a34386d57f96f3b1e5ef72e2f844d701c128ec14dab64ea6a"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.10/cargo-hack-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DBCF34FA1E5417",
       "checksum": "872fffcdb7cbb1e66c5d7c9e292bb28458a8e575b400d768842a46a181fc76f1"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.10/cargo-hack-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DBCF34F619121B",
       "checksum": "e3d9a5cbee1f0a91e07721ac483525f98e0887ed9ba8058de55449cf71b9aa2f"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.10/cargo-hack-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DBCF3528193CFB",
       "checksum": "e77a9ddcc0df20f254354d7cc3c2992908e1621a471e1c43df55b47867153582"
     }
   },
   "0.6.9": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.9/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DBCF1687929206",
       "checksum": "4be65b3c79683d4846ef16bf7b3d53f585076ab708f53a5ec0698f7c8f690ceb"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.9/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DBCF16F28CC5FB",
       "checksum": "e478a9ebccf092e7590647f2d8deb80089c46fa2023d00c22cd569add98f017f"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.9/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DBCF16CACCFF3A",
       "checksum": "d53025b3b46fa2b67a192bc63508a3efc81011799bd107790615bded974fe2fd"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.9/cargo-hack-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DBCF165444C7CA",
       "checksum": "8843746d9edc9ec342c7e23cabff801ba6e9bb3f5fb7019d75a82b05fce566f9"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.9/cargo-hack-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DBCF16ACD9201A",
       "checksum": "af11df14efd96bc28621ae89019ac9fff48daa80c526d2cb8ccd7e4a748bf882"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.9/cargo-hack-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DBCF168AB8F659",
       "checksum": "5bb0b04244ed9a621ce76148103de1e9e25d5db77744391cddeefa5860f45cf2"
     }
   },
   "0.6.8": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.8/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DBB612391D018E",
       "checksum": "0e99e6ecf6f04cfeb7bd126559f94c7d54c891cd6609fc2d5e6b327da9178069"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.8/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DBB61246738BC9",
       "checksum": "f21d6c824bc9cac5c174fa61b8375df35f3c022a19eeefd7156dcaf99c18cb94"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.8/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DBB6127003372C",
       "checksum": "60e272a5f154bff33b8f24f4e47890e7267ed1f583c87f1c425737debec00a5d"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.8/cargo-hack-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DBB612364B15CB",
       "checksum": "ea6e74180776d0908b21d938515e4a04fcdcb02d564bf08e397dc7191cbce524"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.8/cargo-hack-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DBB6125203D8B4",
       "checksum": "9486a0e12919c667e17b9fd22e43c6449369ebeca0e705ed372090e87610e8fc"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.8/cargo-hack-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DBB6128BEC2154",
       "checksum": "946a28154a087ee4c1835327973e3e914d90d9e4840bf67b22422f2b634aa214"
     }
   },
   "0.6.7": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.7/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DBB2D75D468954",
       "checksum": "af3f992ce3bc2f766e1dedd91777b00839760d2571abc3d85f6c6b8a8c743ef8"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.7/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DBB2D78B129DD0",
       "checksum": "c92a155df6839a17e8b167c6a1d0e5adb55a21623186f9401a151b3b478c041b"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.7/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DBB2D7B15DFA2A",
       "checksum": "973a0daf4f09d8b22bbdefcb5ff194b0225682ad1127648e445cad0d2ee30ce0"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.7/cargo-hack-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DBB2D769D6373E",
       "checksum": "decd3237e11fef4d4b30052405905d549d05b9b09c3efe87d45a6f96abbcd460"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.7/cargo-hack-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DBB2D77A4C0176",
       "checksum": "e36fdcdf6b5064f84837acf3616cac1f191ba7af8f4c6bb599d3eb541cc712fb"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.7/cargo-hack-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DBB2D7F7413AC5",
       "checksum": "0aac8f8cb2b3a0e6158f42318b429bd2720ae55f15ca05477e4268bd3a8c16ea"
     }
   },
   "0.6.6": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.6/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DBB1080F6A6E63",
       "checksum": "c706770f61c4dcf3dfc0c87125b443306787032c50bf61d30724bac620846a48"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.6/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DBB108482653E5",
       "checksum": "d5a619778858d18d4ef3b291012b709b509a79ec66dad41590c692d5f35a30c8"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.6/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DBB1083BAB982F",
       "checksum": "1cba2531361ece88f62f826725bb609f17b05baab8da29bbac8bb44fe7e44008"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.6/cargo-hack-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DBB10810418CF8",
       "checksum": "a5d8a424c30bc3b3b6b9e44aa3810d5995dca7e648bfe2f139ef0af14ad8662e"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.6/cargo-hack-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DBB10820B23436",
       "checksum": "aacf5cebfe7523ba1a610192bd76dcccfbea1b16aa8e8bd3ed8356abd5809980"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.6/cargo-hack-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DBB1085918B763",
       "checksum": "329f030f530bb65290150e4bf282065ecfe4f988aee6763fb87720e0dc60b4c9"
     }
   },
   "0.6.5": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.5/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DBAD41A7539534",
       "checksum": "767c91d80cacf9568576d9263b8801d4c38a245c472ac3c58320b15824539a74"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.5/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DBAD41C5EBD48C",
       "checksum": "20530649af2bfa2620368b6a111e5538f9306c4f64a65a1e6dbbb32a7a291b8a"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.5/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DBAD41C38F301D",
       "checksum": "15d7daaad73e7d76acb4d562138709fdda2d077bef426835a77dd7d362eeb13e"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.5/cargo-hack-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DBAD418A5DDF3F",
       "checksum": "743fe76f2115bedf6f5a86784ea254c105f171aeeb75e5f2845d6aa83be7319c"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.5/cargo-hack-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DBAD439CB06B3D",
       "checksum": "3a9ab29db73449b779656199ae645d7b4a3e055e22ee6fa056c7ec61cd57cb87"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.5/cargo-hack-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DBAD41B1B8EBFB",
       "checksum": "2bf9b10a41ce7585fa60b1be8424283433eb000c542652145d89d95be7a6fc99"
     }
   },
   "0.6.4": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.4/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DBA89443E071EF",
       "checksum": "f50d28b566a270c49cd5d44fca3badfc0279bd681e9788872c875f81f2125ca0"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.4/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DBA8945D6B170A",
       "checksum": "09502a5e1e66457cc98f114e3ab80ace837c42ca20d12439b45ca09febeada05"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.4/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DBA89463DE0175",
       "checksum": "b54bdf9b1968a352644e9d7faead9a3832e0a2c5f8f89f2c513f258dd3423216"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.4/cargo-hack-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DBA894301BACE2",
       "checksum": "0b3cf069d1e433882f800129b288e76f8b0f4972e2f5d2746a43f5976b3f234d"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.4/cargo-hack-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DBA8943C8D71E6",
       "checksum": "01e237e764b098d1a482e4fc31c2aa1a64d6756e885421a95faa5578cfdd2a50"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.4/cargo-hack-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DBA89459AF3568",
       "checksum": "af68ead95d98a18750da188259678ce53f8cecae8fb7109ae0c631161da8406e"
     }
   },
   "0.6.3": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.3/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DBA8067CC27438",
       "checksum": "b9515accb2c8984841a152f860d6c7c827ab4f91c4e5012d86ef7c44f319bd41"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.3/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DBA806CBC5B545",
       "checksum": "c144b7912bbc9089c116d7c4610c4fc221705af93d6994c31314663bba47785f"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.3/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DBA8068EBDA43D",
       "checksum": "3a4d6958e616ebb6d446adeb7cf42674e4d4e9315c10c8cbfa5a00758e7e277b"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.3/cargo-hack-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DBA80675645C63",
       "checksum": "c8ee443bb05cd8551b2d9d93befbe7a8f0994a128bc33125cf97da443077b579"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.3/cargo-hack-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DBA80693B4E90B",
       "checksum": "279e5cbbcbbe607ac5c81f204f0ae83a62132476fa1ff53f0d8ec24d879bf7f2"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.3/cargo-hack-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DBA8065B266D8E",
       "checksum": "63a9df0cdad068b3124a858aa3d47c93513caaaea0efc61befdb0091efefb64d"
     }
   },
   "0.6.2": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.2/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DBA7F53642ACE5",
       "checksum": "322d1a965c94656e7b766dbdf4f5726372fdd8ac3b98b7aa3fe0b50dd4892be9"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.2/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DBA7F57E26EC9C",
       "checksum": "a6713d40d955691b0efc48d77f42a9c58f740e9036eb052a4c5b8843477054d3"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.2/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DBA7F591F27D6B",
       "checksum": "a6078aef3cc7bbc5992519909229b074bf802dcc3693e5d90405790e1927060d"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.2/cargo-hack-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DBA7F536E7F6A4",
       "checksum": "305b59c9d89fa76ea91002894cea58e296c062da896a2784c04a39305221079b"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.2/cargo-hack-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DBA7F5485ECB68",
       "checksum": "860b867a047c8d89aa2b0adb12d6ff085190bde80516a49be6e2cad4cc298bc5"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.2/cargo-hack-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DBA7F574B0B9D6",
       "checksum": "73c04e1670b7d7d7696b81ccdc1ea27f7ddcc8028883cf5b5df8edcda61b899c"
     }
   },
   "0.6.1": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.1/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DBA7ED7F322469",
       "checksum": "85f79339499995238287591c86b9ddc9aedf6c4c03f771f9aa7ed0b97dc6da0e"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.1/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DBA7EDB8C3947A",
       "checksum": "c92fb2bd0351e4ac6ea087e5169b5fc56bc03c9afc3c8a299c21aae8ecda8067"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.1/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DBA7EDB9058359",
       "checksum": "ddb32fb03864dace5cd42bf563b8ea459f58620c28379abbc527888370b1775c"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.1/cargo-hack-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DBA7ED85AD42A3",
       "checksum": "4855ea417b54abca02d0fd076fa1cfffd2068ac2f4abbafc52261a7fa2a9ebfa"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.1/cargo-hack-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DBA7ED93ECB49C",
       "checksum": "fe3c9126fa64f7ef60a9a4e78c77f9741f9848221cc44c43f9346a7f9b268bca"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.1/cargo-hack-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DBA7EDBB41F231",
       "checksum": "0c6c21cc1e11c7f2794a4e7c800d2459148a7db33dc162af7c2ccd057ca38ee9"
     }
   },
   "0.6.0": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.0/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DBA7E5AAEEACF1",
       "checksum": "c1a539de7f0890527d6ecd87c0ac73097921a0cf071ded9a3cf60e6c387ba69d"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.0/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DBA7E5E110F2C7",
       "checksum": "41fd4566cf743ab06a46ee556be251e8948b1ecc316b2e61bc25ecc818cfaf91"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.0/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DBA7E5CF2F69B0",
       "checksum": "e2e80b5a7c6588a6e8af4b3ceb460e1c859951c51066514727a9434dfff5b07d"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.0/cargo-hack-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DBA7E5B664BDCD",
       "checksum": "f5156e8522abd9c2545425ed251da6411bf824b5d94cb0000e0a90153c78b8a2"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.0/cargo-hack-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DBA7E5C2399A1D",
       "checksum": "c8292ab17351307d71fcbe68dad39e0019227b89c3a73dc4a0d6db8ca0b2663e"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.6.0/cargo-hack-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DBA7E5DFBAD287",
       "checksum": "9d7ca4e2c0530ad966662a56dd7b8b211cfe1067c4e46813ff82f18476dd24f8"
     }
   },
@@ -768,604 +942,740 @@
   "0.5.29": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.29/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DB96604C0C07BE",
       "checksum": "97be81fba9a94970d9984ea6a02028d9c6a83d53071456aa7c7cf35b9a150405"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.29/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DB96607C3CA448",
       "checksum": "1388d51e994673f30380f709f3a8bacbc7f2981c3b294f34945b9612977ae6dd"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.29/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DB96607223BC28",
       "checksum": "5de11259c7bb37506c6c6ff1427d0afddc5fc7e35688e1e6a43255d6903f1063"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.29/cargo-hack-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DB966041F651A8",
       "checksum": "e8729bd85be2c4efc3c72c8a7c995758f4b531334144cb7376557d44492c102e"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.29/cargo-hack-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DB9660630CE1CD",
       "checksum": "3a024f71643a0cb137b28c7da9530c417f2c64dfa5f78d5e615b7f7376b43558"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.29/cargo-hack-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DB966066F5E0E4",
       "checksum": "79261291cadb00feb75f70d50ba33ff8fb6c68d7ab9c66614423610dd840d23f"
     }
   },
   "0.5.28": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.28/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DB19AC8CA53298",
       "checksum": "87fb6dbb3e8272ec912f85b80366d0c4784fbcf0fe4e5981bf442efaf29dfe48"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.28/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DB19AC5EBF713B",
       "checksum": "e926dbb2921544835c5e38cd4e3ac3ef5be4b4ab752528f45d805b652df11ee4"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.28/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DB19ACA033CF41",
       "checksum": "688c5febcd440da377af72dc66933b03c70a7393981cefe3fb40b719504900db"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.28/cargo-hack-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DB19AC4E8DD9D5",
       "checksum": "788308e4504a2676d97847fcc3993f47e8c93c4b43b46b8566b7b18cef01093f"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.28/cargo-hack-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DB19AC4C833ABD",
       "checksum": "47c3390818b5f434a4697aeff0f71f4f69b7e7c2df946b74cce45e2bb0fc8dfd"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.28/cargo-hack-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DB19AC8D2DAFAB",
       "checksum": "c38da73a61a3600aed98d4ee00bce0c64bca4b4e2200112f55011872d420ead5"
     }
   },
   "0.5.27": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.27/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DAFE7AF864E9C9",
       "checksum": "a57248a36e5f95b88eda8fbbfd1f1170992abe7d126c7778aa2bd0508625592f"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.27/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DAFE7AEA505944",
       "checksum": "8c3f574813316c74f8f6871eea60af1e9f161ffe598e5ee49029929eb48dadd2"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.27/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DAFE7AFA51A14A",
       "checksum": "f9510e9e84e4911feea8038d4358d0fc6c5aeea266508cdc4ef58d0a547fdad1"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.27/cargo-hack-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DAFE7AAD8D134B",
       "checksum": "14deb7e0772fd0090ca3b04117f70cc10b20a370edf56b9255d24e84e755f7ac"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.27/cargo-hack-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DAFE7AAB7D48B8",
       "checksum": "c16b74d87ad26f5d8147bf3c0b17bd04c77b0bdeff836c7ae2c0a02959e761ed"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.27/cargo-hack-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DAFE7AE7EC3A12",
       "checksum": "d2694b937d0c8fed71c1a0d3aabd9d9923a808d7196b15fd6d2eacde6755d57c"
     }
   },
   "0.5.26": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.26/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DAF3DA27133671",
       "checksum": "e4bf3b5ee4be1d7e324c625f18ad85db22ab7bab9bb76988e3901358bc6b6e23"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.26/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DAF3DA5832973C",
       "checksum": "697b11ef5f79c9976424c46be7a7f6a7f8efa94b587deb41fa37a2aa0fbcc28b"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.26/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DAF3D9F862CB91",
       "checksum": "f959bcd911be619c24c627a3ccaca36424215f5dcfdbc3e6443508f8c9d8bc50"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.26/cargo-hack-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DAF3D9C2D430E1",
       "checksum": "50814c9e1bff259816e03508aac9ac06be18bea4bf220928fac10b1de9494abc"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.26/cargo-hack-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DAF3D9C47E4722",
       "checksum": "fb4a1d38ce5edc5eccc3ecdc2aa27dcd58b0984ec76316f52d9c8a3c97679a4f"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.26/cargo-hack-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DAF3D9D4AE56B1",
       "checksum": "abb797d5794ea0456b323e5074b452c798dd5b5a94135d91f38494e829c8bbff"
     }
   },
   "0.5.25": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.25/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DAE689D09C3DFE",
       "checksum": "174ac9958cc93a197821012ab74a7b96836f0792ba031c3edfec3b81e7cacb93"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.25/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DAE6898EA902E6",
       "checksum": "db2c58207e0e8682e8c0a8785bfa221bf54fe7bf4806c39bbc4358bc97c1a146"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.25/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DAE689C752C0AD",
       "checksum": "1462f59293c111ed61bdad6ea8783635c22e9b2bd0ebeffdaa95f7587ede6c80"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.25/cargo-hack-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DAE68996F559C6",
       "checksum": "e955398f465f2152b1c4717a2c3ff4dd9525d7a25f01c4b1d85e4e2db4b57ac0"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.25/cargo-hack-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DAE689823C730E",
       "checksum": "69bdd8c7c31434c7ef76addc44fa70b873f637ff2a1b245fdf0ee85f1f278f28"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.25/cargo-hack-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DAE689B61D9C24",
       "checksum": "2a8ad14a57a373529b1bbdee10a07b27012b4a0e4506df09d16c949f2c0b1429"
     }
   },
   "0.5.24": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.24/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DAD578F233DDF9",
       "checksum": "645eaa98b5f582a2668ac38f139d5476ee605a6de3adaa4937d4ee84f1cce209"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.24/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DAD57964C8778F",
       "checksum": "976bb3fc5eccfff7a6bd4ca0b520cec731bf73dec7a2150328cfe8e139afdabb"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.24/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DAD57905F2C686",
       "checksum": "63cf751b00d7a44cd612fbbd2c45d16f3d0577710ddb0cd0b599f05748b5ea43"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.24/cargo-hack-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DAD5789C8EBB37",
       "checksum": "245caa8882423682945815e5ac98efc45aa78b15f57f9df3ffc71d0cc40d6a46"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.24/cargo-hack-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DAD579048BA377",
       "checksum": "61195f2409284f59ef7aeac792e29c545c770f263942197fffa6c5a6ec17145b"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.24/cargo-hack-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DAD578D3C36A51",
       "checksum": "5f4423598a1007957b399250c12723a88ffa9d38b2bd4d1ac5ecfdd33edfdb94"
     }
   },
   "0.5.23": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.23/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DAD0722A73B7D3",
       "checksum": "47d0b7f906395c39c249bb9be71541ca16bdaf7a6476ad20072ff9d7bc934664"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.23/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DAD072957C01E4",
       "checksum": "45861be5b6d6501294ed81fbfbb59f93b758f963fe3d818d46d17317ec934371"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.23/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DAD07209DB055F",
       "checksum": "91b1a929add1e301807a1cfe37f840616c0a5154063078910df487065830b9ee"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.23/cargo-hack-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DAD071FA2AE8B4",
       "checksum": "a81d682a88470f6ba761d4cee18cfaafe63113e3131772feb6dbf8efd5ccfd65"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.23/cargo-hack-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DAD072714D6905",
       "checksum": "f0f73073144deefa790ebe50e9fa60ddd694df043f6461df8afd40623efb52ab"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.23/cargo-hack-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DAD0720C3BF504",
       "checksum": "d080aa704dfdfa51f7151c10fafc6fde5ee3d9f2e4485cc244fa5024160a16e9"
     }
   },
   "0.5.22": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.22/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DAB69B0407B3E6",
       "checksum": "39fb5278e5a5782c92e13c134c2826dc9a9b2ed37f1df354c3c82dae705eb464"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.22/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DAB69AEA202B03",
       "checksum": "a33d6fe8a132385975a3dcde955152095807d7d5d70fd821c10bd973b58591ea"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.22/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DAB69B12684EDD",
       "checksum": "4a8f1d2405cc51002af163de3d5799b6f38f4168314848fa6da7b0cc09f218ae"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.22/cargo-hack-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DAB69B04D1740D",
       "checksum": "57d08f3caec65e90af45114108902cef88e01ea6200ccec7fa94b3ada397fba6"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.22/cargo-hack-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DAB69B4356F5D0",
       "checksum": "124d25e71cdf840ef7a1c34829822bddc4305ea2e3e4abd6f5dce40b447301cf"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.22/cargo-hack-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DAB69B4C1C4A2D",
       "checksum": "10e81e47097c6126ab10dadfc12d2b15fce10ed00cd89e9b39a1938c9567ea38"
     }
   },
   "0.5.21": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.21/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DA9FCBCB2D607D",
       "checksum": "eae32e44290f06e69ac2220c8d1e448c2a6f08f8672d2eee6e879ea4f7690457"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.21/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DA9FCBDFD15C24",
       "checksum": "9c176fe69e36ba2fbc7f4858b62f4997456b4b4d7162a0ed3fd234ea8413a476"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.21/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DA9FCBECD3F76F",
       "checksum": "72e3574450eda59ddaa75eba5b0ff58e1434f9e3447aed492191fa00ff6b0ea5"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.21/cargo-hack-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DA9FCBD4521AA3",
       "checksum": "a0f92a1ead13504cf872665e70d2aa53d25138a3eb22b398f8038051dbd12d8e"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.21/cargo-hack-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DA9FCC4FCD6F31",
       "checksum": "090af158dc4f8c6a5f41259d4756d77e82de4db9430822fe84d9dd293fcb595f"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.21/cargo-hack-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DA9FCBFD80C147",
       "checksum": "01b463955386daa9330ac23ce873409f11695e9fd39e4d9db27099f128de192a"
     }
   },
   "0.5.20": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.20/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DA9DE9938731B1",
       "checksum": "82f2383ff38f26b4b12f9fc7c9bd43608a30eb6aea5b103795828c327a26af94"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.20/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DA9DE9A151BE13",
       "checksum": "07c6d081ee4860b513ea85449b26db5a398bba24fe0b163885fd3964cffec9f5"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.20/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DA9DE9B98744E7",
       "checksum": "45c22dcdd736ba2b7ab9a33a0e1e00186ee2d34b97e65a0e72f715511c339e96"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.20/cargo-hack-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DA9DE9919F5D6F",
       "checksum": "43f7236015a0d1f6047f7ffe784109d90966ed7a0cb2551a334047bc339761b9"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.20/cargo-hack-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DA9DE998A593D5",
       "checksum": "87d75808cc9453a9887c588fe8e62c18fce659aa2e871e75febf2f51bfabd62c"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.20/cargo-hack-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DA9DE9A9A3A1B5",
       "checksum": "e1e712c3768a5dbcb0aba4bd146f8fdfcf95c0c6a4e9d6f69a320db3f3f79cf6"
     }
   },
   "0.5.19": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.19/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DA9CAF21A7907A",
       "checksum": "3c54b469fc5f57499468d3c1fe262d6a15b6829e43eb3c5070a9115bfb667a0c"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.19/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DA9CAF42387AF5",
       "checksum": "d2a0cddf9d40185269d353446adeb6fdaad5420966ec4743545a0953e72f4b0e"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.19/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DA9CAF303AE26B",
       "checksum": "32a60932193443947ddde4fae1f3235fa947826eaf1135a33a4a1d7e8e07d71c"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.19/cargo-hack-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DA9CAF0F9F9BFB",
       "checksum": "51c3e9d4e1f31f2cdd9b3af4d6f657bc721452b9aba76640366fb4ef7541d446"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.19/cargo-hack-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DA9CAF1EA59A4F",
       "checksum": "fa096d27cc1a1098866884537810247f756ca0f00401cf7b300b0a4e8b6ae7d9"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.19/cargo-hack-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DA9CAF33C1372D",
       "checksum": "40a2edaf536eb9afc151140d8dd2c5812ea2b5377e1c55dabfe5b9168ad25c3e"
     }
   },
   "0.5.18": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.18/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DA8E7CAB8D3A1D",
       "checksum": "38f923c7b3ec904536efe319534120307b76418ac4b9c4fe0a40b01f600e4041"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.18/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DA8E7D11C9D75A",
       "checksum": "cf61951503813e1c631f02f4d7791d116b6dd1a5207dd91537ad5d3c205c67ac"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.18/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DA8E7CBDE5A9D7",
       "checksum": "3cb6901d0af50811f6d16c38ce4a1c5b423455817939d565fe15fdfdb6610d21"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.18/cargo-hack-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DA8E7C9E9126D7",
       "checksum": "e28da2bd22a06c99f9d310289fe3777e8dc531ebc3b3f5beb84053006e471622"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.18/cargo-hack-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DA8E7CDB0353D0",
       "checksum": "ef1a07f247d3845bcfba3e297585d670f19f8366f83489a0f5169b31418d338c"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.18/cargo-hack-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DA8E7CCE40E5CC",
       "checksum": "fdf4e1db83736ce02cdaab359622b144a79be0de18db9a838418bb8953e942d9"
     }
   },
   "0.5.17": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.17/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DA7CA86B6928AE",
       "checksum": "2f7a0ea5a704e9d1ed171063fcad50be47ff8d2a130e5ff97bd8c0fad6a581dd"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.17/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DA7CA8B0D4443F",
       "checksum": "d3e467a6e8f3e8a9a2cdd63c2fe19a8ef6d576dfa3f0fefa5e862b4a5e68273b"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.17/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DA7CA889E5673A",
       "checksum": "1fa54dcbbd9e6a60c2d8c36f92f8d026199a54f70eeeac8231a568c2e52fc18e"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.17/cargo-hack-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DA7CA86396AA9B",
       "checksum": "cd7605c23fdd631c110dfe8c47bb2331ca699a4dc49c129b8b7e679bbb3ef52b"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.17/cargo-hack-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DA7CA85A3E8898",
       "checksum": "d4f69cb5f137c74ba4af8696e1c5c06ef2c7d972935548daeca8d0f902ccb6b9"
     }
   },
   "0.5.16": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.16/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DA71F41DE35B82",
       "checksum": "7625df89cf4689bdffb9616c5debf0afab3708478c81d882f911dc854507e2a6"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.16/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DA71F415B44D93",
       "checksum": "fdb6fcab82da1e18578ac9ac8d7c06e1fb00e019f8ffb741f8bd7ea21f9f9565"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.16/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DA71F3EB311785",
       "checksum": "43aa43b41fb1accebeee1dc3d1033031a08a711b295e1801fe62da2b4c8a9d54"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.16/cargo-hack-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DA71F40F0BF494",
       "checksum": "83a901acf9f92f3ce9353f76b326f1c56b4a7c19dbc2d914f067a723916cf585"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.16/cargo-hack-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DA71F3D866EA51",
       "checksum": "731a2c7e0afc0a8b7ac99f6e5e7476dc95705b5ca01c223919a1cbce7f9a7309"
     }
   },
   "0.5.15": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.15/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DA687D59437BE1",
       "checksum": "85a183ee312ecc579be266388fd203886d56704e2468d4a1c98ee1057e7289f0"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.15/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DA687D3C0075C4",
       "checksum": "e8c5e359fc9dc50046b88c6cf08bee876de0952a31f6e6c39ea7bfba71d08193"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.15/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DA687D5AE57577",
       "checksum": "b8da9f656b921406302f2468d13abb3a43a5b39535a8b5e9294fae8f5c78b972"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.15/cargo-hack-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DA687DA32EF323",
       "checksum": "48933088a1feb1776aa7feb35f6aca84b0593ab7602c8197b5d64274f0b4b688"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.15/cargo-hack-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DA687D4FD89F53",
       "checksum": "7c0ba9b4f9194c85dcd344affb77873ceea90aad0b3506ceb45d04528bd82926"
     }
   },
   "0.5.14": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.14/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DA449A18F5A66B",
       "checksum": "11e05d350cf1be6fe95e757f08708122a4ad4e39cbafddbe1baab2c58a547784"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.14/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DA449A9C2B6B63",
       "checksum": "1c0891a71480d25aa2d8da56275be9a7eb378fcdbd318c39b17a3615daeae08d"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.14/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DA449A1B4AAB64",
       "checksum": "5f2f6d60cfbe6323a44ab3631f0a7f65bab87f08f58d4645883bfca35ece0354"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.14/cargo-hack-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DA449A18ECA71F",
       "checksum": "95b599c3e576932b9147b80e2ced64e823b96fc5e2c93d2797df9e16b9bb2974"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.14/cargo-hack-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DA449A11B33081",
       "checksum": "cce95ceef5a56e0c0f7448c7724a9aebbd2fa1fb5a5f77b332393fec65138666"
     }
   },
   "0.5.13": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.13/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DA33B25B525DAD",
       "checksum": "a6e8952a3e1084b28d4968dd2ee28d6777a64c1975d5572e6b081c403d7db996"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.13/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DA33B2484E6560",
       "checksum": "2bb4a3863dc6f1e106b2a325666e51abec8bad18539cd84ed82f05138c931a51"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.13/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DA33B25EADDBE8",
       "checksum": "227c006ae2aa272d6c561322962f92fe384d0a53f99be790e06752bf04b41349"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.13/cargo-hack-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DA33B2608FE9CA",
       "checksum": "08d14b9f380c7ab0408cc3b95913b3c4e464698848af5027be01f1c2dcf97f56"
     }
   },
   "0.5.12": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.12/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8D9DCF18B554544",
       "checksum": "04d33084d6ef8e44f5832205932763c18ad38f61ac8dbb48b31f0585d48641a0"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.12/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9DCF17AAC6504",
       "checksum": "88f0e75955a8192b2b44d7864224dbfe0c35c22e0130aa0944e690d00370f30a"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.12/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8D9DCF25C0041C7",
       "checksum": "96b04eac7fe6f4263670bd593828d8b2f69a5342b1d7a89de272cde617437251"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.12/cargo-hack-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8D9DCF17C56ED93",
       "checksum": "984533e3d8aad2e7923986015ce0cce9c172cd94c21e4e718ddb141fe5698bde"
     }
   },
   "0.5.11": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.11/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8D9DC9F1AA898D8",
       "checksum": "c41ec44f641cb380f180ca03691e8410387bce2d91f3eecadbd09941124aa7f1"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.11/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9DC9F14144F94",
       "checksum": "5d9c4f4d1b125cc7b3f8b3d823f04e4909741b9c657303eb2a03b5c79b0792a2"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.11/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8D9DC9F29393677",
       "checksum": "b8c9eaea1e872b209777ac112b39cb483c7dc229e48c780526ab9f6ac2532876"
     }
   },
   "0.5.10": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.10/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8D9D0C8113F863A",
       "checksum": "06e413c02196e3b5affe363d89c538bc947b24d4dc9678acfd5bc91d94e06868"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.10/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9D0BC9DAD69AC",
       "checksum": "c1459c80d2dfac359189e4ea1f97da9a2576a09a9315f7db751b419239568820"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.10/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8D9D0C80DD64FD6",
       "checksum": "d9d0387e66b15acf89dc8fedfb026c1184736b348800b58e1a2c242eda4374aa"
     }
   },
   "0.5.9": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.9/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8D9CAA0BE47596E",
       "checksum": "98f4010e94700ad342be575156b642be6669afc04ae62eec438d06bd1dd87b4d"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.9/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9CAA09475B78A",
       "checksum": "38edacefb163c8f6b701c31a984fa6b1053747faf988354a7a0e2ef200618701"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.9/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8D9CAA0C6DD2D69",
       "checksum": "27aeaee6a0827e17c3ba3df4a63043e6f66962d5383ef4aec642696c5c680404"
     }
   },
   "0.5.8": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.8/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8D9B955B1E77D0D",
       "checksum": "9ad5d16806deaf4255cd559c2c5411c09383d7c408ef4c8a4e491d0d416f8881"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.8/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9B955B390804D",
       "checksum": "5351954f5e8cf65497e9240735a8bcfd69067e2e94a26f4be41d16e98fc54965"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.8/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8D9B955B0EE2760",
       "checksum": "28e5ddb8fd8f245280131d0dcee6668d8a96994494136325cceacc243dd3bd82"
     }
   },
   "0.5.7": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.7/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8D9B955B17285B3",
       "checksum": "7235b068f65e8d4c14787aa3695984e3fbbcbd7f0c97537872e3c8391eca1db1"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.7/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9B955A7BEC847",
       "checksum": "7ac464b8a3c147949474c49cc89782ecfde2098f42259a59c673579663c8cc55"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.7/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8D9B955A90C4BD2",
       "checksum": "2a198c9506a75a8dc56e23c37c4e4a2bc25573a3c3879bbdfc05d476d57ac042"
     }
   },
   "0.5.6": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.6/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8D9B955A6614198",
       "checksum": "f0d616d878a674b01ff3eaad459bf93e9a424bf54ac12c0e131f70c9f4d98bdb"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.6/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9B955B2AC0F09",
       "checksum": "26ceb577099fb9b7a6128527e666c6737e4eb563c553496a83af347be32fc692"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.6/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8D9B955A98A427A",
       "checksum": "68f2fad33d3ca995c8b540ccd022f22eafdadace2ea507ad2cc7ae57ee630bd9"
     }
   },
   "0.5.5": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.5/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8D9B955AFA7F5B1",
       "checksum": "632f228655646f75a6fb237cd18d11b6aabf9b4814297eda65d3f354bf8c9268"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.5/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9B955AE9C7A55",
       "checksum": "8a802f72e7b746cbfa3988ba0a8e8a4eb3ddc0ae83d44bf7eb982588e3df2bcc"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.5/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8D9B955B5E6245F",
       "checksum": "f690eda799ab3afa94f3ecfe9e786c83a6447e93cb57fb7d5d0d766326fddf2a"
     }
   },
   "0.5.4": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.4/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8D9B955B1124BB9",
       "checksum": "9d90d56dc1c7a1f7747b8b0c27a85c7f630c60cbc7403f986711c275f1265d11"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.4/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9B955B35861BF",
       "checksum": "cf364b6aea436a6751f12b804b7ff2ca6d37ce8ff9090f77255afd2ee4268685"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.4/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8D9B955AE9A09B0",
       "checksum": "f6f89330bb459ffdf1105fdde3e6e9a07335d202dcdda42c160dd560f43163dd"
     }
   },
   "0.5.3": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.3/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8D9B955A657A619",
       "checksum": "4c298cb156f1561e9e84e9ed0f2924d4265234e52ca15aefd743b114b5d161ca"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.3/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9B955A8A5350F",
       "checksum": "6135616c0612e13163e61c08e5134df1c6ab13574e4b0635892ddac92af726c0"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.3/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8D9B955B4BE72A7",
       "checksum": "9ed458229ff9fae3bd8eb4d3e676d866037baa114d05f69b1a72411e81e3d36b"
     }
   },
   "0.5.2": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.2/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8D9B955AD9E6A65",
       "checksum": "d5b37eb22afca1ad817020ec52e776ee0c14c7bb0e9317381c63922d7c2514c9"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.2/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9B955A7B505BB",
       "checksum": "e87fde5b6a606358e47444d8fc24e4b40c857194a209d13d6440ee0b1fc53d71"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.2/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8D9B955B4C13160",
       "checksum": "be8bad1ad9bca2a7c2420357859458c57d9224c96cbd3f7ed809804ce267fd4f"
     }
   },
   "0.5.1": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.1/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8D9B955AB51508E",
       "checksum": "f152cdc7c256d3432e4dbc5d5fb4e3a26a44faa809e1451cd752b7364861d84e"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.1/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9B955AA34C0BD",
       "checksum": "30045b01f7a42ce7d9bed1ac24e5b142d120ea94c4969309bea45583a5a39e63"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.1/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8D9B955AC045902",
       "checksum": "b98c3aca93daf2259859c8aadfdbd0cd776683b7b758145403212af9b0d7f938"
     }
   },
   "0.5.0": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.0/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8D9B955B2FFEED0",
       "checksum": "903be266e25b87511234f8f39a84f0a9ebd40b52ccc2299d4eda4c8da8bfd9d9"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.0/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9B955B250B65A",
       "checksum": "856920064d777168fb9c42e193683632ac6a478ce2887eeb6573722be46eeb25"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.5.0/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8D9B955A8A6BB79",
       "checksum": "8e1b45402516a1c1a91c23c8e79f5874f10da74563d8f0a816898e49b079ca61"
     }
   },
@@ -1375,84 +1685,102 @@
   "0.4.8": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.4.8/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8D9B955B4939886",
       "checksum": "3c2728ec5f7e67014bb1eb4099f7fbe6962b7e13c35988d7316e3d00efc455b8"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.4.8/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9B955B3DFF3EB",
       "checksum": "dea0f5995bda29ba410cd6dcfa6c5b7889df80589df3d43e1ca27879789706f5"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.4.8/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8D9B955ADE7EB76",
       "checksum": "bcfa7e8b9b8fa0310f0a5833302cd641fdb922fb94512390f00a9511cfcebcfc"
     }
   },
   "0.4.7": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.4.7/cargo-hack-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8D9B955B5698D0B",
       "checksum": "7bd068ded6cb4f7671b309a04c73c8d24826d2ee92432e280cfbe9bd6620264b"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.4.7/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9B955B3A1E2E5",
       "checksum": "cabd94401dfbee35df5335ffbdae891dcf5f329824cc254ddca3252dacd7d61e"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.4.7/cargo-hack-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8D9B955AE21DE84",
       "checksum": "dbfd2bf26b9287acd9733af4b07f9333477eedd1ee8921483ad342662c20f4f1"
     }
   },
   "0.4.6": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.4.6/cargo-hack-x86_64-unknown-linux-gnu.tar.gz",
+      "etag": "0x8D9B955AD86A03B",
       "checksum": "cff0ba4789bffe84fd03204fd4f0adb92bc59eedb64b934e4016d68f2c7cd16a"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.4.6/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9B955B433ACA5",
       "checksum": "dca132bd72719ccbd690e6ee30747bf8d8be416c4bb534e05df32fe5e12ad3d9"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.4.6/cargo-hack-x86_64-pc-windows-msvc.zip",
+      "etag": "0x8D9B955AFE14C98",
       "checksum": "4ae216e95d9e41f274fb542c19dc9232e52a848503bf82fb414f74bc42e035a3"
     }
   },
   "0.4.5": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.4.5/cargo-hack-x86_64-unknown-linux-gnu.tar.gz",
+      "etag": "0x8D9B955AB4607B3",
       "checksum": "a6fbf921254a74a043b7b565ea1a1e3cdab4eaef828a637160a4847aca18f27c"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.4.5/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9B955B54DCBD8",
       "checksum": "a4e72599ccded2ba11ec201ec56b719bf1430cdb4d24a2ae9ba96918ea920473"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.4.5/cargo-hack-x86_64-pc-windows-msvc.zip",
+      "etag": "0x8D9B955B17DF5AB",
       "checksum": "304f5db88a9ca0374ed46fd0b1d3b2184f3ecb8b2db17ef9fff435f9d906a764"
     }
   },
   "0.4.4": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.4.4/cargo-hack-x86_64-unknown-linux-gnu.tar.gz",
+      "etag": "0x8D9B955B01C9EFA",
       "checksum": "9e72fd36e5ab4c17225a9b42db87b9bc5886b1b3b298f774d68565318ccde021"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.4.4/cargo-hack-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9B955A83AEA7B",
       "checksum": "c52bb179a26ee8bcfd954632a1272de0cac5ac7fe964dd6a28cf10995b89fe83"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.4.4/cargo-hack-x86_64-pc-windows-msvc.zip",
+      "etag": "0x8D9B955A971DC29",
       "checksum": "3241bf9058bb996087b7deabe6f6b527b8ac9097507ca333428e8e4db3d6af83"
     }
   },
   "0.4.3": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.4.3/cargo-hack-v0.4.3-x86_64-unknown-linux-gnu.tar.gz",
+      "etag": "0x8D9B955ADE15CC8",
       "checksum": "dde36c57020c23b267e20f6f62b13d4541d219a2156fbef926d24eeee1fa2f2a"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.4.3/cargo-hack-v0.4.3-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9B955A89C35BA",
       "checksum": "cb490261e4982becbd2ff49f1b9a0208a843a83e2617264a6767ab66931163a5"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/cargo-hack/releases/download/v0.4.3/cargo-hack-v0.4.3-x86_64-pc-windows-msvc.zip",
+      "etag": "0x8D9B955B49B8696",
       "checksum": "5dd0ad3df93242af2f2f7e06423c732e9f86c665b5e38fd3153a2244bd7cde2b"
     }
   }

--- a/manifests/cargo-llvm-cov.json
+++ b/manifests/cargo-llvm-cov.json
@@ -26,188 +26,243 @@
   },
   "0.6.10": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC8243D7A2948D",
       "checksum": "2350d7d6586c8b1ac828ad5578225fafb6a43fa9c35fe835c28a5ed63499df60"
     },
     "x86_64_macos": {
+      "etag": "0x8DC824412CB715E",
       "checksum": "6355b4536798ba0cea459729cc531f7bbf252d51c86b02683c0b4a4033d8cb96"
     },
     "x86_64_windows": {
+      "etag": "0x8DC82440FAE9FEE",
       "checksum": "3090e71ba2c0e16e593d338f4ed696f3829544f53dea63bdd966398f4379259c"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC8243E0545AA3",
       "checksum": "7921682e7bd925b69bbecaf9bf42f99a6404ef60049b1a9f87fe97dc697265f4"
     },
     "aarch64_macos": {
+      "etag": "0x8DC824405DCA8DB",
       "checksum": "46fe1d529755ca1a39dc7995374eef4482a20f0f632dd113430641c06fc4b466"
     }
   },
   "0.6.9": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC556112FB5969",
       "checksum": "fb4e71dae6fd641257bd4e5827723c58353f005aa06d3d4a5297221db22abc9b"
     },
     "x86_64_macos": {
+      "etag": "0x8DC55624B6541D6",
       "checksum": "7ffe3766f1e357c4d905037e5b2784020ed1788d03cf82f7f95278776cf0cfca"
     },
     "x86_64_windows": {
+      "etag": "0x8DC5561407808BE",
       "checksum": "22ee7042ff2e0571ef65a5a89f322f8207c73e297840e73d174f3e9490bce7d6"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC556118B4268C",
       "checksum": "a88c56940db6dc18d0c75cf77b9f342134b85fafd13707ac1fddde9c5c9aa6bd"
     },
     "aarch64_macos": {
+      "etag": "0x8DC5561685EC821",
       "checksum": "bf4bba9e1490dae056335d99b13bd3ef8497bd8aa53970dbc2a9c733b2220db6"
     }
   },
   "0.6.8": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC459BCEAD9A74",
       "checksum": "2d655a09eb0dec705e1ba6be73b2cf81a85d9eed27b8190db9cbc0af7a3030ca"
     },
     "x86_64_macos": {
+      "etag": "0x8DC459CBC53F163",
       "checksum": "076982bc15cd6ebd2d96102a489fe5e2aef981318ff6cd3076a555c77c793f8d"
     },
     "x86_64_windows": {
+      "etag": "0x8DC459C14E4C638",
       "checksum": "911bf8162e13c9bfe73d65f608874d300dea6f4c7a49d92ee9dc530bfee858e4"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC459BD471FA1A",
       "checksum": "a68a0a2082de3118959020616d3112664882afd203379a098b35c5c676200698"
     },
     "aarch64_macos": {
+      "etag": "0x8DC459C7D0A8CA8",
       "checksum": "27aae20fa89be1e4d3540248eb547b710e6836470dd1ed2bc2d4ac145c0875cb"
     }
   },
   "0.6.7": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC40F2DCF84CC9",
       "checksum": "6204c229d533f164fd6d126fe7299f72b58e456a373ee0fed56ec45ee437297a"
     },
     "x86_64_macos": {
+      "etag": "0x8DC40F364FABEEE",
       "checksum": "a8174bff663399a56a7a393cb2518a81fa1f14717079a7970846c869714cb96c"
     },
     "x86_64_windows": {
+      "etag": "0x8DC40F3038072B6",
       "checksum": "dfb37144a677f0c97087aed92fb71658b62ab8f92c38749661f3f7cdd76afe00"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC40F2E0F66A10",
       "checksum": "87e751a63c3b45163aabdd2b46111aaa08ba4d57b5675d307cd637cfa98031bc"
     },
     "aarch64_macos": {
+      "etag": "0x8DC40F32ACBD3F6",
       "checksum": "307463a3e09eaccd8fa58d5d7005f4fd4befa8c8bae902655cb6567f5cbc6a6d"
     }
   },
   "0.6.6": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC336AD6BA318A",
       "checksum": "554b2dccaf64dacd0388fab1679fbd96ec503d611e6c84f58ba366c5246060b1"
     },
     "x86_64_macos": {
+      "etag": "0x8DC336B6361CB55",
       "checksum": "05650bbb58915e0ba4c0a05978fa832ee87e5f5c256981d066d27f8d7e9f743e"
     },
     "x86_64_windows": {
+      "etag": "0x8DC336B04F440B0",
       "checksum": "dbf7f55962dc3db12b96707b08af67f46284df6b2215a1c58a154ad92284d514"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC336AD57563D1",
       "checksum": "38f00c7b23455d45b829a019ab976b58920defaeb48976936363fa41602c4a50"
     },
     "aarch64_macos": {
+      "etag": "0x8DC336B60B69D03",
       "checksum": "27118cc06ce28bb4ae455aabfdad11a69952483b0aba23d53de9ed73148285bc"
     }
   },
   "0.6.5": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC27FA89981E81",
       "checksum": "c195a8f4fed924beb969ecae324a278db011e7a3877a6495a1d3701cdddbb3d4"
     },
     "x86_64_macos": {
+      "etag": "0x8DC27FB0C3929F2",
       "checksum": "934294f33e41d5cb787f7e9ad4fa4a40551281b0ab6e6ff58adc1b16cb12e60b"
     },
     "x86_64_windows": {
+      "etag": "0x8DC27FB0EA54E13",
       "checksum": "f55f9fe3a5cb5258fb5927b4b9b99899dd5b7b3233570ba31b5212d46ab12825"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC27FA87BA0598",
       "checksum": "1af0ebd20c858e03599ff1c7ded0a95a506653bd88efccff00088b7d3de9a173"
     },
     "aarch64_macos": {
+      "etag": "0x8DC27FAFFA056C5",
       "checksum": "954c61e2d2ea2ca60e2562b93d166f43b05243cd8aaf5b0a341f06af62531125"
     }
   },
   "0.6.4": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC1DAC32CB613D",
       "checksum": "ce41260f7359695a471a936ff8f101334918dda52cc9860ac2bda9c2ed2b72a1"
     },
     "x86_64_macos": {
+      "etag": "0x8DC1DAC86EF7236",
       "checksum": "aa0d329125318a2eeb082131eac7109be7c31adc093da790a7b98dc5da80a777"
     },
     "x86_64_windows": {
+      "etag": "0x8DC1DACAE9E87D3",
       "checksum": "617c4bc210609392b342117d295ded9d5931399e6e767be0f388c4ab605a2c67"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC1DAC369D4B08",
       "checksum": "a57681b63815c2cfa7113854eb95e234575d974d3065f4533512b1163ed2de18"
     },
     "aarch64_macos": {
+      "etag": "0x8DC1DAC52E0AA2C",
       "checksum": "0649b4240ec2d4d0987f43f490c91dfd75a3212007189e051de9a43e3898c683"
     }
   },
   "0.6.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC1CE022D2F3C6",
       "checksum": "9a90036a649398525bdb43cd3d9442cd73e8ee182561cf487c8e686c7c610e1b"
     },
     "x86_64_macos": {
+      "etag": "0x8DC1CE0DF5AC364",
       "checksum": "9da061e9c5b97b9411e6b48d5153f245a8aed8de149cbb307d74de214b88c813"
     },
     "x86_64_windows": {
+      "etag": "0x8DC1CE06526D062",
       "checksum": "7ba076d110b9d9c86ccec51a3e5df6bbc8aebfb5730633ada421848ed4eea8e6"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC1CE01B82AEB7",
       "checksum": "727a85fc67121ce68d6351f0767305cd0299539fedc17e2cc72fa11839be38d0"
     },
     "aarch64_macos": {
+      "etag": "0x8DC1CE0CF884161",
       "checksum": "0cb3aefd698f833a526fe7a55e321750857cde3e357ba4d43e34e5f5556fb43e"
     }
   },
   "0.6.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC1833AC375D9F",
       "checksum": "c239a26343783490aed4fab04c1ad9953e6dad1d073f52b513e4f6cc45649ae0"
     },
     "x86_64_macos": {
+      "etag": "0x8DC1834680BB228",
       "checksum": "282321bbe5bc9476987f42a1d10ace27b0bf6c65c46ec9950997fcce1ec39134"
     },
     "x86_64_windows": {
+      "etag": "0x8DC1834162C1535",
       "checksum": "a4d9671e177ce8b29b921b115741e0f960defa33db9e7ad084ee682e043c3598"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC1833B6B8F151",
       "checksum": "8d02f6ac03fca8134c585291850b13924b9113c0ba9e1e3b8e3d745b987021bd"
     },
     "aarch64_macos": {
+      "etag": "0x8DC183460B18B1E",
       "checksum": "12589f9e99b4e1755752b01f22f72e1375c9d3291dcbeddbc24ff13f83f57714"
     }
   },
   "0.6.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC13FD0F85BADF",
       "checksum": "e9764d62e9ce17e89dcf0332c8f99a4680722ef66b1bd147694ae53e622cf73a"
     },
     "x86_64_macos": {
+      "etag": "0x8DC13FD84345DE5",
       "checksum": "ff68ba09dfb93dfed0e89539f0c0ef20f71803725409a03122bdd61735e71c3d"
     },
     "x86_64_windows": {
+      "etag": "0x8DC13FD468C325D",
       "checksum": "93c18eaa511823834bbfd253ecfc84b869e5c61068d471071f55c30035bf1de9"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC13FD115B7768",
       "checksum": "9359307d5c77e2e7fe9ddf3d0fd46f5e377a5a4d25fd860115ed2a23a434452d"
     },
     "aarch64_macos": {
+      "etag": "0x8DC13FD3AEB7A91",
       "checksum": "79d07bc755a67dd1cbcf462f8eb4f967571fe1b48927235a270dae42a7bdc248"
     }
   },
   "0.6.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC078E4E545A9C",
       "checksum": "2f07927e63bebd70bd13a72299e1a1293ef93c783996297bcd7133ddb86a4232"
     },
     "x86_64_macos": {
+      "etag": "0x8DC078F0A5A73BE",
       "checksum": "c1e4dfa1e7b7429fc56a6d477457572067988f9554a54371eeeb232416cb6197"
     },
     "x86_64_windows": {
+      "etag": "0x8DC078EAA74CDB4",
       "checksum": "321d3e0bd365f61547b78335a71e99f746c2a8f3f8a0d99a70d2b0f55e443b50"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC078E512B70E3",
       "checksum": "ec301c6005501939233342e01789271ee796b2582ca1260f7b016f142bad530f"
     },
     "aarch64_macos": {
+      "etag": "0x8DC078EF7C0D411",
       "checksum": "b3117e7b000ffa41a0261b93b9f80b93f1f7f30b06f782600e97ca58d42683cf"
     }
   },
@@ -216,681 +271,881 @@
   },
   "0.5.39": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBFE36A5BD2C11",
       "checksum": "e2411273e3151383432ec3f7fa1dea89628c9396a4b2077a3cd2ef0adb217a40"
     },
     "x86_64_macos": {
+      "etag": "0x8DBFE37F636B1D0",
       "checksum": "683c5fffab903cdac56c3baa0d319bbedb8983ec69c5839116caed1ffef176a0"
     },
     "x86_64_windows": {
+      "etag": "0x8DBFE36DE95C202",
       "checksum": "2ad67e0a14c1ce7d105127bb1358249b2d578caa2c9c4c70aa4e512eaff4f8a9"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBFE3693032DA1",
       "checksum": "b996cc9ad2979fb8e616ecb37be0dc27c5ed00df52ca7b8e24a3a9d9cfd7029a"
     },
     "aarch64_macos": {
+      "etag": "0x8DBFE37BD5B60AD",
       "checksum": "22042580bcf6797f92a1e458cd03bc98c107adf9c47b39af2d021309b263ff60"
     }
   },
   "0.5.38": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBFBEADD1F4CE3",
       "checksum": "f8820fc550b0d9e78865c0245e7a63ab5b5c88a8825d7a9bdd2e908fd4737317"
     },
     "x86_64_macos": {
+      "etag": "0x8DBFBEB5BCEB9FD",
       "checksum": "1411bff8ac7dc0338f6d687312cf0d8a2b43623fb41692bfb1536e3fe99ea8dc"
     },
     "x86_64_windows": {
+      "etag": "0x8DBFBEB1B1CDE35",
       "checksum": "2b504ac7a3c01a6233dedb4ad28e9103c4de207cdf6440fdb1ef7e929cb78216"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBFBEAE2C0432B",
       "checksum": "6f359baa623e5d98099ab1978e3d5f06bab0d006735fc262056be87106e37575"
     },
     "aarch64_macos": {
+      "etag": "0x8DBFBEB5658E933",
       "checksum": "cf32270e4e9203bfc72a85d514b16ce1f842142cb9adecb2b66e159bee61017f"
     }
   },
   "0.5.37": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBE70F2B27146D",
       "checksum": "3444cd1604eae4e2aaf7ad7be7ebc5be2fc3571000b900e41a63e2fc64ebba5f"
     },
     "x86_64_macos": {
+      "etag": "0x8DBE70F6FF0A01C",
       "checksum": "7662cd747762b6d8e131997b153acf4137f6f35fc3929be1f4db2f1ad4df115a"
     },
     "x86_64_windows": {
+      "etag": "0x8DBE70F1AD19FA2",
       "checksum": "dd2f7624ac0fbad43b927e684fa840d9d76c3a17af0e58ed3acb5e95fc56c9da"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBE70F65B6472B",
       "checksum": "e1ff7c522dd0df727e8af7e83f726094a621418f33ad0da0d49c66fabe76321e"
     },
     "aarch64_macos": {
+      "etag": "0x8DBE70F6A4E98F1",
       "checksum": "cdea4c173930aef177768c6f1ffb928e578ce46a765df0e7c5ebd69bdceadf4a"
     }
   },
   "0.5.36": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBD9885F3B88D4",
       "checksum": "48083f2df7030ac1f5567d2e4155aac71115bc81432da6a97c35b603f8f9d1ed"
     },
     "x86_64_macos": {
+      "etag": "0x8DBD988B7ACED24",
       "checksum": "bcf604c0eb65818e8a3b7b004f45856ef9ab6f0a1c6621c8f3c029e44050f601"
     },
     "x86_64_windows": {
+      "etag": "0x8DBD988D14323CC",
       "checksum": "b5e6f0cfe3e7a5a7470664afac705b55b233a7c3cfa9dab007c725cd94ba0565"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBD98864CC4081",
       "checksum": "3f2e9339d505bb330fcadee6a3a8fdfe69a8490bbdc0858ddc152142be8f0b77"
     },
     "aarch64_macos": {
+      "etag": "0x8DBD98887C80013",
       "checksum": "36f431920be39b719438a0a60a568852e2bcfab79db395caf7f77da304451bda"
     }
   },
   "0.5.35": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBD0032551556E",
       "checksum": "21e7d42185f8eae113508ec2b8c3bfdd22c6293bb6b0ccd74ab0bd21153dc3b4"
     },
     "x86_64_macos": {
+      "etag": "0x8DBD003788648E1",
       "checksum": "dca22baa597f337ee78f5418b19bb2367108da77cb430be30febd55901537a2f"
     },
     "x86_64_windows": {
+      "etag": "0x8DBD003B875002A",
       "checksum": "45b21cd8b0f89b6ee5ad3093fcb542cf8c41ce86e36e89b7a26166c9f7792e47"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBD0033207A088",
       "checksum": "56c69758d6bb493dba53a2ac21343a983d22ca677d9ecfe8a4bb66fd185013e8"
     },
     "aarch64_macos": {
+      "etag": "0x8DBD00341A0B5E9",
       "checksum": "28525454f2fe26ad8eba301134aeff305348b4e143ebdb62f07f2c93db1eb347"
     }
   },
   "0.5.34": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBCF16CCC3A735",
       "checksum": "2d312925ea2178de060b5628c899f44f6a162ce621a87de8c3aa0658573f9641"
     },
     "x86_64_macos": {
+      "etag": "0x8DBCF17A95D1012",
       "checksum": "f36ffdc068216d65618bced4213177a22f9fae8539070acdff4b84757940c98f"
     },
     "x86_64_windows": {
+      "etag": "0x8DBCF16F01173C4",
       "checksum": "62dc60bfb3cde60e59840c72caafe698dfe0d01c63544a31df1d8c40fc924906"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBCF16A76C7360",
       "checksum": "96ea303a801f640a205c3e53bd240ee22c51e02a4feb90ab879882ed9b774247"
     },
     "aarch64_macos": {
+      "etag": "0x8DBCF176642C94F",
       "checksum": "81eb3dc6dec49c1eb1a9eb5cbdd40395dbf62541be655c4df3ebb09276a5c0b1"
     }
   },
   "0.5.33": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBBEB6E4E3B6D8",
       "checksum": "3274fb95c5d7ab7dd37db6b75e77b666c6fc06b0bd0172e7923af95fe77711da"
     },
     "x86_64_macos": {
+      "etag": "0x8DBBEB7310EBA46",
       "checksum": "e890a29534e8a10439bd8c8fccd39867d2cb016f82d7b51e615c60caf67491b7"
     },
     "x86_64_windows": {
+      "etag": "0x8DBBEB7062A2448",
       "checksum": "332004d47ad0259fbc077c3dde2fe7f7b51dadcea859ccc33759bc149a38b777"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBBEB6CE029C9B",
       "checksum": "dd6deacc791de61dc31e45537bf2e7c9c8c652f51e06357d4a700ec7e81188c9"
     },
     "aarch64_macos": {
+      "etag": "0x8DBBEB714E846D3",
       "checksum": "8bc5722370884500381eae586910b633f2a215cd5b5feed31d67682e90bd8412"
     }
   },
   "0.5.32": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBBC282680AC69",
       "checksum": "2709f1c132eac8c3e1e98f658e2f8fd79f71f0a72b373491aad9e92df3b6684c"
     },
     "x86_64_macos": {
+      "etag": "0x8DBBC28DC049EA3",
       "checksum": "d56c7b8d5ea02196b8682d242440a400566583f724dee9c9832a99ed9734fa0e"
     },
     "x86_64_windows": {
+      "etag": "0x8DBBC28729FEB79",
       "checksum": "194ec6f3657edab3c5f9a4d7a5bb2ab614084d7484f69274d02798fcd2dbea0c"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBBC283890F7DF",
       "checksum": "2274d691284e4de55fa0a0fd4e7b5003db21f7c62d72986586a81a169cafd7ee"
     },
     "aarch64_macos": {
+      "etag": "0x8DBBC288438598F",
       "checksum": "7893b26db568ce0c606c0b07cad52659abf2ee488d385581e166fa20924168e5"
     }
   },
   "0.5.31": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBA4D376A8A54F",
       "checksum": "f3814f9446f441c8b280ca93ba5aaf211295a6c8363d52e03d7e700808e6692c"
     },
     "x86_64_macos": {
+      "etag": "0x8DBA4D3837908C5",
       "checksum": "9cd643daafc0e868c5c284a68cefb57fbc3bb2a11e8c59e54e738168bc691126"
     },
     "x86_64_windows": {
+      "etag": "0x8DBA4D3D77EA5D1",
       "checksum": "392cb5e11eaebd21f7ae865807837d0ab54df86e7ab5f98d3bf5b3cda65fea93"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBA4D379660E5D",
       "checksum": "0261bbfa0bd49964ca3dbd3041ec3fe5b23efd62b51e794bf516cc964af24079"
     },
     "aarch64_macos": {
+      "etag": "0x8DBA4D38A7E6385",
       "checksum": "9b7e2cb8fbc6694c2a0fd2abb7867108447c39350ca0fd3688a1b991877dff69"
     }
   },
   "0.5.30": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBA3E8C7447517",
       "checksum": "6731e8d7767145debb825095ab3ab7b9ab25cf7f5a10d22d17c1ef4566fbf249"
     },
     "x86_64_macos": {
+      "etag": "0x8DBA3E8D9B4EAF0",
       "checksum": "9f634e2bed2dff89ec21177daf8abc1d55c1cca07e73d52f70b796f63a7a3d52"
     },
     "x86_64_windows": {
+      "etag": "0x8DBA3E917E59869",
       "checksum": "60dd774010ae493d17ca052f33d4976f5fe13e462d5b0f731a6c5e39de7475e8"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBA3E8CD1ABE47",
       "checksum": "87718e164f6206fe4b2cf9b600bcafa1b582f22509820147f1060569e1d9217c"
     },
     "aarch64_macos": {
+      "etag": "0x8DBA3E8D06BD30F",
       "checksum": "58d6295dffafdb920a1096635f9dd5334e5911d3e27cd7bccb0d2d9f99cc86b2"
     }
   },
   "0.5.29": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBA3D8D9696B7F",
       "checksum": "963ef54eca8296c4c112f0453b9bc36e5103ab1bee2b272abeb1e3474ae4aab8"
     },
     "x86_64_macos": {
+      "etag": "0x8DBA3D8CC47E0B6",
       "checksum": "be124539c0a1cc99124b28bda4fa916b5189a706fc975add13c4299f74d31237"
     },
     "x86_64_windows": {
+      "etag": "0x8DBA3D8C42FD5D5",
       "checksum": "ac70d70ac560a433276b6037f684044fb66627a8ddab38fe999599951d075845"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBA3D88A8D9D35",
       "checksum": "5865b9f03bbc6684731eaaa2ae512bf85dc11ee409e25e77882f4183af1ac03d"
     },
     "aarch64_macos": {
+      "etag": "0x8DBA3D8A730B234",
       "checksum": "e05bf23c4d8b0af4b3127e10cf3484ca107e32a808e1cab48e417a14d3542edc"
     }
   },
   "0.5.28": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBA32EF9560E21",
       "checksum": "2e615725d904a4372f8613b8fc2012f392e22e8ce1190b3ad38a63ef25958f9e"
     },
     "x86_64_macos": {
+      "etag": "0x8DBA32F2998E3AD",
       "checksum": "56cc1e4c456b560608edea0871b7d5c0f6b61abe2eab6dcfdf66ef5dc32849c9"
     },
     "x86_64_windows": {
+      "etag": "0x8DBA32F367BDA1B",
       "checksum": "60d1c6253a6ac1d33127d22f9520237229422f9c91102e02134d9ec2f40d21fa"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBA32EF198B6CB",
       "checksum": "a944fb36384a8baf9625c26f5232a82e344be38075be9175d50acf1128c418e3"
     },
     "aarch64_macos": {
+      "etag": "0x8DBA32F025C29DD",
       "checksum": "035f1d632073d90d4b7986e9392b6659552d83759e154697d6032d2eb5fb7557"
     }
   },
   "0.5.27": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB9CD7483A7976",
       "checksum": "74e554fb069ee0410422158d293f91eddf1f126c59801df5474d79c39c6c63af"
     },
     "x86_64_macos": {
+      "etag": "0x8DB9CD751776C30",
       "checksum": "8f86128ef90534f1ccdb033ec05f37447e5861eceacb12871598a9f7b1097a1d"
     },
     "x86_64_windows": {
+      "etag": "0x8DB9CD78B28FE26",
       "checksum": "f9f0eadbe325594dc5b45cf226fa8c738635539a6a93fce39783876c0f6b4344"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB9CD750CAB05A",
       "checksum": "20161f2a1f8322ec98281bd818219a9c9cb4744b2dbe95bf073af29b1e47cc83"
     },
     "aarch64_macos": {
+      "etag": "0x8DB9CD7524A22F9",
       "checksum": "43ad8e2bcd3a394f08c6e1582253ea759b611b0b94774933b7ebcc91a23f82e8"
     }
   },
   "0.5.26": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB9B412127983D",
       "checksum": "9284d4ff91e76a12186670a370ecd481e0ef430f077d5258b7c45560fdce2a1f"
     },
     "x86_64_macos": {
+      "etag": "0x8DB9B41508A77D0",
       "checksum": "9972f993cab0668ee22c1b1cec6c84b00e810ba56c1479122751dd23a9fd71df"
     },
     "x86_64_windows": {
+      "etag": "0x8DB9B415FBD0163",
       "checksum": "f60ad6861037cd98cc5f9ed640f5bc347188ca4053956dfdc544d4259518ee29"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB9B426814D21D",
       "checksum": "0bc7aec3aa09c638c0bc153170ab1f60802057ce9037c6febd10941e5751dc07"
     },
     "aarch64_macos": {
+      "etag": "0x8DB9B413D2B03F8",
       "checksum": "99864fc0f04d337a9a77fd24b89a6e9325381b5f7fb4542ce5e4a2ad2c12363c"
     }
   },
   "0.5.25": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB965DB9A70432",
       "checksum": "0567e6b651bcb819afcc2cc8f49f18a74c57ffba0aa9a2640b313c5f2568ea1c"
     },
     "x86_64_macos": {
+      "etag": "0x8DB965E081134B6",
       "checksum": "7af62464a39cc9732567ba2b3213c19afe85b20f0ffd7e70ba56cd7bcc78e661"
     },
     "x86_64_windows": {
+      "etag": "0x8DB965DF95496AA",
       "checksum": "2b91db2b1b329f700337d5ec2323e969527644f3761cc1ae7a4a94a9faff2d0d"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB965DC64E17B1",
       "checksum": "a16b7950746dd8d764479289ac48cb06ebc156e2a750c595b95589a68342bccb"
     },
     "aarch64_macos": {
+      "etag": "0x8DB965E04A34357",
       "checksum": "db6d159acf27ca7d6f148fc5604dd9f2ff39da163f94d9a1c37c3f063dd664fb"
     }
   },
   "0.5.24": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB8FA0BFE471D0",
       "checksum": "e1c15ac5a583eeb4c478eed0222c3a3629aff3c9f151d8bdf7b50704ef9073c6"
     },
     "x86_64_macos": {
+      "etag": "0x8DB8FA1892B2EC5",
       "checksum": "c12b25c44fd1b1b76ecfff7ca1ed4a29b2ec6f9c707f0d09a8716ea7513a557d"
     },
     "x86_64_windows": {
+      "etag": "0x8DB8FA110448261",
       "checksum": "e4221c57b1cd759c0c659f66673f0fd5a03a1a8d2f3c95462b9af966273301c6"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB8FA0C0161F5B",
       "checksum": "0f3edd524e10b30c26c6ef7ff069843e89a75441c5f281254c2e65e028ccf29e"
     },
     "aarch64_macos": {
+      "etag": "0x8DB8FA13C72CEB5",
       "checksum": "0d90b623b4dfa4fe631aaff13b891096224346ce907f0dbd61ae9276717f1bec"
     }
   },
   "0.5.23": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB7EFC46BEF5DC",
       "checksum": "cdbb1c34bffeb2b5b986f16e3e1dd08c01d9ef2cbd1cf2d989ae7a184ce91302"
     },
     "x86_64_macos": {
+      "etag": "0x8DB7EFC7698289F",
       "checksum": "e87ffd34514d23b5ce5d70e62eaff51c8a56308fcfea5d2df1cbf7a4930883af"
     },
     "x86_64_windows": {
+      "etag": "0x8DB7EFC786D70BD",
       "checksum": "3b0885d80a5d33c687331628adca4307cfb5d80a3d76a344ebf1077e504da08e"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB7EFC64C92E26",
       "checksum": "5ad1d9b56601b76112c2555289763b88e0aba57b5188c7cb0b7e0c9f17141590"
     },
     "aarch64_macos": {
+      "etag": "0x8DB7EFC494C85FA",
       "checksum": "bfc30b8d89cf3b477caa8b4eee89bc083d8a3649e57a88eaa7a3a4948e5eaa0e"
     }
   },
   "0.5.22": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB78C151611D46",
       "checksum": "6a3f93f12e93853844dfa8b697ff86aaa688b9f44b82ba75b3f4ddd8905f3de5"
     },
     "x86_64_macos": {
+      "etag": "0x8DB78C1AFAB33E7",
       "checksum": "9860cd3df6947817b689772d976f03f8b4edddc98a7d000a36d39d286c2ef663"
     },
     "x86_64_windows": {
+      "etag": "0x8DB78C170FCAB52",
       "checksum": "c5cc93820d54c83fda40251c3f7a06a89de4cd0a5bc330208b5c7220c3bc8890"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB78C15DB1C14C",
       "checksum": "bcf7cf97bbf49932b6cf43554a2ebf7ed9d50a54c16b0b33cd95cbc90e66008c"
     },
     "aarch64_macos": {
+      "etag": "0x8DB78C18E2EAB74",
       "checksum": "c2b702c10a033edee94fbff3b62d0e248932187431fea1b02e652762a0ae2c8d"
     }
   },
   "0.5.21": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB78ABA8922512",
       "checksum": "bd23aced73f17c2178569c058f6cd78478cb38b233c45660eacab853b42353d6"
     },
     "x86_64_macos": {
+      "etag": "0x8DB78ABBEDD9F15",
       "checksum": "d56ee6a72d496f86d8a387da9c5f66a88fa4dd568d822a0c78c4e3c6b901fdde"
     },
     "x86_64_windows": {
+      "etag": "0x8DB78ABD2F0EAFA",
       "checksum": "94f0cf996f63e5eea5ef908bb7bfcf2df1eb6f12508d7e5a435a5f8bfb9a4238"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB78AB89D91A3A",
       "checksum": "6b3f727af761400bec3a6b7043e228722060fda045fb68d05a33ed28befa39f2"
     },
     "aarch64_macos": {
+      "etag": "0x8DB78AB8C458B13",
       "checksum": "4572ef983631d461088a658f9d0fffe0a66ee2584b1160deca7fb48e91823b34"
     }
   },
   "0.5.20": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB63909AFA2BF2",
       "checksum": "688aefd7b53917d29b3fa8d81cb449e98138c6b9a6c768eff412f9a523fd3e62"
     },
     "x86_64_macos": {
+      "etag": "0x8DB6390DCE27D0D",
       "checksum": "69eb20beb8a2d2f455bd8be486f92718645fa94c726751698c125f92d11bbc54"
     },
     "x86_64_windows": {
+      "etag": "0x8DB6390B709E46F",
       "checksum": "e69502d1fa9003cd50d003142afc8398a84442b630cb2279b6291dde65d66ac3"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB6390AF0AEA29",
       "checksum": "dee687b786492b3402dabda190e9444f4e4f5e412d0e1ce7d541dd1d5d519243"
     },
     "aarch64_macos": {
+      "etag": "0x8DB639099469D61",
       "checksum": "5ff99c8b17dafc24471d0e498cd68f8c858a6dc613535f7ffa738a12e11b18cf"
     }
   },
   "0.5.19": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB480E1CC37D4A",
       "checksum": "79129f4adf9b9dd239a7facd041630a6b29c123a3e0ccabfbce44c71d391fc17"
     },
     "x86_64_macos": {
+      "etag": "0x8DB480DE99CEC21",
       "checksum": "ab5400be7319b519350e535a71e210197c2597d416beca2c839676f2a28804ae"
     },
     "x86_64_windows": {
+      "etag": "0x8DB480E067002B9",
       "checksum": "88f7dc8155d9166f512e1ca2d3dc986a987c7bb145f43836dee0246eaea1db9e"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB480D16CB4283",
       "checksum": "6e5f19e65646b2625bb820d00065081d62bd19f6d483054b1b43a152678f13a6"
     },
     "aarch64_macos": {
+      "etag": "0x8DB480D6B555BEB",
       "checksum": "fb8aeeb7af828ab0b49462cee13d60f1d7c69d55226ec0fc11c3082004a08513"
     }
   },
   "0.5.18": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB45947FFDA47C",
       "checksum": "eb5db22d1c4e67913d983145fd8473edad8f84b60b08398b634b275ccf1ae324"
     },
     "x86_64_macos": {
+      "etag": "0x8DB4594CD7513AF",
       "checksum": "05621b99740a9499ee5336cec4fff63ea69aa5a731e29574b71d7c54baa849f4"
     },
     "x86_64_windows": {
+      "etag": "0x8DB4594B4B2A361",
       "checksum": "d0330a9c9a03c8fa49e755d6ae5a62c4a6faabaca9cecb343f4b3de8ed2b6e8e"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB459499DA32B5",
       "checksum": "c63c77048047aa14f43bb5d266e5eceacc510c551fb17c8968b2f8887516bee5"
     },
     "aarch64_macos": {
+      "etag": "0x8DB4594A0745113",
       "checksum": "d766e832e4b01808b0359a0241c14141be010ec2b0e79e19d5e05c0746969c8e"
     }
   },
   "0.5.17": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB427A5FB1297B",
       "checksum": "20b563871c1ac1a83ae5683dc97fa0a1bf15ca16407b3daf751dbf652ecbea95"
     },
     "x86_64_macos": {
+      "etag": "0x8DB427A6CA0D7AD",
       "checksum": "1f089884ad5c367015971166b8f752717eb70980241ce0125da86f4044547939"
     },
     "x86_64_windows": {
+      "etag": "0x8DB427A77B5C6BA",
       "checksum": "94b7122c70a53072a6d4c51040cf0093207d40151a21a28b12040e8a21bd925f"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB427A6BFBDBC6",
       "checksum": "83ce55e7df193d86e491e5f911a63e4123e9fe182bfd89eed273d3753208190d"
     },
     "aarch64_macos": {
+      "etag": "0x8DB427A5A2297E0",
       "checksum": "cb5d1f1c700a7e1069898714e82005417a07d5455ca93fc3278cd0e5340338e5"
     }
   },
   "0.5.16": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB4040080973B0",
       "checksum": "d7759f9d465907f4a8fa24f10bfa0817863f62c412ffaae7b8dadab370201f9b"
     },
     "x86_64_macos": {
+      "etag": "0x8DB4040FC3B846A",
       "checksum": "67f720d403569e7fa69ed2ed74c90d06658dc713c0f1f60088f12af267db5c6b"
     },
     "x86_64_windows": {
+      "etag": "0x8DB404030B70A83",
       "checksum": "d19af20d0e4688f2557024fe84c6eeaddf3e7abcb9fb45304a9d042dd155d1bd"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB403FF1414F6A",
       "checksum": "f1055016db604f346d351d16fdb3ae43d7ab7ebc31e4463b836daa990b17c78f"
     },
     "aarch64_macos": {
+      "etag": "0x8DB4040CABDADD9",
       "checksum": "db2780cf7af86b50ae011f49c4a91f2da58115ff47835a96dca134de2bd60c7e"
     }
   },
   "0.5.15": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB3D88B30ED485",
       "checksum": "407b0ddf85e6a39dfe5379761fc1074c7e79f7b518c732072bda1e4fc854d0fb"
     },
     "x86_64_macos": {
+      "etag": "0x8DB3D88DC022DB4",
       "checksum": "71c6d3010f8d08ab45b23e3459a751d4f8afeaa96f1537815f3cc9f96c4cbef6"
     },
     "x86_64_windows": {
+      "etag": "0x8DB3D88D4C27BCB",
       "checksum": "8de32cdcb14a4ca1fabe5dae76761bfa73890fa070e935a4628f0ca8ac050759"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB3D88AE62C4CE",
       "checksum": "93cae63fb000fbe327a0f5e8caf6507f9d6c9fdf6775c248968ad977411d8f51"
     },
     "aarch64_macos": {
+      "etag": "0x8DB3D88CADC9ED6",
       "checksum": "6286e6e73bf505c67b23d47591f6f05e5f5feba809442a6a66d1b7ec3fc8a93b"
     }
   },
   "0.5.14": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB35D9426DE2BB",
       "checksum": "688e56f78611f7866842f5b86e27672225b28c8a536c75d6c0a3fd67082474ea"
     },
     "x86_64_macos": {
+      "etag": "0x8DB35D98B61A33C",
       "checksum": "8d4a93175d5ba0710a46ccab007444cea4c53406b4c0b6c6ae6916d1192ac333"
     },
     "x86_64_windows": {
+      "etag": "0x8DB35D95B1CC5E3",
       "checksum": "5773b119db63bbbcb975ecd3e0c71ae548506d85312248d6d3e94758cf88bba6"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB35D93B6E9B36",
       "checksum": "61b22ff22d95ca6af9c668c780fe2a23a519a44d1fab3de01adadfbb36cea54d"
     },
     "aarch64_macos": {
+      "etag": "0x8DB35D941C33C97",
       "checksum": "f98c5d4bc2f7b67328a82028bb78f0a67436ae81a4e2a7911fd4f18f572c434b"
     }
   },
   "0.5.13": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB344DD5604209",
       "checksum": "e57875cba95527149d15d7f9c66b9d624d8154040f19aedbca96e2c6b7687ffb"
     },
     "x86_64_macos": {
+      "etag": "0x8DB344E0979062A",
       "checksum": "f694bcaf714f352b76182b0aeec9626ca5280ceca275f949caa762a561030350"
     },
     "x86_64_windows": {
+      "etag": "0x8DB344DFD5BBDDA",
       "checksum": "642046071c3c221748a3a6a08b5c7d71d7644928d4d7707fa30b38da8357f074"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB344DCA3796A7",
       "checksum": "d9173b2aae99f29276cd7d84ffdea9eb29f8831acd3f9d9de1c2af4366d917df"
     },
     "aarch64_macos": {
+      "etag": "0x8DB344E21784417",
       "checksum": "b9bb4d03065c4d7e52ed4148d71d36a4c890dee37108addfa9ba19771e46fa1d"
     }
   },
   "0.5.12": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB33BD24F79C79",
       "checksum": "998b1d9e630295459743fe7051a7e3d04e82836456171493eb5983dde710b07e"
     },
     "x86_64_macos": {
+      "etag": "0x8DB33BD2F32102F",
       "checksum": "77faedad91c300b51d2d40040a6c61903a555da319047983ec56c81598cbea9b"
     },
     "x86_64_windows": {
+      "etag": "0x8DB33BD5CC0EED8",
       "checksum": "5d0d3df674a431272f75e77dd2c07fdbc5ee83ade11c0839bbd0fdae35480351"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB33BD24FCF2E1",
       "checksum": "87c54166055d2d486620ceb27440442d34d71b364fdd6f6da57a210ae5f75e33"
     },
     "aarch64_macos": {
+      "etag": "0x8DB33BD1DB75CC1",
       "checksum": "05c8f8e2210a3218b167dce33477785a0bc0c718fac7b15d2f4a428791234f03"
     }
   },
   "0.5.11": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB19B004ADBE8B",
       "checksum": "3bd355e29b8e29d0b42f0c95ec487cd8e00ffa419ba65b83968740a641a46c1e"
     },
     "x86_64_macos": {
+      "etag": "0x8DB19AFDF1C3645",
       "checksum": "fe0e54836a367697a1b475440af2e7438e56caf6e548b88faa88edc221a515f7"
     },
     "x86_64_windows": {
+      "etag": "0x8DB19B03636CBE0",
       "checksum": "528202a08b47ca579722db1949da2362a7f03fe0ea84a45d6679dc73d33603e9"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB19AFC9212E2A",
       "checksum": "479f51fac713151f73ee0ab5d7cb1155646cde17903dfd7c526cd51253e99a4c"
     },
     "aarch64_macos": {
+      "etag": "0x8DB19AFD5A64C84",
       "checksum": "276d8fa70299ec9ae014cab905cdbd614d6bddfa6abcc414492091585dd55ab5"
     }
   },
   "0.5.10": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB15B714029C89",
       "checksum": "6ff31ac54aacc133c8d462c99b353dc31924aa9d0bc088ffdd8caa8cc7a14be4"
     },
     "x86_64_macos": {
+      "etag": "0x8DB15B717FF7371",
       "checksum": "a0924478bfd7a62711d8e9186470dfbb2a00ed22dba704bcd98f65dc41fd5ec7"
     },
     "x86_64_windows": {
+      "etag": "0x8DB15B75C0FB8B5",
       "checksum": "3504347f7bdde8fa7c73e938c3cbce5397418799f9125ee3729e7168e387e5c0"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB15B71270779E",
       "checksum": "c395bb8834c779b1bb5a2e0d8302eeec1ef389ee980b47b21f4573181c769786"
     },
     "aarch64_macos": {
+      "etag": "0x8DB15B70B448303",
       "checksum": "3935ac3f3e4af883f698d5e41dae9b3d248ce0a606b0520b739d5e967d78a10e"
     }
   },
   "0.5.9": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAF7538774CCC1",
       "checksum": "aadde3416c86403f72986f6c68001d2a46497ee8892f5affdb6b681213b586a2"
     },
     "x86_64_macos": {
+      "etag": "0x8DAF753D5D86330",
       "checksum": "7f7d17223237cc2ea65a4cd2d3ea0f0868711bd44dd56ee35839b41202b08685"
     },
     "x86_64_windows": {
+      "etag": "0x8DAF753A5BB6B80",
       "checksum": "efd986565868a0f1a255af9b913e77b95eb77b49940a93dde4e2c88874f2da39"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DAF7539499C7FB",
       "checksum": "d6d539c038a07c12e04954af3357afadadf92ca3eacf5a155eb555b47d3b1ca4"
     },
     "aarch64_macos": {
+      "etag": "0x8DAF7539CABF3D5",
       "checksum": "4a023a922507d8a63424cb4b3d98c695fc2a66f8596b1e93b3a573afc2a384c5"
     }
   },
   "0.5.8": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAF6A539D4C912",
       "checksum": "78a2b85c54d2ecf76ad7309278901c2f4d6dcc611ef095844e8c6bd87b2d6a72"
     },
     "x86_64_macos": {
+      "etag": "0x8DAF6A52B276E6B",
       "checksum": "b1227359e4994f9ee96247bc2d47e36612f0b5344f9010f31ac965163a44e98c"
     },
     "x86_64_windows": {
+      "etag": "0x8DAF6A55EE67915",
       "checksum": "d18f4da434596eb2c4aa2eaa95e00482130affa0a1710046c2d29c5c6edcb202"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DAF6A5139C04DA",
       "checksum": "11a3018bd91ff62806e7aa3413c5dc9af22ede870af4850866dbfe94cec0bd70"
     },
     "aarch64_macos": {
+      "etag": "0x8DAF6A519A0D72D",
       "checksum": "d4c67fac1dfa16cb130142bb572b310de856a8ec0494cc95351b5d82507793f2"
     }
   },
   "0.5.7": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAF3E67714C9C6",
       "checksum": "e085b93a22d5f0daaa5c1bcce79885e549057f41b1229c08435c939c4fdf87ed"
     },
     "x86_64_macos": {
+      "etag": "0x8DAF3E7216084C2",
       "checksum": "c4592c9691e508d2b0fd1c20b0227638fe47f752943339ebe4e50affc532ea91"
     },
     "x86_64_windows": {
+      "etag": "0x8DAF3E694B1822F",
       "checksum": "2304501710ed6959c71127a99c6630f2cebf7cba4ccefb213b1a01a0a8a8b0af"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DAF3E67BF3BF09",
       "checksum": "23a302bdb5af5dae2e941414ddf3abb4738b9b4d89936e31a971241b92c4f85e"
     },
     "aarch64_macos": {
+      "etag": "0x8DAF3E676EF1F3B",
       "checksum": "07d09d8d902a1b07554c1eb3d36abf3aa971477d33b1604a31eaf3c2e13f57a0"
     }
   },
   "0.5.6": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAF3DA461A3CC0",
       "checksum": "9b45fb8b1fbac1977ed828c248228f31cc2caf6f2ce8b27bd38c25b7275ef701"
     },
     "x86_64_macos": {
+      "etag": "0x8DAF3DB52BDCB7D",
       "checksum": "f249dbf6e8c750a43a933845a6141e6bcbf0ad022c9d8e7ba9f0d6b9198146b7"
     },
     "x86_64_windows": {
+      "etag": "0x8DAF3DA6244FAC0",
       "checksum": "6dba76298961771c08e643d8c69e06d5c2a39f1918f4087e5e02eac920470372"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DAF3D9F3FF45F1",
       "checksum": "3518e7b954fad878db5be7beafe8015d75ded892e7df2cde8359a4a830842751"
     },
     "aarch64_macos": {
+      "etag": "0x8DAF3DA94E87AD6",
       "checksum": "6697a3b11dc36bb4e654a90f1e8e66afe0a49f4c8d815fa214129721a20058e5"
     }
   },
   "0.5.5": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAF2CF12352E80",
       "checksum": "58f459604beef46eff43d14fc41cb39437a2834bece9b91823cafce7a3e91428"
     },
     "x86_64_macos": {
+      "etag": "0x8DAF2CF59F797B1",
       "checksum": "870334436497fa4ec5aea8ca353688881ad9f8f6cc4ad61c4837de1f078d637b"
     },
     "x86_64_windows": {
+      "etag": "0x8DAF2CF321003D5",
       "checksum": "107581052c1978caa9c485d3c3b41e60ed9d335023434e4af1be51a1e0cac458"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DAF2CF1079405D",
       "checksum": "a48b20d8f7ebf35949ba6e3419106afdfe638d1527ffeb5945385d51c82a443d"
     },
     "aarch64_macos": {
+      "etag": "0x8DAF2CF72CB8669",
       "checksum": "00abbc5db882b766d92c08a7069902cbe3f183af066a42bf079f954fc32f3c29"
     }
   },
   "0.5.4": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAF23154547457",
       "checksum": "c4912bb56a25a8ea17bbea843019386d191d789d66d19d3fa70b49fc1efb4599"
     },
     "x86_64_macos": {
+      "etag": "0x8DAF23142747F0F",
       "checksum": "af12ff744aacc5a78e84ac849dd09d8a8babfacb10926a9b32e97bf008624165"
     },
     "x86_64_windows": {
+      "etag": "0x8DAF231820799AC",
       "checksum": "ff0d031ddd1fb99a7788124b9b6cafe26f29aaffd82481140f763b95d7b7ba8d"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DAF2315629B38D",
       "checksum": "e730738b882ade2d1a0747ee83baa147cffa30ff286e11b94224e2b68ba3a087"
     },
     "aarch64_macos": {
+      "etag": "0x8DAF2316C2AF385",
       "checksum": "a56c6046c7c6eb5030acf0c28b1448e675e072fb7eaa94b8674934d167f6c445"
     }
   },
   "0.5.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8DADE946E8AEDE1",
       "checksum": "d155c41fef38ac35c315fe420d229fca5fd754d12c6ae0bd300bc25c1274c1fc"
     },
     "x86_64_macos": {
+      "etag": "0x8DADE94E125EE70",
       "checksum": "7c22f6223b0128ab0c3462662d9770e2e2bb496830767d90e7a0f936952c93cf"
     },
     "x86_64_windows": {
+      "etag": "0x8DADE948BF96150",
       "checksum": "997d3f15c9624ab23fa1d84b671255e6c2f889358724e2475e40d99b0e6e2638"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DADE94671A58FE",
       "checksum": "f3b59292fbae94f9d83006406e88aa753f2f6dc8c025a93512674e3e88b7c3be"
     },
     "aarch64_macos": {
+      "etag": "0x8DADE94B2E0E595",
       "checksum": "54973a3416a3781c6e31eb6bd89a5c3859d36238298d68b327efc3ad3137ba8e"
     }
   },
   "0.5.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAD08E7A2E3DD1",
       "checksum": "e62fb99bb24c5f422a5b007e692abfbeccef932882b9ca356291e01112f78e79"
     },
     "x86_64_macos": {
+      "etag": "0x8DAD08E7A0426ED",
       "checksum": "80bdc4005c1c85aa3bdcf0713aa5969667c8c225e7560648672b7fdd06b5f2fd"
     },
     "x86_64_windows": {
+      "etag": "0x8DAD08EA504CE5D",
       "checksum": "882a8c80e6073cba64b1534b69c2a9cc99ee86b8118be50a115bbb86505eb33c"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DAD08E7B933D0A",
       "checksum": "f95ed3dae0c59b12243c8370767b46ec3d8c6d162a680f67beefd95e2deda3e2"
     },
     "aarch64_macos": {
+      "etag": "0x8DAD08E776C5477",
       "checksum": "2ab4915a7f86e9296b44f16dd8ff0ea9132ebe7002170e7650c392ec32292aa5"
     }
   },
   "0.5.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAD072E6422730",
       "checksum": "883c623ef0a66d6b1045c8dba1ec43c30b7a018b3e977ababcb2eef15f537c80"
     },
     "x86_64_macos": {
+      "etag": "0x8DAD0736D7632C4",
       "checksum": "fe1a41a8ae167b8e8753d7e245298dff7e40716704734ddf3ccffdba255e698e"
     },
     "x86_64_windows": {
+      "etag": "0x8DAD0730960BB3F",
       "checksum": "f4bb2b4eab4af4d3a81f00aab8aa35a749678fa8f60becd00e527f9c8fcffa43"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DAD072E408E272",
       "checksum": "f98dcc2175e0b5620bf1310e286804417f1fbb53f02ea94270ee065dc5393f3f"
     },
     "aarch64_macos": {
+      "etag": "0x8DAD07388402734",
       "checksum": "ec7316b83d31e82636beef74d312f8c46a45fabc0988c8913604a165be00695c"
     }
   },
   "0.5.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA930506999BA9",
       "checksum": "186111094fe5da1176dab4cda351f964103ca4fcdc41b08ec701363ebba00d11"
     },
     "x86_64_macos": {
+      "etag": "0x8DA93051A3FAF0A",
       "checksum": "bfcb739b3c2844be0459a26f990f5d6dd83bd5afa8f9b2193ac4d3451bd0dd7d"
     },
     "x86_64_windows": {
+      "etag": "0x8DA930522180DDB",
       "checksum": "4ea108a4cc464339b358d4a21954873c729063ef364cb6bb3adf63761757b016"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DA930503552B24",
       "checksum": "24f64495eaf0d2a9162589bb81c7aa7956bd5be157db0830867a8a23347eaf93"
     },
     "aarch64_macos": {
+      "etag": "0x8DA930519E1E617",
       "checksum": "a21ab46fa2457f5e6252eeb6a34a539ca0238f0550e9d333fc24055c9ee8e9d8"
     }
   },
@@ -899,241 +1154,311 @@
   },
   "0.4.14": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA77CC935709A1",
       "checksum": "c5d08670b667c7c34fe3ac8580e3c1ee1dd2b554db1f1ee476ef7f7114df103d"
     },
     "x86_64_macos": {
+      "etag": "0x8DA77CCAFEE9D30",
       "checksum": "cd7410d82346f478203e2d4c60265e89ef83d7a5d5eba5ae10d5edf8e8f93844"
     },
     "x86_64_windows": {
+      "etag": "0x8DA77CCA096CE46",
       "checksum": "d0e9c4362a14548dfb68d6acad7e40a50d85ab10cd44850d0ed6eba12815c06e"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DA77CC9ABA32ED",
       "checksum": "8341e9ba276c9819d0b59c9fb8bc9419ffe76ce0906a46a554fd09ad21842caa"
     },
     "aarch64_macos": {
+      "etag": "0x8DA77CCC7B0097E",
       "checksum": "f9635fd760622e4b1cfd9ac8b8c65f6a38ba4b3d40c939e622369af191b3bdd3"
     }
   },
   "0.4.13": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA7369D0E46015",
       "checksum": "44e7e84da6d533d2975ff3c448cb27d429728e629ae896691364b0c4a9726ba9"
     },
     "x86_64_macos": {
+      "etag": "0x8DA7369C4263BC4",
       "checksum": "d0d8716f11676536aff573d9355f15c9471336452dbf5f89f5704db6cb4379e9"
     },
     "x86_64_windows": {
+      "etag": "0x8DA7369E6BF9FCF",
       "checksum": "69e00802cb1c793631610ddef9ab0e7e3e852309fbc9d644eac3f428c1823d12"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DA7369CFD08073",
       "checksum": "5d091e43f088b00261fd7c8725bc70367d3bd951349ecdc3352e302d38224161"
     },
     "aarch64_macos": {
+      "etag": "0x8DA736A28FF392D",
       "checksum": "51def92f0d399f0473a89e03796f908f463d6e459a19a7c1d1f76854e66d49c7"
     }
   },
   "0.4.12": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA71FFE28CF99B",
       "checksum": "810235170247ebeb63bfe8707d16db6dd99bcaa368b38020f656c9a5d7881b68"
     },
     "x86_64_macos": {
+      "etag": "0x8DA71FFADB89BC8",
       "checksum": "286596f70a983344253538ef82015446acf55e55d12c322c4b707e5eeaaa891c"
     },
     "x86_64_windows": {
+      "etag": "0x8DA71FFCD21A97D",
       "checksum": "66db418bd604be47b5dd6403b771e6ab4056f7759e61fdf81edad9db89d047c0"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DA71FFDAD09A0A",
       "checksum": "9dfcc26a1202dd7ecc0cd3ca6a5a7e2ba08d4a53e090b5be0a7b11cef2931b07"
     },
     "aarch64_macos": {
+      "etag": "0x8DA71FFB473687F",
       "checksum": "8c3877b8619ed244f565ee6f7985c966adec498d7bf51ca1a5d5f7c6f322c93e"
     }
   },
   "0.4.11": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA6A57532924ED",
       "checksum": "ce328017159b3120733bb3a3760ec27277c0234837f72ffba4abca054eed19cc"
     },
     "x86_64_macos": {
+      "etag": "0x8DA6A573204B933",
       "checksum": "cef7ced7393460a9ef0eb076c900a6a7bba1ec2da56838723ff9fd5e4cdb21e6"
     },
     "x86_64_windows": {
+      "etag": "0x8DA6A575802C47E",
       "checksum": "488d20a7e6bf5a04570c56a62b3556f5a93d5bd646e703500c1cc0801f2ec345"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DA6A574C18B180",
       "checksum": "642b6b82c921defc5c25bbaa56de76f35ef101698bbb766bf1cbca64e49ab947"
     },
     "aarch64_macos": {
+      "etag": "0x8DA6A57396E8921",
       "checksum": "b814227443433b39369dfbb572b776ac900b3cd9a914c5060964b4f324478f37"
     }
   },
   "0.4.10": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA688AF9AD86ED",
       "checksum": "a5106d477a994b8afd40e7ebb85317b5960c19c31d548a244c46b50b3c7c3e41"
     },
     "x86_64_macos": {
+      "etag": "0x8DA688AE68BB7CA",
       "checksum": "7ad3d75c23ca34bfc43352bdf2efcda0cbd4e51d34418cf0656c41132eac6877"
     },
     "x86_64_windows": {
+      "etag": "0x8DA688B007E6BD9",
       "checksum": "caeabd591908a8f978ee30e3963a6ebd624aa7f6fbde10d7e4884c5aa4d529f3"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DA688AF0B225A8",
       "checksum": "3a5422ae1cc10672f421bb72d5a613af85e17f89270ab4809da0609b4f598bc9"
     },
     "aarch64_macos": {
+      "etag": "0x8DA688ADC451CE6",
       "checksum": "1c224719fcbf3abe06777b41a81d05972d11a5ef95561f509a9a05d2f3d44559"
     }
   },
   "0.4.9": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA602D01DA79E4",
       "checksum": "01d66a160b0c3049897f00397056e340a908222afa252ce8a67ab8c18a3983a5"
     },
     "x86_64_macos": {
+      "etag": "0x8DA602CD0917D09",
       "checksum": "aa54185c2c1ca46fc235930f8f3dbdd422e1a6d858d3cfaaf98828b3f5deee81"
     },
     "x86_64_windows": {
+      "etag": "0x8DA602CDDC24F60",
       "checksum": "3fba0edf66f94aaee120380e347e50c90008ad1e21f3d5ea2ab08ff3e2bdf63b"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DA602CD2DC9DAE",
       "checksum": "9a76b2c2df531bb24fa8b2ddb4520de8153f53bd0e2218611998a2d8fef5479f"
     },
     "aarch64_macos": {
+      "etag": "0x8DA602CC2DE6E65",
       "checksum": "19837a98aebdaa208548d44840fa1e8252db3d714b7d98164c2caf84e48ba12d"
     }
   },
   "0.4.8": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA4FB05D009EC5",
       "checksum": "e65c92a945e3d8c23bc02f4b72d2380783d4d5c73c4f33d0f94595e62062c47f"
     },
     "x86_64_macos": {
+      "etag": "0x8DA4FB06054A3CD",
       "checksum": "bdd933abf963f178ffb409b38dec846c3133c03b53d5153880a8f613b764b72e"
     },
     "x86_64_windows": {
+      "etag": "0x8DA4FB08300039E",
       "checksum": "c5b866f3ee8776d68cec2a41a3a114cffc76f8112cc2689a48928ecd04e0f238"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DA4FB03C33A317",
       "checksum": "becfc744bfd2a2bac478ba6f74cbc17a37e10e5e8ca3f3012850d91835b04df4"
     },
     "aarch64_macos": {
+      "etag": "0x8DA4FB055E91A2E",
       "checksum": "b90c477b610b781e3531bd9980c16a20e99d31b72509b82fbed2ee6250908a5e"
     }
   },
   "0.4.7": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA4D5566F35DF4",
       "checksum": "2c354260c0ab47c5f8a1d9dd54284311ded7b5b36e211b06852edc70a22f536c"
     },
     "x86_64_macos": {
+      "etag": "0x8DA4D557EDFC824",
       "checksum": "3f3c29517cc607e9d5b26ace6f0b8f8d42e901e9f3cf7bf583bf87b6fa5ee994"
     },
     "x86_64_windows": {
+      "etag": "0x8DA4D558782E292",
       "checksum": "f76f8bbf98fff1d9d7f6c8fa3adbbda124148da08e2615dda70e7490bc3475f2"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DA4D557625A6BF",
       "checksum": "10e6e20816ada5b7fc6182f6e6bf8f68de112436abacca3c4751d27b50172562"
     },
     "aarch64_macos": {
+      "etag": "0x8DA4D5588F1F416",
       "checksum": "61dfba65756e0e1265ac7244e5ff522531544415b12eb2c68404b323ee866fb2"
     }
   },
   "0.4.6": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA4D3AA7A4509F",
       "checksum": "2291c74e9924f24518a1b2595897f41ce796186185dc904d8dea53ee22d9c894"
     },
     "x86_64_macos": {
+      "etag": "0x8DA4D3AA07E4F05",
       "checksum": "a44c94289a1b2aae0cf1d1f1016281b7680c90d1044dee55f2bb32b5168f23cd"
     },
     "x86_64_windows": {
+      "etag": "0x8DA4D3AE8B15EF7",
       "checksum": "42ed64728c37714921a98f751987c7962c3ae2adc95438df5e1ae185985063eb"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DA4D3AB64DF676",
       "checksum": "5845761798c222bd1e41caafdfd8caccb1c046a651e848e2ffa4a493406ceb04"
     },
     "aarch64_macos": {
+      "etag": "0x8DA4D3AC9F36E29",
       "checksum": "669d6494db784ee87de0f1dc890c30161ff1459a53e1d18d3abd84c8b8479181"
     }
   },
   "0.4.5": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA449ACE19C4EA",
       "checksum": "29ccdd0fba1869f4afaa2f696557d33fe7c8f41bdd4c47870db4a9ea056b80b0"
     },
     "x86_64_macos": {
+      "etag": "0x8DA449B638ED7CE",
       "checksum": "27f64ddca7a77cc67f8cdbcf495194fd20531fafe84bf7f509a3b41361107086"
     },
     "x86_64_windows": {
+      "etag": "0x8DA449B56493AED",
       "checksum": "79184ca5c241991a732a0e626d23ac87921d752c56f4b84d35c475790e7b1f6f"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DA449AF1052C1E",
       "checksum": "75b06e88de41a7c5e09c32e25ed6626e827818ad833a1654786b0c810a18ad48"
     },
     "aarch64_macos": {
+      "etag": "0x8DA449B2EFBAF2B",
       "checksum": "4abf4adaf9734134bf751f6485ea31adc73915237916e5e5f2ce47471a045a49"
     }
   },
   "0.4.4": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA41DB2DDE7320",
       "checksum": "156575db66d144399cf02a2e70af36be6d4ac4a69b2babd893d73e0f7bac0742"
     },
     "x86_64_macos": {
+      "etag": "0x8DA41DB4BFA6AC0",
       "checksum": "2aa402d5785acfec0eaeae689ab9ff0bc62065838e28b5763d63137554a7b536"
     },
     "x86_64_windows": {
+      "etag": "0x8DA41DB7B78A54B",
       "checksum": "698ebcac01ef95384731ce0fec0c773c929e2453cd013f181426fa1ad2320956"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DA41DB6ACA07D8",
       "checksum": "9658f8104ba65b472a088716f6a7516e514139717a91d53a1bda14c83e7757cd"
     }
   },
   "0.4.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA417CB4D7CCC0",
       "checksum": "29bb725e7e21cfae91859b56d60035979a50a0da53ec8594cc8d5b7e37805dfc"
     },
     "x86_64_macos": {
+      "etag": "0x8DA417CD11E80F9",
       "checksum": "8caa244f3170f919bad6f5eaef1c8805e3352c25529722b2a353afbaca5a34e0"
     },
     "x86_64_windows": {
+      "etag": "0x8DA417CC9DB613B",
       "checksum": "418071de044e7c0880bb78bfee4a8d1195ddc4a3de77c15806ad1151c9f40a4a"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DA417CA7142436",
       "checksum": "8679310c36680db3a8d7c078effc7071563c9eb15d5829070079b117ee57f69a"
     }
   },
   "0.4.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA417865926207",
       "checksum": "f103a601b687f33e35236b3da16543788eb2e0044a34939b325537baa6171d55"
     },
     "x86_64_macos": {
+      "etag": "0x8DA41785B16B178",
       "checksum": "3574be38b4a0672e99ee2f07f66eceedafe2cdb9f1a7d05f4f7d07d353eaa286"
     },
     "x86_64_windows": {
+      "etag": "0x8DA41788D2FE945",
       "checksum": "7d187dfcdffcdf2dce7930f778a87764381d1e086ce1f63066ce0c3bf267bb7d"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DA417849F14B6A",
       "checksum": "d9622a6d4f1f56a1f114a5d948094b5a5555646263247f96c4c6d9c027f6f6e7"
     }
   },
   "0.4.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA3D8A40FA024D",
       "checksum": "0604d4dff928379df7c8e1693ded89cfb364ab9b08c88b03ae924160dcd92b3b"
     },
     "x86_64_macos": {
+      "etag": "0x8DA3D8A5AEC9CD5",
       "checksum": "fd5e1e4e16f6fa14c86dcabfc534c95cf336f7ec35ca9e01ac71bfb1478568bc"
     },
     "x86_64_windows": {
+      "etag": "0x8DA3D8A71878FD7",
       "checksum": "9523b7ce7106f4c45a031da38af9c5c1105dc9be65b28f288ded5c3efe5c7da9"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DA3D8A5D7359F3",
       "checksum": "159a264feea697b5ce886919aa691caa45a49d1de292a0b6e42a7c439797b2e4"
     }
   },
   "0.4.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA33B0975D0792",
       "checksum": "55ad6fdacbeff5e848b4bbb0dc0ea1cf855b51d30a34b08c84f0f87792ed576a"
     },
     "x86_64_macos": {
+      "etag": "0x8DA33B082E7ABD1",
       "checksum": "3107b26a32d58b518a6fd7d322451fd70364498bf9cfd1cecef1dbf806ab1ef7"
     },
     "x86_64_windows": {
+      "etag": "0x8DA33B0C679E4E3",
       "checksum": "f7e15d69e1c802b0e99bfccf759beb9132c988eb2a3d8c6d4fb56af3dc2dea3e"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DA33B06D886400",
       "checksum": "9e1248a66b71dcd792128469f8718fd07335c3f10cb81a5876eaba8fd0019187"
     }
   },
@@ -1142,57 +1467,73 @@
   },
   "0.3.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA2FB0D4EEB25F",
       "checksum": "021b3e34a8818b54b78f5db5efa9cf8cc04f6123137695f9fd858e53c5694f48"
     },
     "x86_64_macos": {
+      "etag": "0x8DA2FB0C529BCFA",
       "checksum": "052d034d6be6c8ebb12ec361941243e86f9cf923ac79d0b314815fb2f7a9121a"
     },
     "x86_64_windows": {
+      "etag": "0x8DA2FB1023517BD",
       "checksum": "c3c0d0fe4000abf6155a13831ecc2c383ee89fcf65cbddb18e0b22102454df70"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DA2FB0DAFC3DB3",
       "checksum": "6b6f1f9f651da010c681ee802a5a94f93d94ecde13ca0eb403280f79e71c2456"
     }
   },
   "0.3.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA2EE8C1028DFF",
       "checksum": "e852181f617ed12b4f69b3b40fd5db0914c27ff6852639ebb505563108f8f79a"
     },
     "x86_64_macos": {
+      "etag": "0x8DA2EE8C3CC192E",
       "checksum": "45c591007de20c675cb136313e5eed8a7d5695f366413a471a19334020d05286"
     },
     "x86_64_windows": {
+      "etag": "0x8DA2EE9261EDA47",
       "checksum": "0c71b2ff3ed0d2c5bc8da0bac6e3016bf8b342552e502177e26713d395de9503"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DA2EE8BE4A8C63",
       "checksum": "5d09b9a382161a1a92a503164d462c64094d6fdabce82cf7fbb1fd5b21bc4cec"
     }
   },
   "0.3.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA2B27103F6809",
       "checksum": "014229fe5a8a9c41cf8291fda9288f729b69d54155b24396c7ab6ef10d84da4a"
     },
     "x86_64_macos": {
+      "etag": "0x8DA2B277BB754EA",
       "checksum": "ae0c8b0389adca335a096e6abb799d32a114ebec0d5dbaef2f35da768f5257e2"
     },
     "x86_64_windows": {
+      "etag": "0x8DA2B275860E032",
       "checksum": "96515e62815ea3f3df792554d00bd2d3a43ddcc34cc4072bc5947d5c60b895bd"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DA2B2713C4AE8A",
       "checksum": "99facbd74ed6661e330d4de92509a6a695d81e192e8f4e853c87404f8bf2ab53"
     }
   },
   "0.3.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA194D94FE565E",
       "checksum": "a1e8ca2fa2532d61c972d1aae74eb5186a7766d82a9062ce6b6212783d0b7c9c"
     },
     "x86_64_macos": {
+      "etag": "0x8DA194DA33A068A",
       "checksum": "40e9c55d5704558b8c83033eae55d0211139b5d0cbaa7521a5626daad73944cd"
     },
     "x86_64_windows": {
+      "etag": "0x8DA194DCC972F84",
       "checksum": "02c17e80f70d1152d30e6ad878b2f85decbe81b490f65aa4905895600e0e3915"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DA194DA2F42E33",
       "checksum": "a17641ed87c0cfb0ba41ff534d0296e070adb200b71517462b81fd7d42cd8b1f"
     }
   },
@@ -1201,71 +1542,91 @@
   },
   "0.2.4": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA08F5C2AF8E53",
       "checksum": "b3ce5762df4cafd49b21507841e5bc6dcf55a2702ee7431aded473a0641f2115"
     },
     "x86_64_macos": {
+      "etag": "0x8DA08F5E2F30426",
       "checksum": "f20e5a826333d3afb09d057649da9ba814f743b9a864de812f28747afbf763a1"
     },
     "x86_64_windows": {
+      "etag": "0x8DA08F60FE0A5CE",
       "checksum": "ce247b933eb1bc524d12fd332da9250f74c4e4eebb675d2bfc4dc61732111166"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DA08F5D9F2B97E",
       "checksum": "6d6767e448757039afb8d2977296e1cf123a21f311ed7320dbb416d9aad62efb"
     }
   },
   "0.2.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9FE9624F0E036",
       "checksum": "71fd8a8c1ad55c38f8c403e1dc5dc7c399a2107017741c8238ea5b50d308a487"
     },
     "x86_64_macos": {
+      "etag": "0x8D9FE96937763C7",
       "checksum": "8d11acd4f7c2c84ecadccc3db5f59366f852c067bf029d6ab59bfb167a10b0db"
     },
     "x86_64_windows": {
+      "etag": "0x8D9FE96444FD1D5",
       "checksum": "147c706ad3cb7aafa8da511072473783c27b5d05efd1dedc12e462e94890363e"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8D9FE9625649F84",
       "checksum": "f41c21d743a90b5c58e971f95872742989a006621f769449b9b3031db6f8588a"
     }
   },
   "0.2.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9FB8242956252",
       "checksum": "d5f6e661a54d9df7e32575d4c075a7644c76587a0d35e1fea7a399dd2515c2d6"
     },
     "x86_64_macos": {
+      "etag": "0x8D9FB82569F03A0",
       "checksum": "386f2f09b806c23d586f63b98aa06729273bf195a26c465a0a04fec58ea259d4"
     },
     "x86_64_windows": {
+      "etag": "0x8D9FB827670EF7B",
       "checksum": "72a992403dc459c58762b683b18725d7a9a1141c9c8b5d4de55aba4ba445079b"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8D9FB823E064DED",
       "checksum": "d354a9e65644f1542939e2cc3ad5c6f317f9a35ac42acb7d3c4152e2f1a0534d"
     }
   },
   "0.2.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9F287EB393710",
       "checksum": "9c04d52b830cb9b129198229f2358bca85798851d418c48d1cb180a0e93f6866"
     },
     "x86_64_macos": {
+      "etag": "0x8D9F287E27E05D6",
       "checksum": "d5a448b5559ab24604748a0a2c681a9dc187d4eca8245c89bd76bd887464fde9"
     },
     "x86_64_windows": {
+      "etag": "0x8D9F2883A93BA74",
       "checksum": "a9396a54c33d7673a554e65cf64280f9890870cc38e77dac921521f2edf06e21"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8D9F287DF1CBCE9",
       "checksum": "adbf6648e7f7b737a7f3abaf7f7917b039e9e543d898d6710d88c6a726d54f83"
     }
   },
   "0.2.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9E9784524D7BF",
       "checksum": "13bb3143de2017e34eeb80deb7d71a31d4daf20e148c159d75d07174d6a86afc"
     },
     "x86_64_macos": {
+      "etag": "0x8D9E9784133C0DC",
       "checksum": "2ac134b2f57156b13fea80b653e0f4a9e071a1a14c0cc2c58bc0e56cd6227783"
     },
     "x86_64_windows": {
+      "etag": "0x8D9E97886BB30D3",
       "checksum": "2811d90ea580fee753e5d43f4c9c2820439568bd0ca758dde2942365168ca19b"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8D9E97862A7D205",
       "checksum": "7f44b6984ff804aaac4fd8eaef6129e8f69e0839b2a25b61eb94ed3d8be26f57"
     }
   },
@@ -1274,191 +1635,243 @@
   },
   "0.1.16": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9DCEE7A771535",
       "checksum": "4baea3a569ffe977039a7092786a6f53a41734055e929a7da174974c7bf7bf7e"
     },
     "x86_64_macos": {
+      "etag": "0x8D9DCEE9C72A356",
       "checksum": "d5a95a49afdaef41f1fdcd7ec595bae706a38be612a210432991927f5936c4f2"
     },
     "x86_64_windows": {
+      "etag": "0x8D9DCEEE9B1DCFF",
       "checksum": "cdb8764336d724ff4a8b6f9cbde7d4cbbd7287208f0f2a8ac58433b5442f5b92"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8D9DCEE848AC8E9",
       "checksum": "3365a217816ca84fa4052db3231de19b5a07ad5e2f818bc39c482bf8e710776a"
     }
   },
   "0.1.15": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9D1BCE949E4D8",
       "checksum": "ebdec5d6bfa4abf4521932855739221aea964b52c9a914e4a682ee672497a2cf"
     },
     "x86_64_macos": {
+      "etag": "0x8D9D1BCEF376B79",
       "checksum": "19f11d48cf447146c2016312e985858d48a162229d167409bd6148f57dad93dd"
     },
     "x86_64_windows": {
+      "etag": "0x8D9D1C4C103E323",
       "checksum": "511ecb791f0a8b6025a19343decd87c2126518bdc183c3d868e8d77613873cf2"
     }
   },
   "0.1.14": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9D1B94D1F6F2A",
       "checksum": "b72f98a053a4895468415ed938bb342a63c3708b41b0809ff9f35c7ac0ac381c"
     },
     "x86_64_macos": {
+      "etag": "0x8D9D1B9A8095E4A",
       "checksum": "32155369414dcebfab01a7f886b254fc9b60d79eed3be7a8da84a8f69f27bb56"
     },
     "x86_64_windows": {
+      "etag": "0x8D9D1B9A97D77EA",
       "checksum": "b7525f544ca1354c8087e11353c17a089294d66fc5a48787bec467f84d00a3c3"
     }
   },
   "0.1.13": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BEFE3F6E6EBF",
       "checksum": "3583ff08159c650e8e312b4a1b221e87df618e9b75b5b3187942438f0b0f970d"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BEFE36785680",
       "checksum": "bacdcf5c7299b4a8bedac6a40d8ebe592311632976b4dbab8070492ba2aa4309"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BEFE57E9AC95",
       "checksum": "144c500fa23265e5690a7f98aa742aacbf47407bc29e7025ab1232f3eb1e9242"
     }
   },
   "0.1.12": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9B9664CA37C",
       "checksum": "775ffd8c1bd4ed5dcded78164ec182ca4650a3d98b0700fc1c5daf3b6e33014f"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9B964A720AD",
       "checksum": "07e7d886d52c31fec5b5bebfd77fce5d5fd34666543b62a7d326e9dc7aebb68b"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9B961B2B9DB",
       "checksum": "cc232143c55e69e002bce2edf361ac59d608d50a133fa4e2262fa2c5186c1213"
     }
   },
   "0.1.11": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9B96040C29A",
       "checksum": "b262bbc7e600a251ccf937d62fdd01e59f006109c3a6518f30e17dd3b99988d7"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9B96405C84B",
       "checksum": "0421276dcffe808a54927b0308bfe0ef1b106bf76c940cf88092b5f171439ad9"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9B95DF2957B",
       "checksum": "eace75d04cb54e3bc38f7a4a75d520b888d272cfd3fd0717160f630585191e75"
     }
   },
   "0.1.10": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9B9653430BD",
       "checksum": "b72463f53eeea3e4eea82772a77d9f9e3918e2155c341fa87a043f21daeebeb5"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9B966F9E106",
       "checksum": "2222389b0600eaf62b0e9403acc7b00233d55ec0ad78f0689dc9557b94aacd94"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9B96702B952",
       "checksum": "df994d9fd1f56fac50408e1eabdbf969d325e5fbecb890033c75863a6ba13dbd"
     }
   },
   "0.1.9": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9B965205D8B",
       "checksum": "8b0b825f26415f2b8998c99660f543f8ade9bc0421258beebc6328efbd6b4dd7"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9B95F1518E7",
       "checksum": "f2b4bd40ced4962aa72e5429c29421017ea466765f316e6923912c6ea1a63802"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9B95EF2A1D6",
       "checksum": "e3ebde12d023f16a1171efb9b7ad795f18d26aa9249b907d7570990efcc6a828"
     }
   },
   "0.1.8": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9B961D6903F",
       "checksum": "87e1ab05ae768823035c9d897bca8855058b94ccd6b15a2642decaf2fa7ae86c"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9B95EF89456",
       "checksum": "779ad3dbf5b4a9053960eb27fb7f903957b4775078c4be71ab1acc94993d2042"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9B9686F8132",
       "checksum": "abe7ce0b3e27baa489d2a1b4853cb125bbb43283910911cf1c2fc95b293d210f"
     }
   },
   "0.1.7": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9B96592BD95",
       "checksum": "3d8d830e0a19b2e9229fff690dc803d1d442dcf4831b52294bb02bde0dce2e3f"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9B95EDF43AF",
       "checksum": "61d36ffa6e06b77774c9deb57196ea9f53620176cb2597e019e8bccddd58f460"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9B962E5B590",
       "checksum": "e5066e2f0c984eb5c72b6a0aa923ed67ee3726478ee8af654e2b853c9019a272"
     }
   },
   "0.1.6": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9B95FDCB85C",
       "checksum": "9fdb60de8c1a1fbca35924967c6650f16ecf5312492aba2471ed375fcdde45d2"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9B9642C365F",
       "checksum": "17180e423e765b4517b909d450d44acea8dfb527a772b8e3687f50fe48f2db45"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9B9635F6792",
       "checksum": "be7253efad0ee1af5e74e9ebdc14f90027dcd47c82762332c2537fcf59d9f6b7"
     }
   },
   "0.1.5": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9B9645E1482",
       "checksum": "a96f14a58ec235f003be5fe58e57ffe4981f741425e51ff780a2be71adeb3146"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9B9689A827E",
       "checksum": "2082063ea3f4c69b5d42d638a93801a9e7515e699ef92cb45b7f7d5d8c7c556d"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9B95F5F0F4B",
       "checksum": "3cb1761115de690f863577dc3750471281f95c999b56417cfc312adb0b8fc8f6"
     }
   },
   "0.1.4": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9B9666AAE5B",
       "checksum": "5b1b58bb4c325d5086fba70e40aa70870e1ed77371a7e3f1bc3d772ebf9f5642"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9B961DECC69",
       "checksum": "81334147680c66914a31e55e9dcc60a5f161f58c8ab959050fcd1a2854614292"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9B966EFA955",
       "checksum": "95b2175d10440c94c1a744c25d068b758858e5071eb0b6b9297017cfe05c2d80"
     }
   },
   "0.1.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9B95FC27D6D",
       "checksum": "526cde2b2dd53db834ff2788846e65793c88ecd1866190247febbaaa20ceda50"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9B9617CBDAD",
       "checksum": "6ddbf39361f2836efff3cebd3f704c80ce4f55e2a2bba3b12e5670bcd10a83e8"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9B96473BC2A",
       "checksum": "667685ac4291a0c573bcfc49aabc7296ed04dd841e0af80292e677348a794173"
     }
   },
   "0.1.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9B964FF1ED5",
       "checksum": "89e5162db8f9a4537aa563c17b0989537594a6cc388cfc858008e4aba2b15d80"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9B95EF07F3B",
       "checksum": "23c0233f501a5adee7a8cf78a623dab70764a9f2be0b4b1b6fc9c3f603e693ca"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9B966A34240",
       "checksum": "ac610da3a3c522e341ecfd03566ef1da537dca023506bb828f0a246679054440"
     }
   },
   "0.1.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9B95EF84647",
       "checksum": "ef3f6535f997ccfaa6d2612e8e3b41b3fe7a34e44c60b295a0f439ce80afa3c4"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9B96030714E",
       "checksum": "741d57b1c02d8c488ddc9d004b78844d3d094f384542d5affe543dbe10addb23"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9B95F41C7A9",
       "checksum": "6d9eb3350ef9d0fbe947ce7ef514d8aa87317189d738c162b7f94f91aa064003"
     }
   },
   "0.1.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9B95EA63AAE",
       "checksum": "36484249ac5cadfd77664315d69582c700f6fb8124758d495c9dfc8b852f60fb"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9B964876858",
       "checksum": "6a29ea7d5518a7ba043aefebb83e4d4af8b93a72cb7cb5860f767472bea3b1b8"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9B95F52B519",
       "checksum": "612ef4b51d4a86321f885a491b8d63158961ea5e2b5af8eeb8d0a1f034f9802c"
     }
   }

--- a/manifests/cargo-machete.json
+++ b/manifests/cargo-machete.json
@@ -11,21 +11,25 @@
   "0.6.2": {
     "x86_64_linux_musl": {
       "url": "https://github.com/bnjbvr/cargo-machete/releases/download/v0.6.2/cargo-machete-v0.6.2-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DC4BFE33150C60",
       "checksum": "7c3e6b1407445dbfdc072ade38adc6a200f6967e39a4bf8fb2e0e0ea825ab24c",
       "bin": "cargo-machete-v0.6.2-x86_64-unknown-linux-musl/cargo-machete"
     },
     "x86_64_macos": {
       "url": "https://github.com/bnjbvr/cargo-machete/releases/download/v0.6.2/cargo-machete-v0.6.2-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DC4BFE689FCE95",
       "checksum": "53dd62d3bf9be63aca8be9d801c9ff2a3ae740495bea4c390634d8b3eb76c8ae",
       "bin": "cargo-machete-v0.6.2-x86_64-apple-darwin/cargo-machete"
     },
     "x86_64_windows": {
       "url": "https://github.com/bnjbvr/cargo-machete/releases/download/v0.6.2/cargo-machete-v0.6.2-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DC4BFE54073D9C",
       "checksum": "9e1d911d5266c5ec81f85a3feacc223f181a6573060803aadda9369ea9973e11",
       "bin": "cargo-machete-v0.6.2-x86_64-pc-windows-msvc/cargo-machete.exe"
     },
     "aarch64_macos": {
       "url": "https://github.com/bnjbvr/cargo-machete/releases/download/v0.6.2/cargo-machete-v0.6.2-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DC4BFE61E4DF50",
       "checksum": "486b046d10ba14371efedbb44a226b514c42a1735a247f3ff8ad9a548395f080",
       "bin": "cargo-machete-v0.6.2-aarch64-apple-darwin/cargo-machete"
     }
@@ -33,21 +37,25 @@
   "0.6.1": {
     "x86_64_linux_musl": {
       "url": "https://github.com/bnjbvr/cargo-machete/releases/download/v0.6.1/cargo-machete-v0.6.1-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DC32EE10499FD1",
       "checksum": "d5d178010e8b9da69caa02b1abf6c9765cc6f3e8810a73483272c84204fd3715",
       "bin": "cargo-machete-v0.6.1-x86_64-unknown-linux-musl/cargo-machete"
     },
     "x86_64_macos": {
       "url": "https://github.com/bnjbvr/cargo-machete/releases/download/v0.6.1/cargo-machete-v0.6.1-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DC32EE26D36322",
       "checksum": "9211abb47866c3a3b0a283903511428d97c9cf35508fd4eca5bef0489e578af8",
       "bin": "cargo-machete-v0.6.1-x86_64-apple-darwin/cargo-machete"
     },
     "x86_64_windows": {
       "url": "https://github.com/bnjbvr/cargo-machete/releases/download/v0.6.1/cargo-machete-v0.6.1-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DC32EE3907394B",
       "checksum": "c142cf3b01aa3c321495659fe75f483fefd278172c4d74b0dd567639ebec000d",
       "bin": "cargo-machete-v0.6.1-x86_64-pc-windows-msvc/cargo-machete.exe"
     },
     "aarch64_macos": {
       "url": "https://github.com/bnjbvr/cargo-machete/releases/download/v0.6.1/cargo-machete-v0.6.1-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DC32EE286D4456",
       "checksum": "676fdd6ba18e830e4f7a279d4f47d365fcde4cbaa89bf6f0e4a08fbc4555821b",
       "bin": "cargo-machete-v0.6.1-aarch64-apple-darwin/cargo-machete"
     }
@@ -55,21 +63,25 @@
   "0.6.0": {
     "x86_64_linux_musl": {
       "url": "https://github.com/bnjbvr/cargo-machete/releases/download/v0.6.0/cargo-machete-v0.6.0-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DBBC1F1F916FBA",
       "checksum": "8f7f67f87c80d8ee331857e61c03762b71f9e68266a9193f4934cef1c8ccb449",
       "bin": "cargo-machete-v0.6.0-x86_64-unknown-linux-musl/cargo-machete"
     },
     "x86_64_macos": {
       "url": "https://github.com/bnjbvr/cargo-machete/releases/download/v0.6.0/cargo-machete-v0.6.0-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DBBC1F3127716B",
       "checksum": "dab6a9127166b8889a1933864014664288e16a211a2e3de65585d69b18b84bbf",
       "bin": "cargo-machete-v0.6.0-x86_64-apple-darwin/cargo-machete"
     },
     "x86_64_windows": {
       "url": "https://github.com/bnjbvr/cargo-machete/releases/download/v0.6.0/cargo-machete-v0.6.0-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DBBC1F38E28250",
       "checksum": "4e3369fea5e87bdab2d4219dd07b69fa562a7b0081433464ead82dced36f3af1",
       "bin": "cargo-machete-v0.6.0-x86_64-pc-windows-msvc/cargo-machete.exe"
     },
     "aarch64_macos": {
       "url": "https://github.com/bnjbvr/cargo-machete/releases/download/v0.6.0/cargo-machete-v0.6.0-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DBBC1F23348E5E",
       "checksum": "c4957bade3109f147ebe1598fa8f0b555713bbe83310cd99c927fa25398ae847",
       "bin": "cargo-machete-v0.6.0-aarch64-apple-darwin/cargo-machete"
     }
@@ -80,21 +92,25 @@
   "0.5.0": {
     "x86_64_linux_musl": {
       "url": "https://github.com/bnjbvr/cargo-machete/releases/download/v0.5.0/cargo-machete-v0.5.0-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DAC75526FBCE01",
       "checksum": "1ce5cf9fa24f6861a14318fb96db59011865d0adf979c2240d006407815ca174",
       "bin": "cargo-machete-v0.5.0-x86_64-unknown-linux-musl/cargo-machete"
     },
     "x86_64_macos": {
       "url": "https://github.com/bnjbvr/cargo-machete/releases/download/v0.5.0/cargo-machete-v0.5.0-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DAC75588F403E0",
       "checksum": "0550b85e43905fe8bfe0e83cb04d220a80f7aa898aaa3be0fe7a96f8ffd5e7f5",
       "bin": "cargo-machete-v0.5.0-x86_64-apple-darwin/cargo-machete"
     },
     "x86_64_windows": {
       "url": "https://github.com/bnjbvr/cargo-machete/releases/download/v0.5.0/cargo-machete-v0.5.0-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DAC7555B0DC73A",
       "checksum": "fd5ebb959cc214e8dab2661c65562eb0ec3d1da72d5f5a746f6bb6111b1854f8",
       "bin": "cargo-machete-v0.5.0-x86_64-pc-windows-msvc/cargo-machete.exe"
     },
     "aarch64_macos": {
       "url": "https://github.com/bnjbvr/cargo-machete/releases/download/v0.5.0/cargo-machete-v0.5.0-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DAC7556021FD0D",
       "checksum": "0386aa9ace17f6d96244b1315f8e996325ab81584a37fd3bc1d300a84455e55f",
       "bin": "cargo-machete-v0.5.0-aarch64-apple-darwin/cargo-machete"
     }
@@ -105,21 +121,25 @@
   "0.4.0": {
     "x86_64_linux_musl": {
       "url": "https://github.com/bnjbvr/cargo-machete/releases/download/v0.4.0/cargo-machete-v0.4.0-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DAAF8A261C442D",
       "checksum": "92e77b38b91e30e9d7383779b71035c5eebd8d874e1683db19239062d0dd1000",
       "bin": "cargo-machete-v0.4.0-x86_64-unknown-linux-musl/cargo-machete"
     },
     "x86_64_macos": {
       "url": "https://github.com/bnjbvr/cargo-machete/releases/download/v0.4.0/cargo-machete-v0.4.0-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DAAF8A4AB0DE41",
       "checksum": "db1f036bafc424af7247aa27748c08b3174b85b414e774cad51689f3e01ec64e",
       "bin": "cargo-machete-v0.4.0-x86_64-apple-darwin/cargo-machete"
     },
     "x86_64_windows": {
       "url": "https://github.com/bnjbvr/cargo-machete/releases/download/v0.4.0/cargo-machete-v0.4.0-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DAAF8A77D99FA6",
       "checksum": "0c31b0b4d7a3092dc84375d3993947cbdbf9db7f4d81128aca8a13e268cfe49c",
       "bin": "cargo-machete-v0.4.0-x86_64-pc-windows-msvc/cargo-machete.exe"
     },
     "aarch64_macos": {
       "url": "https://github.com/bnjbvr/cargo-machete/releases/download/v0.4.0/cargo-machete-v0.4.0-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DAAF8A5D3C0EAB",
       "checksum": "5f8a3004642535c78d2b7a49cb0e1fc6287643bc5c52d10e77ae3e79b558e190",
       "bin": "cargo-machete-v0.4.0-aarch64-apple-darwin/cargo-machete"
     }
@@ -130,21 +150,25 @@
   "0.3.1": {
     "x86_64_linux_musl": {
       "url": "https://github.com/bnjbvr/cargo-machete/releases/download/v0.3.1/cargo-machete-0.3.1-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DA9FC99B735AB3",
       "checksum": "d5e15a4c1926296746e0da4d52d8c7203acc1d453c8874c6b6f56a0ae52d4d87",
       "bin": "cargo-machete-0.3.1-x86_64-unknown-linux-musl/cargo-machete"
     },
     "x86_64_macos": {
       "url": "https://github.com/bnjbvr/cargo-machete/releases/download/v0.3.1/cargo-machete-0.3.1-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DA9FC9D5DAFFEB",
       "checksum": "83431f27f24f59d47385497d1a19ebe7c6e32f36dd163d804aa5b1337ca1489b",
       "bin": "cargo-machete-0.3.1-x86_64-apple-darwin/cargo-machete"
     },
     "x86_64_windows": {
       "url": "https://github.com/bnjbvr/cargo-machete/releases/download/v0.3.1/cargo-machete-0.3.1-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DA9FC9CC8C2C57",
       "checksum": "28aa111b283bc97f9259b0644b99e0109dde6414a5a672e00347d8cbb6e83804",
       "bin": "cargo-machete-0.3.1-x86_64-pc-windows-msvc/cargo-machete.exe"
     },
     "aarch64_macos": {
       "url": "https://github.com/bnjbvr/cargo-machete/releases/download/v0.3.1/cargo-machete-0.3.1-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DA9FC9FDA831CE",
       "checksum": "3ac0cee2102d74c71c831af1c7b8e229b254d3318927baed340728ddc61a10a8",
       "bin": "cargo-machete-0.3.1-aarch64-apple-darwin/cargo-machete"
     }

--- a/manifests/cargo-make.json
+++ b/manifests/cargo-make.json
@@ -27,183 +27,235 @@
   },
   "0.37.12": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC6C084BA4B16B",
       "checksum": "d07149c4425ec93fc1cfedf8c8092d3b405482acdb2d01ecd8fba3ac755a381a"
     },
     "x86_64_macos": {
+      "etag": "0x8DC6C08407F8043",
       "checksum": "96799def4c15cfe81e72b96a8df90a49e1cca0d2899f4e928e69e8a1f6e46ee1"
     },
     "x86_64_windows": {
+      "etag": "0x8DC6C0871BDBED1",
       "checksum": "271c37b5f63b02a1c4ff5f33935976df7cb473ada221dd06bce7282520f7be65"
     },
     "aarch64_macos": {
+      "etag": "0x8DC6C07F515EE09",
       "checksum": "091b93de51096c406c698b567e8d5bab83c2ab030b5b2a763104efe841ffb079"
     }
   },
   "0.37.11": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC558F04C95F6F",
       "checksum": "6c5b0196681e4582269a6bee9c85d98533debb628ee0a7d4580c68f6f47b6cdb"
     },
     "x86_64_macos": {
+      "etag": "0x8DC558F39C43556",
       "checksum": "c92d7e381c87d3619084dfb83743cf273a0e78b5fa2fdde030e12b0bfbbba954"
     },
     "x86_64_windows": {
+      "etag": "0x8DC558F9858CED1",
       "checksum": "097cb1bec258213b8b91cd54ea39d41018e5caac6c48d04e60d245b31838210b"
     },
     "aarch64_macos": {
+      "etag": "0x8DC558F65686D1D",
       "checksum": "1bfb4f3fba3e22efbc504421739547eaa063414f82d7a7b1af4ff0e98cda0be3"
     }
   },
   "0.37.10": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC349BD4DFB095",
       "checksum": "f75cd1d6d776754a88c20d22190efdaa4ac5066e61eb9699ab6b3d884c3b116a"
     },
     "x86_64_macos": {
+      "etag": "0x8DC349C50A39AE3",
       "checksum": "0046eb73677639aea70ec890896c31f5c9bfca12a9bdddf8be155738189ad1a0"
     },
     "x86_64_windows": {
+      "etag": "0x8DC349C12CECFBC",
       "checksum": "ee550a626b0ec1d03b703bd6e53ad17f95eb7586f8c6d7bd589e0a6a77b87eac"
     },
     "aarch64_macos": {
+      "etag": "0x8DC349C4C26CA93",
       "checksum": "cba2c5ce4f9f60255046e7b8a3547eebf6a62f59e20fb64adc2811f1a855d0fe"
     }
   },
   "0.37.9": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC23DEFF050C67",
       "checksum": "f41cfe97b38bb30c2973d1ea3f327fb3bee0ab67de0a9aac9ea894895e45eb55"
     },
     "x86_64_macos": {
+      "etag": "0x8DC23DF70D60481",
       "checksum": "f95913ba9a0d1497f3fd7177943fee1bceaa445a35b53fca7333fa98c2b78759"
     },
     "x86_64_windows": {
+      "etag": "0x8DC23DF3CA6258A",
       "checksum": "4d4c45546402e6edf387348f9e83281cc1415b0990c69a31a4462a81b43b8835"
     },
     "aarch64_macos": {
+      "etag": "0x8DC23DF0A8F253C",
       "checksum": "4dcef5b4d87d5cb6331cc4d9fbb6c855cd9ecaf86be54b91fba99f22795cfcfd"
     }
   },
   "0.37.8": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC1D0E961E491B",
       "checksum": "e7c5b4a7555eef6151a020dea810035c95891fc46cc0a8abbf1451f2136d105a"
     },
     "x86_64_macos": {
+      "etag": "0x8DC1D0F4C133298",
       "checksum": "4f59bd699892dd0d29b23ebd6f95589b9afa241003e0147a6bf1076784d40a07"
     },
     "x86_64_windows": {
+      "etag": "0x8DC1D0ED8BC422B",
       "checksum": "fc8005ec4086ef3ad812ad1b889576ae972df44856bd77f16c157ec222eb1d5a"
     },
     "aarch64_macos": {
+      "etag": "0x8DC1D0FB6F40E5E",
       "checksum": "b92471448a78c74c7b9563bcf45b2b047d7d8f311082fad5c6a02b34b3a20d19"
     }
   },
   "0.37.7": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC14CC80A5A550",
       "checksum": "101c6bef3cc1f8d6d2193d0cd8d2037a74583cad59fb9446ca0b51fc17586b1c"
     },
     "x86_64_macos": {
+      "etag": "0x8DC14CC8D24526B",
       "checksum": "46b27aa5f2bfac1d87588dad0289b64e100a3dbf29db5e6908331aa4d0dcc0b1"
     },
     "x86_64_windows": {
+      "etag": "0x8DC14CCB5AFF144",
       "checksum": "dc41ef6526b4b9239aad02159ab7d64e38519386aa901c5783baf12e9d79b240"
     },
     "aarch64_macos": {
+      "etag": "0x8DC14CC53B5A2A5",
       "checksum": "1079874f2adf66db8deb54c2260523a7b8a4f9f4b35398f280e3ba0c9f87fa2a"
     }
   },
   "0.37.6": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC14547EE5F500",
       "checksum": "3659f50c1b47c685f8e1008132b193c9d1c823ba38d110fff2fabc6043c37cfe"
     },
     "x86_64_macos": {
+      "etag": "0x8DC145538848101",
       "checksum": "632bdde01952c5884106218107ed3c8de35ff4f68eda3a69d70efc2d121ef213"
     },
     "x86_64_windows": {
+      "etag": "0x8DC1454A83A435C",
       "checksum": "7d9af4b44d306606568d71a75f237e9904c768c43a872e69aa716a5e637d85cb"
     },
     "aarch64_macos": {
+      "etag": "0x8DC14545C560689",
       "checksum": "b0fceee4418aa02daf8416d3bba5f34799e20943affdeeea1724536ca8643898"
     }
   },
   "0.37.5": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBFD957EF1C909",
       "checksum": "f02499cd7435bcab6c8d888c3855a95956b4e9c8d3b6a775ad04fb544e112cf7"
     },
     "x86_64_macos": {
+      "etag": "0x8DBFD95AC4B071D",
       "checksum": "ddb99573bc8c50c08786d14366c1e6940db1d186fb31107be1e0c5cfa6dc8b15"
     },
     "x86_64_windows": {
+      "etag": "0x8DBFD95AC751C1B",
       "checksum": "174cd7c16a169676ab56d177f4f4609af3a95ca2c9d939f3b3a8d412e324e3d7"
     },
     "aarch64_macos": {
+      "etag": "0x8DBFD95D806BECE",
       "checksum": "b6d31f9859e30a5d8f80ee20bcc4f78aa9166670e4b23693a4fa74e03f9fd42a"
     }
   },
   "0.37.4": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBD9E56C8DEC93",
       "checksum": "bbfd8d09b62dbb447022a041eae40a185172a8ca75b151365e6347d880ee2870"
     },
     "x86_64_macos": {
+      "etag": "0x8DBD9E4AEA15BED",
       "checksum": "4629a0b8a1c201676701093f8206c2468ac4a5a62884f0d88a72bd7d81d60e76"
     },
     "x86_64_windows": {
+      "etag": "0x8DBD9E5CCB995E5",
       "checksum": "981d60e42e3b31382385fcbafd4e42cf48cf1c80fb3b33a9f3fe62b8d49b7c62"
     },
     "aarch64_macos": {
+      "etag": "0x8DBD9E4E1E90F1E",
       "checksum": "8a3a4cbe458b873f743c5b72174104759001b5980fa52edba117033a55c6167a"
     }
   },
   "0.37.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBD78DA6D108E4",
       "checksum": "5c780ecc94dac2bf653ca46e6f7c9d1178961d3e16d8623928d7d6bf21fa2e5e"
     },
     "x86_64_macos": {
+      "etag": "0x8DBD78E074F904D",
       "checksum": "916d7f27c9899a53e388099afe22582f4b8a4dd23f55b1fed43d7a8ffcbcd6cb"
     },
     "x86_64_windows": {
+      "etag": "0x8DBD78DE0FFE639",
       "checksum": "d2fb430a39498b030033e97260fcfe09065cd1fd37f1a59180af8e521e677769"
     },
     "aarch64_macos": {
+      "etag": "0x8DBD78D20E94DC9",
       "checksum": "a38a93a85c8d3225b3fecda18bceaf141e890b0bed54fb58f929b56dbac6e908"
     }
   },
   "0.37.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBBF276BF9F965",
       "checksum": "6413e92bbeab0e43aa933a2843cb7abfc087dee7a076f3b367d2b7a0054f1c88"
     },
     "x86_64_macos": {
+      "etag": "0x8DBBF271412E377",
       "checksum": "265125172bf82d985bb71974b576a763c7da34ed7f6889ea324ca4910f728b54"
     },
     "x86_64_windows": {
+      "etag": "0x8DBBF27E2395E33",
       "checksum": "5f20ef9b30620113d2b8c4c0663f4ba219afd8e01868774702889abe4ac75843"
     },
     "aarch64_macos": {
+      "etag": "0x8DBBF274EBE847F",
       "checksum": "0cb0ad856383162cf2e3634e6264f096b420694bf78c224afc999d8033186eb1"
     }
   },
   "0.37.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBB767EBC62DCE",
       "checksum": "6a4fbad3d519e6189772dd0b0d16aa137c8208e7492576ff11497645588459c0"
     },
     "x86_64_macos": {
+      "etag": "0x8DBB767D3FDF971",
       "checksum": "a8dea1a7f8bc1e7e35bc14dc1cde15a2e122db1ee2ed8dbb787b5d4e33a19f12"
     },
     "x86_64_windows": {
+      "etag": "0x8DBB76892400FCC",
       "checksum": "531677bf6322139e694da4f37c5df722566675b32a020b7e0f37d4ec5d456052"
     },
     "aarch64_macos": {
+      "etag": "0x8DBB768A004EA3D",
       "checksum": "b074fedfb6282b846e047a6336920d2d1bb65c6aa25ce03aa4465615e83a407d"
     }
   },
   "0.37.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBB0754D04401B",
       "checksum": "ea7d52e9847c38f5aec60cd8e2f66fd90a9284f1e06fb25b3ef1276acb5251d7"
     },
     "x86_64_macos": {
+      "etag": "0x8DBB075E7C1CE62",
       "checksum": "3265730662da54c91002fb4d7deb93c61c46d05f937f751764f3625c22ead87a"
     },
     "x86_64_windows": {
+      "etag": "0x8DBB0757D041710",
       "checksum": "09041e88db9ec51d2c93448ed4b16f78f0e838ee6e549b0139a71ae30cdc5239"
     },
     "aarch64_macos": {
+      "etag": "0x8DBB075254415F2",
       "checksum": "8df5efcc19246c8e8fed753ad05f1d95efd2b9ecb84e3f306a36b8056ae631b9"
     }
   },
@@ -212,176 +264,225 @@
   },
   "0.36.13": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB998CB46D04E0",
       "checksum": "7f89f550b69e7bea469d34c09c6462cf8c7b08a5746c4e59a16600a4ebf6c409"
     },
     "x86_64_macos": {
+      "etag": "0x8DB998CF1332786",
       "checksum": "fb383b0c461df1e1824caf6787035ca834d02ea765d6a18177bc1dbd3d2ac4c5"
     },
     "x86_64_windows": {
+      "etag": "0x8DB998C957F6664",
       "checksum": "390379ce493a788a0853fda09480dde00b7bb3c717393cd3785e45a9b42e6aa1"
     },
     "aarch64_macos": {
+      "etag": "0x8DB998C4BF68AFF",
       "checksum": "e4dd8ed9035babdd5bd16799b713ec90373e65354aa92c0322a8031c78fcb65c"
     }
   },
   "0.36.12": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB886847CAE257",
       "checksum": "111c5896fc73d0601eba8b5a4c9edf75c7b7e9f7ab9261e5e1432fb43fc83061"
     },
     "x86_64_macos": {
+      "etag": "0x8DB8867D8126DCE",
       "checksum": "84e7d1a07e81f7c9442ca1c2b9bea3ac6e5ef930bd290be16155297c8bc0f460"
     },
     "x86_64_windows": {
+      "etag": "0x8DB8868A485E4E4",
       "checksum": "e19e0c4043d63923d5bc14bbb6133ed5a3b31821e39c23ce552b76e98e278c85"
     },
     "aarch64_macos": {
+      "etag": "0x8DB8867D3475F03",
       "checksum": "3ed909efb440321a2fbc8f559c5f3399f857ec7369a3ec5ae1a078d5e45ca4a9"
     }
   },
   "0.36.11": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB6DE72C1E7E69",
       "checksum": "0de56c00063a3f18d23ef386e3d3c55dddb37208f69a8592b36d283d2bc07db0"
     },
     "x86_64_macos": {
+      "etag": "0x8DB6DE7D60C741F",
       "checksum": "dbfdd45c567a4e9e57a804ad0e4f98ce11cc71d313c0663090f34223d7e9fe0b"
     },
     "x86_64_windows": {
+      "etag": "0x8DB6DE7A57CB1C6",
       "checksum": "d772ea983e7bec55c765e8cdfede2de950e63d4350080462e75a72020148d6df"
     },
     "aarch64_macos": {
+      "etag": "0x8DB6DE7B3243825",
       "checksum": "7e637e5c425894d550ddc1ce2e5bb63f1a4388e8adfcf7d36f6caf02ae84995f"
     }
   },
   "0.36.10": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB69DBC0A2D3A1",
       "checksum": "5b902720ba24eca8c67798b46dc0465e38a761b66fd4198162c13ce1cc1bd933"
     },
     "x86_64_macos": {
+      "etag": "0x8DB69DBDCFE50A2",
       "checksum": "b56a7d5610fa8b3f02d9a7193c3cc2e4501184ecaa7023ffb10117874e32ac00"
     },
     "x86_64_windows": {
+      "etag": "0x8DB69DB2E057EE4",
       "checksum": "ef12e0b06fbb98cfafd4910df53d25c24947b5e168e5ac1ba7a5ff8fd8f74d8b"
     },
     "aarch64_macos": {
+      "etag": "0x8DB69DC7878620E",
       "checksum": "12f03cee5f26ccb89aee6c99477baa8f32b1876aadd6af6699980287e2338c5e"
     }
   },
   "0.36.9": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB6594C82A4E71",
       "checksum": "28abd201805fb193ac95c1f4596373078cfd395f2e4735cd46050bab4e37b64f"
     },
     "x86_64_macos": {
+      "etag": "0x8DB6594FFF3FE29",
       "checksum": "74690b4d4ed652f871232ae0f2b06398dbf1967f4d9849eb95392257bd63244a"
     },
     "x86_64_windows": {
+      "etag": "0x8DB6594D7674E44",
       "checksum": "ac4daf3d7b1e299b8d3fc9bf8dd96e076b29d5a52a07605ee04ca4d2d640d420"
     },
     "aarch64_macos": {
+      "etag": "0x8DB659509BD9B98",
       "checksum": "09855810c42dc7b8eb14ff19ccf8bd30d17e34714dc095d081eb6a1954e1dea8"
     }
   },
   "0.36.8": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB5EEBEE134613",
       "checksum": "cffdf9b4f43d2d24165012e44b648e5c82edc3d0b13427d5335b23f125527bd4"
     },
     "x86_64_macos": {
+      "etag": "0x8DB5EECADB2DEED",
       "checksum": "7517fe6c63ecfa744ffd04ff38db95e06146af4bddf1491c4e1ecd1935c5e230"
     },
     "x86_64_windows": {
+      "etag": "0x8DB5EEC23F2D016",
       "checksum": "a4a9e6ecd321a87604f282f99e9dda198ceedf363dc7cee4d29108faf497caaa"
     },
     "aarch64_macos": {
+      "etag": "0x8DB5EEC2CBCE3AA",
       "checksum": "aeae97b8f47cfb8af3d00062a1e65eae83458522d28dac075330002e90a5a19f"
     }
   },
   "0.36.7": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB437B1B8BFA74",
       "checksum": "c758364568cee83e597d1d063212435d42d1b36105188e4ef10a5fd25897539e"
     },
     "x86_64_macos": {
+      "etag": "0x8DB437C1D292E44",
       "checksum": "c29f13ca5f1b45eab181e148b7ed56cc6f8eb3ce8ff6941711e9cc10a790cd91"
     },
     "x86_64_windows": {
+      "etag": "0x8DB437C686F449A",
       "checksum": "190591705d3dc744e2c3b78c1a1cb81580e9a51cf258ab7ff19cab171d4e9f3e"
     },
     "aarch64_macos": {
+      "etag": "0x8DB437BED76A4BA",
       "checksum": "f0cda3bf4ed8f606548fdf338206bc7df378b8136d367ff5a74fb2840a75284d"
     }
   },
   "0.36.6": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB1A7362AEC96C",
       "checksum": "900323cd32566ac5675f33bf2661717e3eb8ebcdc6100eede428d04376fba07a"
     },
     "x86_64_macos": {
+      "etag": "0x8DB1A73BD2E5BF8",
       "checksum": "3b57b1ea0d6d0619769dfdd6bda41b6aeefb2605fb602a45145cb4286ac0ee3a"
     },
     "x86_64_windows": {
+      "etag": "0x8DB1A739AE4D3BB",
       "checksum": "695ba4dd2643caf9bf5cedf7bfe7d2667171e1cdd71e5375d37bbd38bc484777"
     }
   },
   "0.36.5": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB11D3E93FDE76",
       "checksum": "95e9964640d5e45ac7756e0cf0496612b8d790ef0cbdda8c99c476e27106d44d"
     },
     "x86_64_macos": {
+      "etag": "0x8DB11D5776F057F",
       "checksum": "a410ab968d8d5f050c419cfa692517ff5afae9f03315707a2a61cc912adeccf2"
     },
     "x86_64_windows": {
+      "etag": "0x8DB11D5151566AA",
       "checksum": "50e3ce32c4b76406cc9364b55f6eb610225ca45e4efc2ae5479211db02560927"
     }
   },
   "0.36.4": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAFCA74583F162",
       "checksum": "2fc65e1f34789da87cab387027a8179e3589a8a78b0fa3063b26f63be8cb507b"
     },
     "x86_64_macos": {
+      "etag": "0x8DAFCA8D62F672E",
       "checksum": "1a2d9570034ed02a4e0a5067b790894627230722ccddc931b1d36bfd6c7c09a5"
     },
     "x86_64_windows": {
+      "etag": "0x8DAFCA847C1221E",
       "checksum": "66a10d3121249f661243fe06f56e47736da6f0fdcccf7b9414477ecb5cfd0a3e"
     }
   },
   "0.36.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAC6E88B83FF88",
       "checksum": "7dbb719698fc05f7c58ead0650fdc77f253faf98c14f1260733b3943d8d59122"
     },
     "x86_64_macos": {
+      "etag": "0x8DAC6E91D45532D",
       "checksum": "cd9ce4838699125e039cb2d85a1022a7b1cf118f584a0e258851f132af2afa5c"
     },
     "x86_64_windows": {
+      "etag": "0x8DAC6E96D40CDDC",
       "checksum": "f143a68d03526bb17a54ccf60d0479fc66b11a755d5424fee69715e049effedc"
     }
   },
   "0.36.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAB149F8625806",
       "checksum": "f38140a74fada27ae20e859bd3d8b5f464df12416fa110e443db99b4708a3d5b"
     },
     "x86_64_macos": {
+      "etag": "0x8DAB14C76238D27",
       "checksum": "56a55a7798a834f2fce7acb40550f08ae19f367f300a7b073e38541415062c2b"
     },
     "x86_64_windows": {
+      "etag": "0x8DAB14B4CB3E421",
       "checksum": "94a9e5391ad2443edededebca5c68c741083131a8992c47128ebddc782644c18"
     }
   },
   "0.36.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAA06D8B54AF25",
       "checksum": "b5f52ebb95a123d1026914231144f389ae1c993439afd12f974b2ed2c2d384f1"
     },
     "x86_64_macos": {
+      "etag": "0x8DAA06E56C9B3A8",
       "checksum": "a0736b3067aad74b610abd944011d669cbebbeb91f6ea179f43aa2284d4246b7"
     },
     "x86_64_windows": {
+      "etag": "0x8DAA06E137C65B1",
       "checksum": "63780ddaf15b6dc5225c5fee3a3152d5d19ea764c1eef43f65fcc2ebe277eb47"
     }
   },
   "0.36.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA8A4635A25D1B",
       "checksum": "fd98a0330412963326bf9767f86acb232f9c058bc8b6e21f61e78bd79122bb65"
     },
     "x86_64_macos": {
+      "etag": "0x8DA8A469741EA02",
       "checksum": "e71061f1be3fa73bdda4cdf8618fe790c68e9e0eb01276d255a407ecec0e5171"
     },
     "x86_64_windows": {
+      "etag": "0x8DA8A46AB162058",
       "checksum": "f61fa934f258218cb0b40ba8f6505749bea2743d0b6b9c261e6734f17b7efa70"
     }
   },
@@ -390,174 +491,221 @@
   },
   "0.35.16": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA79102B71453E",
       "checksum": "59c27cb85df7e26db7210bd9c8c2b9624cb408b9ae0cba24d16264b89bee975c"
     },
     "x86_64_macos": {
+      "etag": "0x8DA791198EBB22E",
       "checksum": "b540c0be28e61a90fc1f9a6affefaee46bd4cbdd96e80cfc903d5e760e913631"
     },
     "x86_64_windows": {
+      "etag": "0x8DA7910797DC509",
       "checksum": "44b524d52a5c61d87ffaf0f8152f97916fb4c6ce8f59b6517065310cabf3114c"
     }
   },
   "0.35.15": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA6B3AC0DABFE1",
       "checksum": "016be6571afb2281ec4841693cf8eb485d9073eaabe5f799d80c2e7dc2cac878"
     },
     "x86_64_macos": {
+      "etag": "0x8DA6B3AAB96EB3D",
       "checksum": "ab5705d9b23a90f83dae2ae29782405076218f10c0ce77d5b4720137464282ae"
     },
     "x86_64_windows": {
+      "etag": "0x8DA6B3AD1EECD52",
       "checksum": "d0f24811b6ebd945cd666ad6cedb83df220424efdc75a65cfe79b077c3d7fa9b"
     }
   },
   "0.35.14": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA6B36F906F739",
       "checksum": "73b872ca41998df4ead9dcc39dafd745c4aafe82cfd490d45e7e1bb5544a2649"
     },
     "x86_64_macos": {
+      "etag": "0x8DA6B370398F1F2",
       "checksum": "d26ff4a870c8f5914215db6f27907203ba18f5eddc5fef1e095d3a31b05c84bc"
     }
   },
   "0.35.13": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA4BA3B0B70329",
       "checksum": "d24a36f707b43a9b6102095bb1bb5cbcd12b2f793c280a9ab7f02a12ae3b1bce"
     },
     "x86_64_macos": {
+      "etag": "0x8DA4BA3DC3A5F19",
       "checksum": "4fbd61c81d0dd39bb4d260b8cb1e67bc71adc33c28950b75b91ba9327d60a168"
     },
     "x86_64_windows": {
+      "etag": "0x8DA4BA426A0DA57",
       "checksum": "25fe397a2c919529ad0681d13c830e05b94b877645686c9a260b8d762bb6a5a4"
     }
   },
   "0.35.12": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA2ED42A622BDD",
       "checksum": "fcc769ffa3233ebea09938b3db1ff5b9102be369955aa8ed7aaaeb95f7c0cdd9"
     },
     "x86_64_macos": {
+      "etag": "0x8DA2ED442676A05",
       "checksum": "4e10a2e2883780e1685362e504340930c3a5af07fadb2ce50a58097d4196a132"
     },
     "x86_64_windows": {
+      "etag": "0x8DA2ED4F1ACF230",
       "checksum": "ed4c959979a48d82eefd63b8795bdf1d7177302d6ca0106ac643785ccfe9ce85"
     }
   },
   "0.35.11": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA248A8F1678C1",
       "checksum": "b198d8cebeb3a78c4b96e977a7adcfdaa5a974e5eb7227481afe1f3cf54b0590"
     },
     "x86_64_macos": {
+      "etag": "0x8DA248B1ECF7FFC",
       "checksum": "4ce6d73b2c78a12c916ff2296dbdf6d35d164bf2b5d79133ccf9bab5ba38bfe7"
     },
     "x86_64_windows": {
+      "etag": "0x8DA248B38B90E1D",
       "checksum": "03d8e42c2d55baf0219d8d85817f68e69435cff86120eeb482079e58541cd2f4"
     }
   },
   "0.35.10": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA0383D8E185D3",
       "checksum": "56c0d84d4e5151504b1803248ea3a141d80aa91867af70f27236529c40c9f277"
     },
     "x86_64_macos": {
+      "etag": "0x8DA03845083BDF3",
       "checksum": "cef734b73efbb2105cb1c1e5a62512d13f874d55298582a895378b13d0276943"
     },
     "x86_64_windows": {
+      "etag": "0x8DA038433F3AECB",
       "checksum": "3ae2eee58161c0f1d9cf15f7680ddcec2dce6e481729ddd2c80d2276251c0da4"
     }
   },
   "0.35.9": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9F7E39C3A39CE",
       "checksum": "5759db0b6ffbe17ee2d762cad59814e086b1b619dabc4b2a14518035cc1bebc7"
     },
     "x86_64_macos": {
+      "etag": "0x8D9F7E3D092F87F",
       "checksum": "61a039af37f7d56ecdbb025458cc86c8a0084073e0fb1d2cfaf90ca33d8eb2b8"
     },
     "x86_64_windows": {
+      "etag": "0x8D9F7E43865CF9C",
       "checksum": "4f47e5548a62b89eb0dee4f3b1fc5e0d5c2391cadb2204b16eb39c25cb62bf84"
     }
   },
   "0.35.8": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9D5BF8C432767",
       "checksum": "e99e105c1bef9c54fad91715f7842ca0e8301d4aaf5f9a8d4949e37dbfd5fe7d"
     },
     "x86_64_macos": {
+      "etag": "0x8D9D5BFC5CFF7B7",
       "checksum": "a40daf4076036fb681bf8e9dc94566dca1b7b708f6985a85d13363a0c5893d19"
     },
     "x86_64_windows": {
+      "etag": "0x8D9D5BDDA26BDF4",
       "checksum": "857492c24b8d674eda9a38363455821d4bcae861cb50a96ed70b43fa270f5a34"
     }
   },
   "0.35.7": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BC91E1182C3E",
       "checksum": "cdacd5dc3cd5f2c92657e6776034ac70b1efe8497ef5ac807ac2f10361cb2992"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BC91CBC9A6DE",
       "checksum": "8d4b4274f5f148692a594a89080b4dbd0e9eb9d89da24ad3fa872d6064b094b9"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BC9256056114",
       "checksum": "d9d2186bf425547805d8391082189c9a070eb7552d998fe8c237e91a3f84b5a0"
     }
   },
   "0.35.6": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA27F0746732",
       "checksum": "de90c2b0dd8ea7f065f2e25cf914d9bc4a8ae5541bc4d90f47e4a41db5665681"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA28145EDEFA",
       "checksum": "cee66e71d956e529068098262a6ca385ba3a41c219574970d9076549b055f4b3"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA280FB64F4E",
       "checksum": "f9d5eb1175ebcd2004c6ee8c43c888e65f862f8f3b7dbfb4d6e973ec5e2314d5"
     }
   },
   "0.35.5": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA27F23DE848",
       "checksum": "a993e24ce1e707be544dfb37988162994e531ff616c8b8b4c27ea29967562242"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA2802BEF6AA",
       "checksum": "5e68d6b45bb9b9982ad0b2a7d81c31f585b4fca67a0fa41f58bbd87dcad1f64e"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA27ED29D523",
       "checksum": "01d33929aa6b5bf0add853a05657a47b4ce60c4793ebe4694f019d4cc47e97e8"
     }
   },
   "0.35.4": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA27F919F71E",
       "checksum": "cb836d9df047b7186ef1ab360b71f79c77a3b7a2f4a83ce89fb42f6f0df01402"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA280991B708",
       "checksum": "c287024e3b595b9c5dd8f413a3628f67cccabceac2e5894f44a18ef5a6d0b4de"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA2804BD3BBE",
       "checksum": "beb3ae6290b65ee1f290d3b7a6832f5dc5e1096331400841f80c31e45d865cb6"
     }
   },
   "0.35.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA2807A37532",
       "checksum": "5e50e9b4b9272adbb9301872e795d10917df8ad01704a507616627897e51c5c3"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA27F33F5470",
       "checksum": "a8ecce03a21b0cf8535745b6397589effc687fe61d61f4c97c7ecbc097055178"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA27FB088702",
       "checksum": "d89cf5d2812a77c990e02950d563712d476408be5499fc013a7902c72da808d2"
     }
   },
   "0.35.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA27FC69917B",
       "checksum": "b3ded2426d987a784497a89891a271ff3184c8cce53243df9ca51a70ac77a6e0"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA2814610189",
       "checksum": "cbc6cfd6a681af40fb9a0e18a0bff04b461cd40222086f363e0fd93800708e6e"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA27EDAE3443",
       "checksum": "e37f89258ade2d2acfcdcec01177b7ce559699be94d32380378585965b3b64b9"
     }
   },
   "0.35.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA27EB14B004",
       "checksum": "429c60665b20d43c6492045539add3f41a6339a0fb83d3d7d5bb66f926ccff36"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA27EE6A15F0",
       "checksum": "eed7b38ed99050258d99ad144d35c2a0a2dfd59373c5787c49f1913fd48d723b"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA27FC0586FB",
       "checksum": "89a4a208c2c8190036a13adcf04cdb51e3763254b41bef19b7c38935b2446941"
     }
   },
@@ -566,12 +714,15 @@
   },
   "0.34.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA27FFDBF10A",
       "checksum": "e5c32dfb43f02713b3e34e9120fe29efa1b4493bfabcd207955d3027fd7e9da5"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA280518BBF4",
       "checksum": "cc3729e864a7ba904772195db3483ab722fb1b4f32be7c54297167db4322fdb1"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA27FD566729",
       "checksum": "3cd89166cdf2d2025c74d6dd36ad15c5fdaaae33b14b3e5e559bb9351e5d3ca4"
     }
   },
@@ -580,12 +731,15 @@
   },
   "0.33.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA27EBC214EE",
       "checksum": "670d3419372f58c0563179e8702ec1d031a76d840a376685ad05423434ecc773"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA27F9E53FED",
       "checksum": "be27c110d6f81eb95326aaeaed196cf3b77183e15f0a9c28a808bb870ccbaacc"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA27FF79BB0B",
       "checksum": "3f68107e377267793f3281f0e5bd4b17e40076fc6e157c4b3d477a8b81c232f6"
     }
   },
@@ -594,199 +748,253 @@
   },
   "0.32.17": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA2811D7CEB2",
       "checksum": "21f8b5416135d4fc686fb2e7c1b6f355b810bcbe94707c8094275ccae409b820"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA27ECC618C4",
       "checksum": "52781bd70b2bea54620ba10e88601a5bf4c710a171d288192eeba4fa3d4da0b2"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA2802EC8FBB",
       "checksum": "09ddaca087d8b53c4d9723039358477b1516eff31ef1d40260fca3da046b14b7"
     }
   },
   "0.32.16": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA27ED826F9B",
       "checksum": "f84bf2c9f8b6d57d8cfc2cff185a3bf1725ad7f411292cc22c83cd2eac4d3fad"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA27FB4CB214",
       "checksum": "c74c6867475d2e856ef914418e92aea3d0d4cce793ccabba270888cb96444be5"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA27F94C4A6D",
       "checksum": "44c25ca562482ccc363bd357cb8091b4c2da0225db564fdf54d1b36bc9e846e4"
     }
   },
   "0.32.15": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA280B512777",
       "checksum": "4837542b1f9046563228ed98c11c1caf0ea1cb213c14297ada5c71d2a0fed96d"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA27E9823C82",
       "checksum": "a88221c2358acfca87bb59f91d527d06aec805c8d440378c727d1e04550f1ff8"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA28137082E0",
       "checksum": "9d3bb63ee7e837085adce3ed0e29a387579c84611aa4064c6514508b2f92cd29"
     }
   },
   "0.32.14": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA27F80D1AF0",
       "checksum": "189b57dddce8944fc27a7bec0696d204fe1a70b4291181c0e563850befba7b2a"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA27FEDE06D4",
       "checksum": "79951f7152c374a0a0f8809d245935f6b977053e32b9ff5dcfe46e7bd54ed5d4"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA2813638C79",
       "checksum": "388f66fbbf2682a853e99e3bf0aaa6251fddc5de77bacf143e3b4f44e312e5d4"
     }
   },
   "0.32.13": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA2809C235E0",
       "checksum": "62f895828ba1dd3dfb49eba643b4017c727730b586de9a52963919c123f13827"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA27FD32DEC5",
       "checksum": "875721804278df79c8620dfacc85f92afe84bc860541811006c2e74d785fa342"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA2803ADA0D8",
       "checksum": "5c89f81db071ac772ae82c7449b1ce4a53534c059deab29c671f75a12248a202"
     }
   },
   "0.32.12": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA2811C47091",
       "checksum": "dc71a66f4ad8125d9950170caec894f58244a59afb1b672480743f0c7c5ceae3"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA2801A1A223",
       "checksum": "9dfe002be4e131cd89845fca6dfc7767817b60074cdad01caf1a277351f87053"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA2800DEBC8A",
       "checksum": "2fe91b3d1f08ae033bef92ec00b861598c2e4bcd5ac82e0319da4187675cd0d2"
     }
   },
   "0.32.11": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA28151C9533",
       "checksum": "6495d2d5db41df2b6abe966ec2fd86b7aef71701245dfd24fb7baa3137b53444"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA27F5F1DC36",
       "checksum": "676f13d18b7986f26f6e68020bb9f62202ac9d0d56fb3e07e6d3155f7d0311f4"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA27F1C7B802",
       "checksum": "2dd1ddaa8f1844b38f711032ec59b34314727fef715bf74743babe50ac36b85a"
     }
   },
   "0.32.10": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA28060F7B44",
       "checksum": "c9c22f5069b660b83e888fe1eaa9f51d1fd413b94fb197324cc7dfbc82668b13"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA27EDB6E581",
       "checksum": "1b48b7e6f10122d1486ca7946313d88727e5453255c2dfd00538ae919a5db5fd"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA27F85C40E4",
       "checksum": "af9a5f07f732288a2478825f8fb3985cd66406904cddbef2d02d6bd15b4fac24"
     }
   },
   "0.32.9": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA2805B88E41",
       "checksum": "737cb605580df41033c5623d7a52fc6ae8fb65e2d41a6ab175ce970d8e78f3ab"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA2812210211",
       "checksum": "05d6db9d251e920a584a94b2dfa760e956c9159b47199fbffb3125fc8454e521"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA27F1E48AA3",
       "checksum": "0e6e86438d43c02f76a1a1461cddf1ba98912a70d413214e49b73b821043a8b6"
     }
   },
   "0.32.8": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA280F05DD9B",
       "checksum": "0ac947ba9a5c61bc83607170661285cdc96436bfbb05c47681cfa74a2bc4a2e5"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA280AE6DC51",
       "checksum": "cd1932e8bc62e0b81336502cff98dad52fcc73ce45f7be2f69ca246c860e9f77"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA280253733C",
       "checksum": "5ebf3391c1b3076de12e62989dd1924ecd858180c0cc3e46a70bcbd94c67397b"
     }
   },
   "0.32.7": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA2810CB40B4",
       "checksum": "9429ab55b6140ed72a035480f875b8a5209a353aabe058bd7756fc23f0a23ed1"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA280598D5DF",
       "checksum": "f455d2ad68178ac054a75c1686214400e322fb3cf47187ea7c71e5a24db3c034"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA27F4884685",
       "checksum": "526f9aebc85a3ef078f4548939cfd1c9deb654b773905222af965e981cc2fbef"
     }
   },
   "0.32.6": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA28062A796A",
       "checksum": "058aaf5f5815d134a45b8bc8e73e36ee21e8ed0ec004e0b9ef770df6e1091822"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA28000C6FDF",
       "checksum": "db52fb6cd2ec86ae07f6863106cad91d8bc658c3be68a3c32f67bb1460b29e65"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA27F0362EB5",
       "checksum": "2fe38b5090b85a779d1b66c0a63a25b198ce17482bcab01f96562931cb1ee202"
     }
   },
   "0.32.5": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA27FB2225D0",
       "checksum": "4abc84163d764dc7e6c9ff3a42f5e93a10b51ecaf7b86d373e57953cf37de4c3"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA27FED0E95B",
       "checksum": "db028ded7c05854e15959f6eb3991793ed8997bb43150fc0a5ebed5c3916a1d9"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA27FD3D3D81",
       "checksum": "1e6ea573937c24076a264230539ff9c7669f41c49857dbf9339d14356fffe8a0"
     }
   },
   "0.32.4": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA280E075738",
       "checksum": "176d3230e2b25a9f4f49f3dce353afe6d5334ef35591474dbf2081bd2129c2d8"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA27FFC3D8A7",
       "checksum": "8ccee95564130f90244650745c45ee525d5bf67fd3ece24d50f5ae15a363cb2e"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA280F32DA85",
       "checksum": "311a96a662a68dcf73ceaa57dc7606f99a8b7696b147eb4e9c77f17aa5b15004"
     }
   },
   "0.32.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA27F63802C7",
       "checksum": "467215bea54c98a6de07ec343de567fc9fae4a8e8c45d6c04b6dce8ea866d539"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA281192925D",
       "checksum": "259d83c8f31f325124ec8998948829fab22ddea676a876463667333184a7d6e1"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA27F85A6C7A",
       "checksum": "9e16ef1e9d24a9eb50cd50b3bede8c413665e00979f945e1a43161771dfb86f2"
     }
   },
   "0.32.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA28043226E7",
       "checksum": "3b9ac1c1fd5a3e49322efdb11195f1c56e118398e8e1a85476d496466a880ad1"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA27FC5FF5F0",
       "checksum": "a8c5129070ed4b44a669da07a1c43d5d5c0c4deba6283bf9153b5cefc081521f"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA28120122A1",
       "checksum": "d0d9c9ad2f401e38403ac56cd0c6dc2566710b6994dc733d0db7f9473b423034"
     }
   },
   "0.32.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA27FA1D85CA",
       "checksum": "db0d5230bb7c1e335adae1506db9494164b44235f08c3d8822b85370ad1b52e0"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA2812E7DEB4",
       "checksum": "208d381081959212c79a266cfed2528427353ea91d2f6e8b50d2e972969afa75"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA28011B95A8",
       "checksum": "8196c537ee428563849d566a1c8cc81e509ebcdc253bdca1a93f54c5a5000883"
     }
   },
   "0.32.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA2802278792",
       "checksum": "49367fe8feafa082b79892b56d694f6dfc9eb98c3389782adfb38d17f4282217"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA280CB65001",
       "checksum": "929a3a973e11fb956e356546a7cd1fe8b5d7fcf61f589acedf1f53a0f9b862c6"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA27F63B36A0",
       "checksum": "430b6446b3aaf9784393697cbca0dae6d31ad7b17fc1e5f1b96d6bf8842d4267"
     }
   },
@@ -795,23 +1003,29 @@
   },
   "0.31.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA27F146B3E2",
       "checksum": "96308d4d56cc9fbe6fec29e4e21a8b36eef6c4c2f44a63ee2b5cc51582639956"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA28022ABB6E",
       "checksum": "e7f334c8dddc456561853992ad1c303abdf061f25f6fe2138c98f357fe63e3d0"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA2811A9726E",
       "checksum": "c5c11a8bbf4ba8299458cb912d44ac77dd66d0b803889eea72586bfe0f72339d"
     }
   },
   "0.31.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA27F52D9673",
       "checksum": "44d822d0a522fbfb40e4773c13c15385d6558a9a82a0162d4381967470e51692"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA2807505833",
       "checksum": "d2377fe4bc67c53e3ec88004bb5ccb6155bac1ae77e92218adbeb69f47b92dfd"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA280D8C93C1",
       "checksum": "20e428ee62ab784e4da43f15791412680d6fdf6327924d90e47f618a0ee84c9b"
     }
   },
@@ -820,97 +1034,123 @@
   },
   "0.30.8": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA27F3C190E6",
       "checksum": "872ea97a41b93fa8c2f73ca4cb19c34b9eea56722a4a8b0b25aba0addef19245"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA27F084B880",
       "checksum": "5bb097a9c0c8445aad6524466989fb7f4899f7c660e2973b884d61260d8e1c94"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA280B2DED23",
       "checksum": "e11850bd6a02bf62f8ed61a2e700207506d32e563190c5a754d89d74bf7ea57a"
     }
   },
   "0.30.7": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA280079C7D4",
       "checksum": "417d334e88812e9c8b154b1ca5e7dc9d4575bccc3ed347549d8c9f95bda795fb"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA2814D731D0",
       "checksum": "5f745bcead4d3566ac024eda470955953ecdadd6ff2737a611e427e659bf0e62"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA27FF3C6CDA",
       "checksum": "4f9c0ae02ca0ea72a53247b53163b768d219826d107077e824b82f76287c5485"
     }
   },
   "0.30.6": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA27F770075A",
       "checksum": "2de70a59c320c2fc2486f39ef373fbba08f43eb7d23b2d873acc4f7291568b09"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA27F3641528",
       "checksum": "1bc83a3b9e05a0dfa1101bed7d38ac6b5f39f4a36c42aca9544cae30572d0659"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA27FBC04AAC",
       "checksum": "40bded564cf6a8224ee4becd19ceadae4789759f110226d7828d3302f224de1f"
     }
   },
   "0.30.5": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA280AB3029B",
       "checksum": "1e3057a6e313382180b10d2a8416d6a484476e9f7c4cde8a21b383c1150aa72b"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA2805DAB74B",
       "checksum": "073a504554473b40e6e171b0834f8866d9eb73da93871229607d672fc9559b95"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA27F0D2A62C",
       "checksum": "593e9004746da2744b3f5c87b1fc6ecf894456c84ca7fd4e960845c3d308bd60"
     }
   },
   "0.30.4": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA27F22B2654",
       "checksum": "15b96f573701f5d192238ec2e5e42f3d007b6c1c08e130dd2488c1156748c2c2"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA280D3CAA91",
       "checksum": "58fd2b02fa669949b5100b36329a4c70ddab02db109e0511c053fc7f723a0e6f"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA28058D8CDF",
       "checksum": "3d6394df7b0c31497dd72a55f0101e25b3bf1e8d844de7ff5063ea48dd8030b3"
     }
   },
   "0.30.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA280F4A08A4",
       "checksum": "b15afb2cda4528103ad3b150d144aa1658bb9e7fa1a8d1f53da9525978579057"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA280F1B5E48",
       "checksum": "bd00850d908fedf49f71eef13c1cb9969e4554db0b7cd9600ef00bed6c0f9a00"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA2803ED38AD",
       "checksum": "2386a4e458ede8d01723b356e867ddd2665a8de2d5027b519b64c4bc25fc9ef9"
     }
   },
   "0.30.2": {
     "x86_64_macos": {
+      "etag": "0x8D9BA27F54CD9F7",
       "checksum": "03bb9800436e847e7de7b7894eac830b80f1d6f88c47dac78cfbc593c2fac34b"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA27FE9680E6",
       "checksum": "1f322c17cf32f8f874682137bc09477b18a739679ef536a8f07fc4bc701be367"
     }
   },
   "0.30.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA27EF25D09C",
       "checksum": "03820ece1c11bfbdbac8cceb5c0166c83b4cfb5e5f15775d648b1d30e2bc471d"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA280B56CBF7",
       "checksum": "3748f3f30631d3c4a7b86923067bdd64b41b7c71df53a0ed26b61b5e77789c8f"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA2803B0ADA7",
       "checksum": "41bd7a3eba50b88b304677597917919811b38fc97695552414235ab2f27a439a"
     }
   },
   "0.30.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA27FF8B44B4",
       "checksum": "7dfab94855e71c168ab315ec6b4ddd2682665ee4231abcacab1ecb88e9181352"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA280405C62D",
       "checksum": "41c37bac0d56618e3ee9770e1e3aa88c16c99fe073ce49af6fbc0683766eeac1"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA27ED8B20E4",
       "checksum": "962026499bec5d2d5436bae5f0f367bfb98543e75120eeb1b68c662adb672125"
     }
   },
@@ -919,12 +1159,15 @@
   },
   "0.29.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA2807004801",
       "checksum": "440aa36e4fdd94000c8e4e7905d7d2ffca29cd7c090310361ed3aa863b6a6c65"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA27FAC768CB",
       "checksum": "680b0ca478f41a61865a4319177d3fcf8d4ad4dfa97bf4d002ffb41a1fc25ecd"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA280C6ECA16",
       "checksum": "035284ac824621e2bd3188a18a13ad8f404f08ee01fe00f20162d00c8a9d5651"
     }
   },
@@ -933,12 +1176,15 @@
   },
   "0.28.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA27F41A796E",
       "checksum": "5044b89a97c8f432af40ac3a51de9a36ddee13ce1a793ae1e56f1664b575460f"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA27F4254D4E",
       "checksum": "38f8950e30d44568c358774f755e27bf8bae1f771942fb11b4a27d69762c3f18"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA2800697684",
       "checksum": "c08e9b400f5650b0ceb68dc3545ca429e5ecb64f86b0e719d24bbf6e34f570c4"
     }
   },
@@ -947,12 +1193,15 @@
   },
   "0.27.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA27EDBC62F5",
       "checksum": "2cb90f8a8d56b78617c7bc222b0635225375ec89350c820cbed9875153aeb9a0"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA27F00191CE",
       "checksum": "fb4f3205ec76e94557bf81d1c1eb7ffbbe51d0833201f966339de4ec6321d11b"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA27FE39533C",
       "checksum": "6f2dbeee58c50524af71efb52a593c0a7701ea5dba66bca7f5aef1037b42fb97"
     }
   },
@@ -961,34 +1210,43 @@
   },
   "0.26.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA27FA0D347F",
       "checksum": "c7b4454fa6242835c685b7ea4998436646c5212bbf69975024eb6ff2f8bc3ff9"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA27EFC04C8A",
       "checksum": "0ca17ca3f1d4d13883ffdb21c1f96e37dad4a6e71f8b4fec96e29fc014c865ea"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA280E5AC24B",
       "checksum": "ca0f96be343bb9cdba5d1aee980ecb1830ab7f5c2d5ac5db9bc3c38ad0cb973e"
     }
   },
   "0.26.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA280C855C0E",
       "checksum": "f87fa6887dc4bba5a124addb6df3192f9e756ee0058bf81617d0a33123d97ae8"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA27F09C34BC",
       "checksum": "a2596b26e362abde366d25378acb193b096c4227d8500a8f343982e59e2a6986"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA27FB8A0053",
       "checksum": "e0b8049e8ec5588483eb550e7bbd5c0e93f472ce268b5c018823312d3e30e987"
     }
   },
   "0.26.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA28037EA86C",
       "checksum": "f2382c97ff13ebbac87b3b40e0c116d5a3193f7dc0ae5969b2907ece7f5764d7"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA27EFD38399",
       "checksum": "2b1835cd05ddea99247a74cf930b6850e05579838017781771ebd1d6e0139012"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA27F83F954D",
       "checksum": "37bbe1afd0bb77d51ca1d9d671a18450d3029389ff012e5b8acf4acf4f06fd59"
     }
   },
@@ -997,23 +1255,29 @@
   },
   "0.25.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA27ED81374D",
       "checksum": "5fc2b4723bf0eec930321624a2854d9e2a6722f4691a398f7a31959d9c825779"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA27F3E0D42C",
       "checksum": "17934d22b1a9737303c56d8bc8692b760a9193d822c261355d5fc5003e13fd0d"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA2805732AEB",
       "checksum": "39ef6f342830764a25b54f8c6b396b886fc4f5448d6c40cee5d11700579d5de1"
     }
   },
   "0.25.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA27FE47F71B",
       "checksum": "eed6d0126d6a8c71d9271080e5005720d3f1f227b119b0c784921a0a9e3f6cf6"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA2806234E88",
       "checksum": "e7552ca89719ee2b4509ea421306ab4ecdbe8f24b246ba4a5bb8721216c39cbf"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA27F3F606D0",
       "checksum": "c394da933751aa6953a7037ee6f0ec42a74a36e16a0540f1b67517e6564d1da2"
     }
   },
@@ -1022,45 +1286,57 @@
   },
   "0.24.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA27F7C176E5",
       "checksum": "58dc12726bc306840c868d16d7674901c0e65a0f798e06885b7738239077f22e"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA28037F1D84",
       "checksum": "3850c1978e74b8bcb0a8452fa130c14fef857f33d293ac5188088c3d1a16236f"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA28009DEC64",
       "checksum": "20a11561f7576bb9c0909832cf44d4a7228d971d42f50d172c8e8f53ec94149a"
     }
   },
   "0.24.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA27F9877618",
       "checksum": "482447d87724b73dd2274239c37ad0a67ae0aed20c772ed76c22c4a473bc826f"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA27F38CCCEE",
       "checksum": "f5cfd2d5adac6eb7b6c886f16b608a50dd4b513d20121d59915d4be9d8faf7ef"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA27F9FDCD6B",
       "checksum": "eef767457e361cc8007f517136d15346948e43dc1cb124f822f778904868975d"
     }
   },
   "0.24.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA27F1964EF8",
       "checksum": "063335cac1e8d40807a3b75351f129a611632d6891866ac7977a8394f2675668"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA2801BA2FA0",
       "checksum": "40fdc0094c1e5e6e2e6048eba0aebbed9f2fdcf372e9ca50a4f677fe1afa4c00"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA27F784EBE6",
       "checksum": "230f7a3b0fa0027fd46352a9cf29908fd1203db1f7547c3624d4a5c1c4a2ad7d"
     }
   },
   "0.24.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA2812FA0485",
       "checksum": "2848528ea16dd786de013a5b1bb2a7c9cc087c55cafff72d1045891fb27cb80b"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA27E98DAC8A",
       "checksum": "bc8d3f04ef4b92f62d6c3eca56073a5c347e5796edb46e9283ebe7fe6104011a"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA280047266A",
       "checksum": "40fc4402b9a30b49a4b1808635f2045df8c62f2695f773715cb90830e6357979"
     }
   },
@@ -1069,12 +1345,15 @@
   },
   "0.23.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA27F6093162",
       "checksum": "044ac1dca4085c19b695d843c6b7e277f3d956c194188d07a98b2766cc1e5eb1"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA2804CF137B",
       "checksum": "e646ad30bdf0559f7400dbcd39c3c4f41f331c0d05175659c56e0b6f81d5fcb2"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA2812B738D6",
       "checksum": "c21ef84f5ed33b760d892811b970c5ee2cc0a493dddfeeef8dffa3abeeef67fa"
     }
   },
@@ -1083,34 +1362,43 @@
   },
   "0.22.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA27FFBBEA92",
       "checksum": "aaed06d001bda6a26d3a208839a4c6006871f4e92cc8c9f08195bde812cdfe99"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA28150C43E0",
       "checksum": "2a032d31e9ae5be6eee2c66119f4c8be5274965f62eda8a6e50e09e846789340"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA27F6A33824",
       "checksum": "ace9e6aeaad37f97899864068b303ddefca661aaea34dd1cb6b63413f36dd243"
     }
   },
   "0.22.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA28031B6122",
       "checksum": "e7030116bb29582ca6cf2cfbf0b0946729f20f256a7ad0259865b52054dfc5c6"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA27EB20200D",
       "checksum": "e56a817fc8584e1d98c2c339ebc7f5c00e3c3cfd764ca62f38d0d653955fed22"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA27FBA46249",
       "checksum": "4060fb088708d6440427d06273fae112be11f274d48cf1cb7d2f98361c5e62d1"
     }
   },
   "0.22.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA27F3DD523D",
       "checksum": "556c195f830bd7f21024fe8d6115383adf5aadc1c16c1e9d11f53cdbe8c4e4c9"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA27F9E31D5A",
       "checksum": "45092da839ced88558a4b1f11b351aa589373d2a2c0e01a8f8258db2de4d4c0e"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA27FF0733B9",
       "checksum": "817b69a5c764cc1ca0a8d0d13d4a7a4747d92f08b6de3c6d2bc9e35cf5ebd29f"
     }
   },
@@ -1119,12 +1407,15 @@
   },
   "0.21.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA2811CF1D65",
       "checksum": "78593830b8884d515e9bc50573c3037f3d7e5088cc388dfddd3a5fbacc7e4767"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA27EE28D0A8",
       "checksum": "b7182b05d7358832e73aff497aedc7a9ada3a66c2f9ab22065b1a71756d3e403"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA280D2F8D1D",
       "checksum": "2c121af88d73c4779848c5f0d33dae84b430e9d26420622bcbe69033ff101136"
     }
   },
@@ -1133,12 +1424,15 @@
   },
   "0.20.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA27EFF203AD",
       "checksum": "33c61bba8f88b41195e5731d75c5525f4870b0c41c4241e258ab15c2ce32cc40"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA27F7E5C288",
       "checksum": "a41c3c06ed63c2706250492721ed3ba56dc203ebe4ef817b6775ff680514513e"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA27EA7E2B2E",
       "checksum": "67e4d2a0ee286eff03081688ce5b0a598825f57ade6c6d391b90afe6ee41c79f"
     }
   },
@@ -1147,56 +1441,71 @@
   },
   "0.19.5": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA27F440E79D",
       "checksum": "556eece0a9b14101e352b7f841229dba3d34d9437017e082ff733e89a55ae0c6"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA27F126D472",
       "checksum": "bc2b108d00b5d1c97dbb21d86bc784b183f1594eea59d506bd87ba0c7a23a4cf"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA280470AD7D",
       "checksum": "9f54f8ef5c801ea205744466443963be17e5c14d6c7b40ac6af87e98c5208590"
     }
   },
   "0.19.4": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA27F203CDED",
       "checksum": "b34e19709e45d355992ecccf387a369c4cf3668f3f88966fe9f7627687f330fb"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA280D157931",
       "checksum": "2bbe04d6749815f700612521676331a5192d3a0b82dac34d39222c4b2eabcb36"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA27FD3723E1",
       "checksum": "b75cbff66e1bfdfd977266d3197bb4d9cfffc1ee6ae4153ce73c46f4a2a75bc2"
     }
   },
   "0.19.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA27FA762044",
       "checksum": "72cad5d9755eb66038853e1a59d8d6ad8aa582b3989f8d4c36840ab5e9e9f46f"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA27F9A7CAB9",
       "checksum": "25f1d99db2746715825726033c82491da9fa4a7c72ca0f020044248365d6d92d"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA27FB76A230",
       "checksum": "cd203d9b3ca79bc23fabd0acb61a954987fbc1246b4ed305e5ee95e189edd39c"
     }
   },
   "0.19.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA280BAF666A",
       "checksum": "2177e3b78bf08fc1859e8f4655b56c6429c9e744ceba732b47a3e7876395a489"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA280BD9F2B7",
       "checksum": "23ae250715a61dbe4ae8772ca1ce666e8d2e84e495effd1f098f43401d62db8f"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA27EFBD8DD5",
       "checksum": "d7c4746b46be720da6abc9e231d0f30e3435fbbb6da8a393a89bab7c9e14bea7"
     }
   },
   "0.19.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA27F056F86B",
       "checksum": "08d1ac7b77125d37e05523d8babaa9748555fc035158c2b0f985dcfd95afa9a3"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA27F552576F",
       "checksum": "477f653743296e165c1cd1224f2b2aa02eb32037d98bd449475cef80d29aca39"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA27F3E0FB37",
       "checksum": "713579c21a835639aa4b2c3fe7d4f0f8160d504f1d085818b6c5bc2ab55d8cc0"
     }
   },
@@ -1205,12 +1514,15 @@
   },
   "0.18.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA27EBD6F97C",
       "checksum": "eefee39f6f5aaa6d112c59bd098d3f7fb615064c5db0e7697320217c790eb5db"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA2810EA35D1",
       "checksum": "67aaf971374c87129a19b96170962c126e064118e3f0ca50bbbc67184782d0c9"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA27FA1F5A50",
       "checksum": "efd0125a42fc71fb01f76c522e854e1af381ac8c83b1e2724e35f6307136e8d4"
     }
   },
@@ -1219,23 +1531,29 @@
   },
   "0.17.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA280B2B7C81",
       "checksum": "da8e9408d715b503b53e7b531476271c78e528b028e31a0d35355decb5a36055"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA2807215FC4",
       "checksum": "9fead0f8fc6a30d0e9a52eec69f6a83da3c99d75fa570d0c628d412d2ada5162"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA27EBFBE147",
       "checksum": "77d64a98f22d35f06a1daca90fb874e646d14b3491fdc4e49aa3ef660ffba5fd"
     }
   },
   "0.17.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA280FC7FFFE",
       "checksum": "69a6f590bce791070c8b703f2c8c97193ace062c1edad82c7e4c2445a1e00e56"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA27F545D606",
       "checksum": "962cdc6481673d3fdde3e94815f814916f96000e38acb14f11fad7ba9d62c08f"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA2800B6EF00",
       "checksum": "425760afc90a080d734a21b4197761ea0be709466f19231645ecc553789781d9"
     }
   },
@@ -1244,113 +1562,143 @@
   },
   "0.16.10": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA27FA5F192B",
       "checksum": "0fb5dc49936869c246dbfb9990ff1aeaaa3979fea0d637294c504908101bdecf"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA27F5893E55",
       "checksum": "999cba38bd2bbc99ae9cfe43a31affbda6a73e3ac2e7cdfb470049aa0e41e1ae"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA280B6FA78D",
       "checksum": "51c57d4268f47ec4f9835ee2ca219770b04bfa6bdc8e5ce683322e50a2a929a4"
     }
   },
   "0.16.9": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA28039317CF",
       "checksum": "0125031fdbba5c0c945cc8837c28fcf2359df6a1b15f5c61513577d676d5ac69"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA28125FD6B3",
       "checksum": "a6f917bde8b2668445ad010128aa5acea1a161a459e66aedd7af3f8cbc8d2f76"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA27E9C0C30D",
       "checksum": "cd46e87ae424d160a666236e6abeaf7c7f71a53f18d2acb03f9101eae63f474f"
     }
   },
   "0.16.8": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA27F145A298",
       "checksum": "24f09baf6898d3403641a7c26077303f81388202510b91b12debdefadd0288e2"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA27F860AD11",
       "checksum": "6fb9d08a1229bcf9c300b08ca18fcc2dec33e90a46c3f58ee390b1a0b8a11583"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA2809F59A78",
       "checksum": "ec70bc8562ba1236f969edefbbbf7b064d69fe161b75afe747b95a69408d8ab8"
     }
   },
   "0.16.7": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA2804D37FA4",
       "checksum": "728a992713b946d9052206fba39da462dc4167ba8e4ae9a4e94fedd79b4085df"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA2806E06891",
       "checksum": "f665a453ef595d45c99f380a14957b7d0ad9240c1e919b521678cb11b2cd97f9"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA2811BC827C",
       "checksum": "93dabdfc253a2c634000025c70f947000807ed991a994f255254e7336b377990"
     }
   },
   "0.16.6": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA27F06E9BA7",
       "checksum": "3a47efa015f6d7e781432192dca0ebafbbd3a2782eb6dfe22685f3aa809c46d6"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA2808B4BD8E",
       "checksum": "7ae3a3009216b28f2f0c1cfb72b27389faa8a42c911647f95a0b796d4c8bfde6"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA2803E9DDCD",
       "checksum": "9315009e445a9d8948dcd80c37857920c71d1043b1568b7824677ad2329d79f4"
     }
   },
   "0.16.5": {
     "x86_64_macos": {
+      "etag": "0x8D9BA27EB3CCBB0",
       "checksum": "2767b8e1201e27878ee62aa090ff15021add35beaffe6988c151bbb2f61b2a22"
     }
   },
   "0.16.4": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA27FEDA84E5",
       "checksum": "60ba004ea2a0d92ff6f49ad4905c134accf32161d364f0967ebc655a31b16aa4"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA27F4964E3B",
       "checksum": "2ac0fdcae5761070a89c25e23e64b404365c490bfddde0720d8b27b2d8052121"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA2803D40F05",
       "checksum": "ad7128b1b3bf75ca97066a0e94387790f3fa5e99b5e5bd68eae9667ee881488d"
     }
   },
   "0.16.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA28073EA786",
       "checksum": "2fc4275687f37229f57844747c7a82c246250c4d78047ce0b429a061376a6ec8"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA27FD23028F",
       "checksum": "3a98e47cfac1fd8ebd509ded6b1beb9a821479979bc0c13b2d33e2e46a1c222f"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA27F2419141",
       "checksum": "f44c942f8652daf7f986434cc16cdf66af25bbec33269c03808ac93b71b2fd57"
     }
   },
   "0.16.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA27F7B14CAF",
       "checksum": "d8fd83d3de549dfab7ce2ef649935bc8d1e659287e9c5a01708df12aa7f0aa4a"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA280E70B81C",
       "checksum": "a7ae9f3ad69626a058b3c553bb3baf42f2f3381256e9e0f14c23bddbae4040c1"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA27EC691224",
       "checksum": "038df22a51cc27fbe66c9e7c89d7ef6edf704b2c595b97930f85a71607ca760d"
     }
   },
   "0.16.1": {
     "x86_64_macos": {
+      "etag": "0x8D9BA2802F6043F",
       "checksum": "91298f542f535cd36ab6217be9fadd1682408fa899e4a76cc48a506f31f17812"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA27F8057AED",
       "checksum": "1a714676a61b1eec0cb985d6502d5368895a29760ce624626cd9779763ff76d8"
     }
   },
   "0.16.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA27ED37DCDB",
       "checksum": "2201fbfb7298f3e7240aad55838d9c899fa5c3004b4991e4aa3bac0941ad4046"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA27EEB82A97",
       "checksum": "4870df8c60f9898dccb4aabb36b2da2223156df0556ee8a459b71e77e91ac0bb"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA281550E40A",
       "checksum": "0149c1e43423226250def09d0b50e46338c3d8cf817d5bd34124acbf014d558a"
     }
   },
@@ -1359,34 +1707,43 @@
   },
   "0.15.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA27F99AFB44",
       "checksum": "7f20242b8bb9d22844c931a2eee4869044287fda2139488bfa9f75f8c7fbaeb8"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA281279C393",
       "checksum": "6f9f25fd49db9f0fdb419f78bcae9cd36f4a882f189330f327d45851cdbd4108"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA2801F4BF24",
       "checksum": "c8bc4dc62a2d048aecd747f55a153f7cc18555f20936764eff06d29f32d79b69"
     }
   },
   "0.15.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA27EDBB0395",
       "checksum": "f7abe3e1247bbd0fed211ccd902f98a6390c473e271f4f0c37d3e19a5862945c"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA2805D64B1F",
       "checksum": "0b45e818a8ffaaf78944c0bb82ca36add80e6b8a116358a16498cc32e9df4660"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA280B11DDBE",
       "checksum": "9d1e9b399dc6a899535dd14167eff27cb4516bba1d1b2e51b4c92e4942ca484d"
     }
   },
   "0.15.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA27F8762DC4",
       "checksum": "1cdc52339f11c6c48e5a1ac1cbc7f269a93c4fb7b182c6d1f2a74f69e8ef3dc4"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA280C6CCE90",
       "checksum": "1655b6961512f6ba352d50a4eb7a3016643171a1823564490c653111db53445d"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA2803A03547",
       "checksum": "39f9a1b433281aaf8479699174939a96e6cb69d1553d4911657760ba173ca0cb"
     }
   }

--- a/manifests/cargo-minimal-versions.json
+++ b/manifests/cargo-minimal-versions.json
@@ -29,525 +29,681 @@
   },
   "0.1.27": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC48129884D886",
       "checksum": "6b51454adffa828cce8279339c50883a4841a196e778f8bc9a82bacf67f445cd"
     },
     "x86_64_macos": {
+      "etag": "0x8DC4812E17DC13F",
       "checksum": "8796c876ab036b90bbd4d9b2ec7b9a57668cbceb88957040688b6d79dc2629e4"
     },
     "x86_64_windows": {
+      "etag": "0x8DC4812CDB24BD0",
       "checksum": "96d5deb8cc6e89e9fbf26345bc52d342dca87908bf87023e2bf55b233f28402d"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC48129932090E",
       "checksum": "1727b222908e49e57fd93650d798e6327527dbde831b5a432a9b7283a5746d01"
     },
     "aarch64_macos": {
+      "etag": "0x8DC4812AE4AF730",
       "checksum": "39b96ff4a6eae73bbb9f7a4a32a933005098046e44db1ede5bbe898037cc5911"
     },
     "aarch64_windows": {
+      "etag": "0x8DC4812BF12103C",
       "checksum": "e6be0e0d5529554a51334df603442f6bc4553d549b70cac5dd7466358589ec61"
     }
   },
   "0.1.26": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC40C8EA87B3ED",
       "checksum": "6a8fc07cc5bc50f43045322d4e6380df07ff487b57a467f192a9b9627fd129df"
     },
     "x86_64_macos": {
+      "etag": "0x8DC40C9E96A740E",
       "checksum": "11cff520bb3575ce1f0b7ba8e1701e4c2f294a17f85f51a51e1a58bd9b79bff3"
     },
     "x86_64_windows": {
+      "etag": "0x8DC40C9016FA3A2",
       "checksum": "3b9ebd11fe8d4947fdd58bccf4bd81810a5ff71a5095a0e84118715d721871c7"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC40C8E13F8816",
       "checksum": "2f773cbb435511a07a024d2de3e8f60bd284c77a840811c1234e29f3cb0df5a8"
     },
     "aarch64_macos": {
+      "etag": "0x8DC40C95DE28C5F",
       "checksum": "0e7b05d74baf1821e53c62ab6dc524847ea3af5a2b9fa0432e3c570e4ac368dd"
     },
     "aarch64_windows": {
+      "etag": "0x8DC40C8FE84CDBA",
       "checksum": "e21a4b25db1989afbafa9a9cc414fc75ff7f6aa75e783160934729c717b4f15e"
     }
   },
   "0.1.25": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC2A450980AC10",
       "checksum": "d964d443eb233b7922bad32b4a12a2a5fdccf8995160f28f4f879ff8ea20f744"
     },
     "x86_64_macos": {
+      "etag": "0x8DC2A459D5AA32F",
       "checksum": "62b3aa83eb87fd9c39f4aa36df12bb4f9482387f66fd4280cd787f5b731ad68a"
     },
     "x86_64_windows": {
+      "etag": "0x8DC2A4510B32B4D",
       "checksum": "1f411815ff97dc4547417bc0fa94022d0d0966a3807ce6a87d04534f75b28648"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC2A44FB525F89",
       "checksum": "26dea1adc55b2e186735ed35e9525b6170aef1b2914feabcd5c71e976e36c121"
     },
     "aarch64_macos": {
+      "etag": "0x8DC2A457AC0C0D5",
       "checksum": "df2f30afbad85858a3dd969eaabe777c03ba47d5a5a41f40dda9355b531be167"
     },
     "aarch64_windows": {
+      "etag": "0x8DC2A451C0C31F9",
       "checksum": "77c9ac359d2afd0203b583f498fb7610db2fe997820bee57762ce824a13b0d32"
     }
   },
   "0.1.24": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC1CF0506E08F0",
       "checksum": "d60c4320423f730122146d7a19819c017d83e7733d68631a2d67824fe12beae9"
     },
     "x86_64_macos": {
+      "etag": "0x8DC1CF0A3E25442",
       "checksum": "573cf6300d430f59c710e9fd7ddbca105a6285587cb8670765c1f49fce75c067"
     },
     "x86_64_windows": {
+      "etag": "0x8DC1CF07EEED6DD",
       "checksum": "b37db148b89b3557182d807836d63dcc39d2fe8b9a29b90b7e8c3fa53cff337c"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC1CF052672BF4",
       "checksum": "6fb513b479a54a756679fa336b82721701c353061d433773fe406a19b7acadbb"
     },
     "aarch64_macos": {
+      "etag": "0x8DC1CF0750AC731",
       "checksum": "eb73c6fa5fbc26a197ac4b28602bc4d6d99cc8d36a78d1f983a69532c928fc65"
     },
     "aarch64_windows": {
+      "etag": "0x8DC1CF0820D07BF",
       "checksum": "7780e2d60e07b76a969d7b70663ce025d8d4f21784a8ea072ed83d12106993b6"
     }
   },
   "0.1.23": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBFE36382E94EC",
       "checksum": "2f4489387658ff112cdb44844a7272aabac64d9aa3477ef5b297991ee5c74171"
     },
     "x86_64_macos": {
+      "etag": "0x8DBFE36FE14EB97",
       "checksum": "cdadc109c5c51a155d10ed627a284efb09949a7149717c33fe3e6243bc28b7ab"
     },
     "x86_64_windows": {
+      "etag": "0x8DBFE365BA2BF7F",
       "checksum": "3ea7c84ac4d7de49fcdd8114997542663d835b167cb66b016e5e13e76770878b"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBFE363091E6F8",
       "checksum": "9479643f35409317eec70f775d9201eee0a78e2e6f6a589c8e19dafdfa1e65df"
     },
     "aarch64_macos": {
+      "etag": "0x8DBFE36D4527355",
       "checksum": "434293117d2efb1721fe794915418dd6865213710a9197894d5a91058b798d82"
     },
     "aarch64_windows": {
+      "etag": "0x8DBFE36666646A3",
       "checksum": "3cfbb31deb764336dab488e1e11949ebe5e158bf3454940e909461a79d103a15"
     }
   },
   "0.1.22": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBF5981B1575D7",
       "checksum": "87ea60d0e93e239688f23585d238d351702dc0fbe9d3376e460f381aafe95549"
     },
     "x86_64_macos": {
+      "etag": "0x8DBF598BC56FF7D",
       "checksum": "9937c3fc4f8354561a816080da117b948e98571d480bf28eea7ee86513a7e337"
     },
     "x86_64_windows": {
+      "etag": "0x8DBF59840B275C5",
       "checksum": "4a6d2f085d650cfa686d35776f361e1576e0cdea69db8aba8258cdf3c612ac7d"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBF598022357C0",
       "checksum": "7ff801179220876cd5e34f21acc45d6edb3c3a992b9c10718f93522dc5ae9462"
     },
     "aarch64_macos": {
+      "etag": "0x8DBF59897EECF73",
       "checksum": "ca6309a4137229490e885e761d012b03a6aec1b9cc05b97f62f4a21aefb57535"
     },
     "aarch64_windows": {
+      "etag": "0x8DBF5983AEBF954",
       "checksum": "5ef9f17dfa16ccf0c85497cef34c9d7bab7840ef3f2947b162d1e45f4c2eb28a"
     }
   },
   "0.1.21": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBD6FFE4AB8964",
       "checksum": "2fe86915ae5f67a00b4ca0f94f98d57036ed549dba2247d8c20be178d3bd33f2"
     },
     "x86_64_macos": {
+      "etag": "0x8DBD70018A819FD",
       "checksum": "783d3e662e6ad584ba2230ff427debbd6e2dcccb3bd1d1a74ca6dcab1a761830"
     },
     "x86_64_windows": {
+      "etag": "0x8DBD70000F71EAB",
       "checksum": "8abdc6e31e0d925c220b8dd439567dbe6400bdbd0dd293bb659acf6f4feb02c9"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBD6FFA7D4EB9E",
       "checksum": "a21e1bf829b433b86c8bf77da51e300bb2dd06e563c10bae848043f5a6f6d8c8"
     },
     "aarch64_macos": {
+      "etag": "0x8DBD6FFCDAB63E4",
       "checksum": "0a86d29bb4c43e54e0836aa12fe6955c2bc33c1aaef8f0b6f04f2cde24786a65"
     },
     "aarch64_windows": {
+      "etag": "0x8DBD6FFC7337418",
       "checksum": "4d480b90187a813b9d56f957ad5b0dc67e696140c3dc2e5c2fc3a2f8ecca4e0d"
     }
   },
   "0.1.20": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBD2E88AF27775",
       "checksum": "b6bc98e33c7a2868d8d2079fbc0bb4fab13e7b61927242acdade67901eb8a5d1"
     },
     "x86_64_macos": {
+      "etag": "0x8DBD2E8B6C5C508",
       "checksum": "4dfce639a978a913ef374125a8721f7fb551238a861863865244b97742c936af"
     },
     "x86_64_windows": {
+      "etag": "0x8DBD2E8A4E297C3",
       "checksum": "aa87c50a0cfd10c075c51e552f7427272f3fe461c763da29eefed904fc7846c5"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBD2E88A432693",
       "checksum": "9810227752801c9770893613b193db780916a990fb7c8490e55f0ba8352d4d03"
     },
     "aarch64_macos": {
+      "etag": "0x8DBD2E8A83AD093",
       "checksum": "376c20fcf46134a3e006d7b2737521a89e75a39b032868f479755931bb3ae397"
     },
     "aarch64_windows": {
+      "etag": "0x8DBD2E8D3A5E62B",
       "checksum": "90f80b37ec4e33b7d5606b7bf3a023390b708bc0b84e8e1786311b318d77ea01"
     }
   },
   "0.1.19": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBB2EEC673C937",
       "checksum": "ba393e37118a7f55c47cb14099c0554d5e5fcb3f4bfa422b608e00efb7bcefa2"
     },
     "x86_64_macos": {
+      "etag": "0x8DBB2EEC09E418D",
       "checksum": "dacffa0bf0b3e6fa1b587e82084bfbf8f74171240d50ecb3309a832f2e43f8e3"
     },
     "x86_64_windows": {
+      "etag": "0x8DBB2EEE476677B",
       "checksum": "d6be0676301f3c6e6ba41f72a22e878b6e53a1a94cb6fd8a888cfa8fc8be4301"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBB2EEAE367153",
       "checksum": "fa5abed03b435bd6b70543f370fdc1c834611041b6b467d972bbec95aee1f9c1"
     },
     "aarch64_macos": {
+      "etag": "0x8DBB2EEBB0D3DF0",
       "checksum": "376e4aa8f37ffacfd68b1f69fc0aa6ed7dc8f95bf5cc625fc054cc040e2ddd53"
     },
     "aarch64_windows": {
+      "etag": "0x8DBB2EEEEA141FC",
       "checksum": "cde5b7a04a80e465e3ed677ecd75182f9d38e67db0b782d62caeb5f874c34f8b"
     }
   },
   "0.1.18": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBB1B12CCE1E5F",
       "checksum": "d1cde56ac778d61f2179045d9f9f8086afabb1b5a371a35d82000a8cb7b9f150"
     },
     "x86_64_macos": {
+      "etag": "0x8DBB1B1587A1965",
       "checksum": "307f516b0353132fa420e19eff3aae7f83ed84273eae5447752f886c23134bcc"
     },
     "x86_64_windows": {
+      "etag": "0x8DBB1B14B2692AB",
       "checksum": "bd4f276b0c115613992d9fa0ad8dd688828c5bf47c8b91a617638bb170549d7f"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBB1B12F2BFA47",
       "checksum": "efc430279c656b7c58965f41c82688ee10d84d4e5bfd193d3f7858d83db98982"
     },
     "aarch64_macos": {
+      "etag": "0x8DBB1B139967C70",
       "checksum": "b398d09d167b3fa253c835e56876151b59804ba083d9d6b4978d55bac767b692"
     },
     "aarch64_windows": {
+      "etag": "0x8DBB1B1587CD574",
       "checksum": "a26eeef963905cc14de9dd1e11c8d6a7a1a7db812a040de37e3cdbef74cc546f"
     }
   },
   "0.1.17": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBB12EA31ADD31",
       "checksum": "dbab6188ceca0396f80d6f6d931704568377fe5cb2985e3af54b73be721c1826"
     },
     "x86_64_macos": {
+      "etag": "0x8DBB12EE2D45810",
       "checksum": "44134caa5b7a88bff8923c2616c4bc3e940b66539ec7d9bf47775f61873d4fc9"
     },
     "x86_64_windows": {
+      "etag": "0x8DBB12EDFA6CFE1",
       "checksum": "954948921af804f309368c587a38089a132225434be14d1f6a38f0140f39cb7b"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBB12E9BF68188",
       "checksum": "5317743fe7f1306f844062fe05c5777880219bd47a32047f5d9e7c5924b140ec"
     },
     "aarch64_macos": {
+      "etag": "0x8DBB12EF50A7764",
       "checksum": "1550c655792cb18b03b6d3bec8ee74270eadb891c2f06b98c775134dd71b3801"
     },
     "aarch64_windows": {
+      "etag": "0x8DBB12ECFF71BFA",
       "checksum": "fb81001414eea31810aa84943f2cf22d7f423b20170d1350534c04a3fc934344"
     }
   },
   "0.1.16": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBA8067D0D15EB",
       "checksum": "30dc1bc067c6ac347bd0734a3117c0519e7ae715021d56952be3e207ed918447"
     },
     "x86_64_macos": {
+      "etag": "0x8DBA806DCD647C9",
       "checksum": "7b81508be9bb73cef8caa8b1b09113eebd1897356aa371246572c4fa6d4b19b9"
     },
     "x86_64_windows": {
+      "etag": "0x8DBA8068897C6AE",
       "checksum": "7d36c36b5069d1267ec5c485f904382db16c95b6a78288e3853687ec8691b013"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBA8064920D359",
       "checksum": "c42cba95957e6cea55800658367f59c709205d2888a0728817f15c95c6ed257f"
     },
     "aarch64_macos": {
+      "etag": "0x8DBA8067AAF616F",
       "checksum": "27090dbcb9d3046eadc7add438748fdd0795b5caddb985614f5dbcc791902b27"
     },
     "aarch64_windows": {
+      "etag": "0x8DBA80650D6BA68",
       "checksum": "0b727650f83886edf5ad8c97d2389273145e367df88f82f712de9b81f366c8e4"
     }
   },
   "0.1.15": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBA7E50E2E52D5",
       "checksum": "eac1436f7aa50bc34dd2675d97e9cfca6bbda1c9283be0185dae1e9c1c08cec6"
     },
     "x86_64_macos": {
+      "etag": "0x8DBA7E51FBF4F75",
       "checksum": "658581d9ec6c82355c7472d25712eaa0acf048d5cd4a57382bd4a5ba73f212d3"
     },
     "x86_64_windows": {
+      "etag": "0x8DBA7E540B4A2D3",
       "checksum": "b673c444480ca6f6fc983bda35953c2e15a40f484a682c805fbad963dbc02c41"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBA7E51A312FD8",
       "checksum": "accbd49853bc706f9ab330342baf2ff0d2db8f66c26b76b9e6845b911511c2e4"
     },
     "aarch64_macos": {
+      "etag": "0x8DBA7E51A35E57E",
       "checksum": "4f9ae0aaddf0cda388461e246ac7eadbd0cc326eeb3a28d4ffaf1aa8b509d7d2"
     },
     "aarch64_windows": {
+      "etag": "0x8DBA7E531B4DD09",
       "checksum": "827c626f40bead527d6eaf7b48017cfd8f559938c370c893ab00c51d3668b37c"
     }
   },
   "0.1.14": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB9CD8E7669EC1",
       "checksum": "f7284ada48677bef2acb9348a6bfe86705246b57681db178a28634e25c61459d"
     },
     "x86_64_macos": {
+      "etag": "0x8DB9CD8E1B86F6F",
       "checksum": "d5121056830331b512e3648f7edca3d86cc84e1621f2d3369d24bef549b2c0f0"
     },
     "x86_64_windows": {
+      "etag": "0x8DB9CD91EFB0E02",
       "checksum": "00a478f561c25db3009d14aba8d0dc8a9e5c9e4f114fd9522a6a09e5de289f55"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB9CD8E6073A3F",
       "checksum": "8915fdcde61536c740b885ce83cd2f38a607bf5d7121d8535e8be43bd820b0d6"
     },
     "aarch64_macos": {
+      "etag": "0x8DB9CD90360EBAF",
       "checksum": "7c737c7ade8f4080d04dacec82b9b94752d3b98fd179a2f51af986fc26d273ba"
     },
     "aarch64_windows": {
+      "etag": "0x8DB9CD9302AAD49",
       "checksum": "d87025a5881f0c24ecb52061bc0b3c7fca9ca7beee3b75566392dce759ecd7a5"
     }
   },
   "0.1.13": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB8FA08C3A9261",
       "checksum": "7bafe9e8c27207845edb3940e3a91f7cbae7a318472267610017fb6b10d8c7a2"
     },
     "x86_64_macos": {
+      "etag": "0x8DB8FA12768C900",
       "checksum": "79bf05f75f95e20641181d7c5576fa18a9b8eb11ad640a979a8916d8b6887831"
     },
     "x86_64_windows": {
+      "etag": "0x8DB8FA0D8E7E158",
       "checksum": "ab7849653698babfc74dc865c87c3683594174e8f53201dc2bbcdc2100e9b4c8"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB8FA07C94480B",
       "checksum": "c5a1b3d68fc25420806576bc3d947fbb71011f30153c29ff1de162c80dc167e9"
     },
     "aarch64_macos": {
+      "etag": "0x8DB8FA0CC7D1A3F",
       "checksum": "e7ce17977d4fc48d7a240989edf0c88511cee8573133504f0af5b4f7070893cf"
     },
     "aarch64_windows": {
+      "etag": "0x8DB8FA0A9BFFF5D",
       "checksum": "f0f501bb1026cb5e48db5ccff3a16dcc6832d5d2f9da353f17337f86fbceca38"
     }
   },
   "0.1.12": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB3D8AE5B80F21",
       "checksum": "14d33bd273110fc3a4ebc96eab922442e2663f1c8d8da746d66a917fa2957297"
     },
     "x86_64_macos": {
+      "etag": "0x8DB3D8BAF13A594",
       "checksum": "d4a71d3e58f0d0a998f35a034120e831498a36601a02b940c7999030decb43be"
     },
     "x86_64_windows": {
+      "etag": "0x8DB3D8B016ED820",
       "checksum": "ab17ab06b5f211611e88d17e4b28ff19076c5b9a6d351fd7f0d20a071f3a1d03"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB3D8AE56F2345",
       "checksum": "f7aa0d7909f9b828446c9d5f2a0db0ff27df7c167f110609d665b4d70d8a1a8b"
     },
     "aarch64_macos": {
+      "etag": "0x8DB3D8B2642329A",
       "checksum": "1f23174e8a4522799999bac4564d780b7d4893d9f5aa2472b71782e826e3acbd"
     },
     "aarch64_windows": {
+      "etag": "0x8DB3D8AF3410913",
       "checksum": "62267707abf30cacd086bfa035de527d5227682288c9e2176e03de925bae9dd3"
     }
   },
   "0.1.11": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAFE20D4FC9820",
       "checksum": "a7d3f6ba4cff8643b06e5a17f7967043f49a9144b7ae8d24d9542fc29ef1d4f2"
     },
     "x86_64_macos": {
+      "etag": "0x8DAFE209921BF47",
       "checksum": "466a1542dd5050009f11c976018738f38f4a5a481ff9b6b81f45d498eaa7efd0"
     },
     "x86_64_windows": {
+      "etag": "0x8DAFE20CFC618D3",
       "checksum": "59bd40b9562a7717b3746d1558de7f4751b8eac111d5850738ed1756e86cd414"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DAFE209ABDF1EA",
       "checksum": "8e05290054d8554550c859f4f617245aa282d5c03c98b41ab00e19008a4cb081"
     },
     "aarch64_macos": {
+      "etag": "0x8DAFE2086645D0C",
       "checksum": "181a142f2134775c9fb0fe9e465467a2f231893d26193972e312a968f0cf6588"
     },
     "aarch64_windows": {
+      "etag": "0x8DAFE20A154672B",
       "checksum": "d16116fc1a7472cef8ca2497c35559271653e76f6c8c2e8ff99e17dbab43fedf"
     }
   },
   "0.1.10": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAF3DA6FCA046A",
       "checksum": "de28bdc0a9ff95ce607eea9b090525dc967138029f31a0c5173143e3dbe080d3"
     },
     "x86_64_macos": {
+      "etag": "0x8DAF3DB7EFEC08D",
       "checksum": "0092d3f009db6e8af40db25ca078b151cc64556eebbc4afa506f81b17d054680"
     },
     "x86_64_windows": {
+      "etag": "0x8DAF3DA7DFD5C1F",
       "checksum": "7221ee5df739422a9f817f65fd152bbb2313a2fe592cbf2d1f783f90479befbb"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DAF3DA60E0BFFB",
       "checksum": "60b5fc7500415937a29c5d80d2d7772b87583f9716b685d840cd502b2c456a63"
     },
     "aarch64_macos": {
+      "etag": "0x8DAF3DB124DA8C3",
       "checksum": "f1c872f93d526bb9988c6b96eed66a4f5d6ee11170d9b3952e3ffbb441f94d69"
     },
     "aarch64_windows": {
+      "etag": "0x8DAF3DA7B860721",
       "checksum": "eb78f90de7de5ed0c1075c7181fd126265bfaec39f93fe169d2c0aa814892b01"
     }
   },
   "0.1.9": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAE689DB8745DC",
       "checksum": "4ad1c41f00a8258c9c64f713fcb48bab23617273d9363146acdfc4a803ee711c"
     },
     "x86_64_macos": {
+      "etag": "0x8DAE689C101C304",
       "checksum": "b34bfd059a4f7646b6f18861c8684d1ead30962ae8858369f16d74c8457542bb"
     },
     "x86_64_windows": {
+      "etag": "0x8DAE689EDB80D85",
       "checksum": "14ee2d767f3798c7eb4c559bd3d89aa843ddef260942074fea36deded463d4f0"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DAE689E293840D",
       "checksum": "8ca629b9c9fe97caad187e5595baf1afbdf3f584b3901c6add289d8c939549b7"
     },
     "aarch64_macos": {
+      "etag": "0x8DAE689A15D596E",
       "checksum": "307a0efc447d3dd22d9286ecafecdb4ce7241dee3e52c4f10ac6f5f9f495a6fa"
     },
     "aarch64_windows": {
+      "etag": "0x8DAE689E1C04D3D",
       "checksum": "f41bcd424169f073d6ccd39912632f7323b9883b638b71b6a4bfc89a1b3e42d9"
     }
   },
   "0.1.8": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAD0725587CFA1",
       "checksum": "0aa5c502202831dae2ea3c327788e95c9077ae914879dc2f78d66c6b2d4be12e"
     },
     "x86_64_macos": {
+      "etag": "0x8DAD072D33D41B4",
       "checksum": "d363a13641f5be0fe6b23b12673956a7b766c085f3a7f0f6c8e36a2c456251bb"
     },
     "x86_64_windows": {
+      "etag": "0x8DAD0725F6EA14F",
       "checksum": "acbc064f4f1b723f43b520313f9687b328e269e43fca7392b3bbe91e9782b9e4"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DAD0723D87AC73",
       "checksum": "9b0a03f84acd3bf70e63f8fb613917b60af80fc20d98bd67d19e23f2aaa88515"
     },
     "aarch64_macos": {
+      "etag": "0x8DAD072C657DF4D",
       "checksum": "04e41c7fcdaaa724ad7da63237a815d88b9a057800cf1148970d213b08b28abf"
     },
     "aarch64_windows": {
+      "etag": "0x8DAD0726C717CEF",
       "checksum": "210582ed2c3bf0e0e32a5dcb6d40883dd024da44d14be937841f959df157fb7c"
     }
   },
   "0.1.7": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAB6A2B1BBE386",
       "checksum": "70f3a766a785b905b975d988e0acbc7a0685feef91bf05d164d27349e4ad14e2"
     },
     "x86_64_macos": {
+      "etag": "0x8DAB6A2C9F180E2",
       "checksum": "9203cf870c29a63cffb204f0663e29a31d50c6955b32bd9d43d0519a971cda99"
     },
     "x86_64_windows": {
+      "etag": "0x8DAB6A2F3A52393",
       "checksum": "6df4e6b6115164ae1f9b6a2f2afd1aad4883158848196723e8ad640083f560e6"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DAB6A2C12169C1",
       "checksum": "7604fab05ce523ad326d6b158d028035161a18533118a06c6035242439bdf7dc"
     },
     "aarch64_macos": {
+      "etag": "0x8DAB6A340AF187B",
       "checksum": "2528ec81f067623e2cc173ea9c4e2a53c9243d50f931bf516354d27b23d9d195"
     },
     "aarch64_windows": {
+      "etag": "0x8DAB6A2DB4B3AA0",
       "checksum": "54a6341e1f3abb9006c11d3efd46460316e381f2f4c3ab4f9024c6b52864e7b0"
     }
   },
   "0.1.6": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAB69D6DE9A023",
       "checksum": "06f7e18c8afcceb82728b0502d9cf173dc7ba1f70f623c7423e10a15a6adfdbd"
     },
     "x86_64_macos": {
+      "etag": "0x8DAB69D743C6AA9",
       "checksum": "dd7495900b1ecc1403681fcd9f0cc53f467d6220d76273b67545a79127469ee7"
     },
     "x86_64_windows": {
+      "etag": "0x8DAB69D87164A59",
       "checksum": "db713983401c70a598002cf2ce2f188f7edf683f3664adb792ad8a9936c4f56c"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DAB69D7CF135A6",
       "checksum": "6c5d7e6d10e0568f361938808e1480ea2e2a71d08d016349b4dade5a9aeca93d"
     },
     "aarch64_macos": {
+      "etag": "0x8DAB69D71C9CAF9",
       "checksum": "4485fabf45024da18944dbc801245a62874d819da979dc8dcad7383d3fb271c2"
     },
     "aarch64_windows": {
+      "etag": "0x8DAB69DCFF88E4B",
       "checksum": "3fa9865c99e97acd30577054c29f476dde89b3aff174fcfc844335e2a00af4e5"
     }
   },
   "0.1.5": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA60FE2BB5DD67",
       "checksum": "ce4ed231f04e84e11fff96bd0e54cb762a6bf64b981b1083b380938710df94ac"
     },
     "x86_64_macos": {
+      "etag": "0x8DA60FE0B2BF96E",
       "checksum": "7ce9c783c4b2101fe36ef99ee8a0ecb764e7e32b6b905646124b7356050f128e"
     },
     "x86_64_windows": {
+      "etag": "0x8DA60FE22F357C8",
       "checksum": "1b98993e81219890decefeaf161262a5997bf0e145fba9a6f55e73bfed29e464"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DA60FE267C6F27",
       "checksum": "1d09f93ed4fd615f4c6d69058a6a8aa49ab8e50f3e63a0f7be2b7dbb2346a3f1"
     },
     "aarch64_macos": {
+      "etag": "0x8DA60FE172563D4",
       "checksum": "a5539cbf7d43a68180b403727e588ce466fc7dfdbde4fbbe0b2a58fa1185d11b"
     }
   },
   "0.1.4": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA449A57812656",
       "checksum": "739944284263057f8f6a3854e67e66d3d02ed435cc9af9dcc638dc8c09a55d3b"
     },
     "x86_64_macos": {
+      "etag": "0x8DA449AD3D17C58",
       "checksum": "081e23fb403d7cc6b6307fb056c247f5edcb19539558a865ef593802e0e41758"
     },
     "x86_64_windows": {
+      "etag": "0x8DA449AAACE9DED",
       "checksum": "4e08a0cc1498ec0a0483f1c224ab82ea344e354d936bfc6a91b6c6bb707507d0"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DA449A599624EF",
       "checksum": "349f07e51fa733f6b1ae890a6d761f7af53f5679eb74675a7aa1673710bae5b6"
     },
     "aarch64_macos": {
+      "etag": "0x8DA449A80329345",
       "checksum": "ab4bae13d263f7eb7bdf02a931daeab26c16fa5a8585de931a3a6f96fb0a86cc"
     }
   },
   "0.1.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9E8A897D98214",
       "checksum": "89fd8fa3a37d76568122cbce3ba6a4bd7600a1b893be0eef59e8733887758264"
     },
     "x86_64_macos": {
+      "etag": "0x8D9E8A88950D312",
       "checksum": "650cfd6875635509723958c98f9864e5072cdbf7e4305fbeff603010e8fab503"
     },
     "x86_64_windows": {
+      "etag": "0x8D9E8A8A983BAA6",
       "checksum": "df6dc7c9eef65e07b05ea15ff1a03d4d1c0427c5b8bf15b99dbdd554baa60272"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8D9E8A89592F5B7",
       "checksum": "e5cf61743a666a30a66025cd49a8336c4dd2e07605aa5f51bad81b10d7357042"
     }
   },
   "0.1.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9DCF18820B8B7",
       "checksum": "d42cf0af9ca7c449dbad815b450cfbee478c263dbaa3952399e72090d85c4798"
     },
     "x86_64_macos": {
+      "etag": "0x8D9DCF116BBE78D",
       "checksum": "cf29e3cd862ad613a96215b884f77c369b94315f7849dbf2727d2efdaed575c5"
     },
     "x86_64_windows": {
+      "etag": "0x8D9DCF158CFE4F4",
       "checksum": "3543e545f8026e949b35ed331de53ac704f5536587ccd898c8820fa9387217d1"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8D9DCF1359ACBFE",
       "checksum": "0c85913f75f8e74737de76516d84e1409ca3433775b2ed73d29f97905be59b93"
     }
   },
   "0.1.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9D0E1F9A13AB7",
       "checksum": "c80f49034fb8d87869b210535f4d89ad4562ae00da3b97d7a30eae3e17350ae6"
     },
     "x86_64_macos": {
+      "etag": "0x8D9D0E1A6568FF3",
       "checksum": "5ad711a27fce8a176a348427b3f009f8d703663395e5fa19032c72e6d8b1d4d7"
     },
     "x86_64_windows": {
+      "etag": "0x8D9D0CFD15AE324",
       "checksum": "97de219f8d544a567359c58b171f38d5b48fb46481b27ab733770d21667add7e"
     }
   },
   "0.1.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9CA23195439C0",
       "checksum": "19d6fa618494847093f86990ef31b8229d7d032539346c43749a05f73da46aee"
     },
     "x86_64_macos": {
+      "etag": "0x8D9CA22F8072125",
       "checksum": "4edcff7cbabadfd682c44fde4eef8bc097357fe206dfb1d7a64323f9cc6e7a8f"
     },
     "x86_64_windows": {
+      "etag": "0x8D9CA2349C65A85",
       "checksum": "dd7241e0ea5026926352c2fc9efb5f9e11545f69548ff1716863afcb90194a58"
     }
   }

--- a/manifests/cargo-nextest.json
+++ b/manifests/cargo-nextest.json
@@ -27,995 +27,1262 @@
   "0.9.72": {
     "previous_stable_version": "0.9.70",
     "x86_64_linux_gnu": {
+      "etag": "0x8DC7B6C4E1B6522",
       "checksum": "e6f66397d3ba9a150b5debbc414a9ad1f87e4707da1f989c0681444ba5d15571"
     },
     "x86_64_linux_musl": {
+      "etag": "0x8DC7B6C65CDD830",
       "checksum": "4f471fecc32ca4bf745a2c85c2fde7339640cb366f59cd36fbe5bb63d3fd0880"
     },
     "x86_64_macos": {
+      "etag": "0x8DC7B6C2C376B05",
       "checksum": "2816fd2b39fdba8dc16b7144b2c85a6ef62e38c8df87645a8c510e2e78c160c2"
     },
     "x86_64_windows": {
+      "etag": "0x8DC7B6CAADA44DE",
       "checksum": "c9486aef46f8336e11e6162c34bfafa93f46f166937395914bab20701e7e839e"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DC7B6C548B1D3E",
       "checksum": "f49577c199fc95c4076d90fc3017c0689d8a4982176fdefb6faa8505681da10e"
     }
   },
   "0.9.70": {
     "previous_stable_version": "0.9.68",
     "x86_64_linux_gnu": {
+      "etag": "0x8DC64AA0993A30B",
       "checksum": "c2d76b2608ce7c92d95aa016889498f273ecacbb3fcffb83db3385f643aa1a9a"
     },
     "x86_64_linux_musl": {
+      "etag": "0x8DC64AA06CAAD1E",
       "checksum": "c55c6054967aa21bd2e64d97f982a67bf1c10082f3557a61252e28b2f74d1c94"
     },
     "x86_64_macos": {
+      "etag": "0x8DC64AA0E6ECC66",
       "checksum": "68ba1ae1b69a49fbec9a864b4a207dc0e2abcb4d712595e0a3721a9645a17749"
     },
     "x86_64_windows": {
+      "etag": "0x8DC64AA50A0698A",
       "checksum": "9d0ebc751061161c8f75964cf70d64726dbda05bc4ff883b988725c46eb74903"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DC64AA072F8D1D",
       "checksum": "0337406b383be8316aad88347324a276a412e99e3c0ce4f43c1886f7f25c1fcb"
     }
   },
   "0.9.68": {
     "previous_stable_version": "0.9.67",
     "x86_64_linux_gnu": {
+      "etag": "0x8DC46194EEFB99B",
       "checksum": "7244def6f0014423e0785d99023467b617db2117a9a836bb263b52e719d01ffb"
     },
     "x86_64_linux_musl": {
+      "etag": "0x8DC461989344015",
       "checksum": "7141df855d96d8b16ec3506531b7ab113872ba8a13d7be37b8eb05571dbcb57b"
     },
     "x86_64_macos": {
+      "etag": "0x8DC461987DC0030",
       "checksum": "eff1765e505b00addd162cd4fcfd8a3471404b80bc389f018cf3b3e969c98801"
     },
     "x86_64_windows": {
+      "etag": "0x8DC4619DB291AB6",
       "checksum": "1c30fc542ca17a7c454f4931cf91c9b1c665ecefa989bad6cf83068137cc6485"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DC461975949312",
       "checksum": "ba5c9f4d8b3030e803182017424ca3e268659150f697208659ffd15d5e5d9ef1"
     }
   },
   "0.9.67": {
     "previous_stable_version": "0.9.66",
     "x86_64_linux_gnu": {
+      "etag": "0x8DC115262CD0B63",
       "checksum": "5fd46640d3bf6d7f10f0430e33b58ea8f14c6b50a74cdd25e577890eb49680e0"
     },
     "x86_64_linux_musl": {
+      "etag": "0x8DC11527D643EE2",
       "checksum": "b125fd93d093e8cee1b8876f07eb65a3576b565b2144c0922969df81257b64f7"
     },
     "x86_64_macos": {
+      "etag": "0x8DC1153C3C87CC8",
       "checksum": "eabd4a7327b5a1f096973a14576db98e5178940a5c6e0e7480696379c73634fd"
     },
     "x86_64_windows": {
+      "etag": "0x8DC1152D22F3D37",
       "checksum": "a07cd71404e019fb6b2b0dde543b5422dbffc689c12cbf2c813292076db5304b"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DC1152594EF159",
       "checksum": "e53555b82a3060c2af61784ff925d7dde336a45847f2e5e80fbb9e5e990639d9"
     }
   },
   "0.9.66": {
     "previous_stable_version": "0.9.64",
     "x86_64_linux_gnu": {
+      "etag": "0x8DBF9D8B62BF797",
       "checksum": "ab48150a46e0c62ab3787dae420c9331b06b1ea066f4aa76fd340f6a3a87b6b6"
     },
     "x86_64_linux_musl": {
+      "etag": "0x8DBF9D8DEEB9690",
       "checksum": "b3b01d7c8dd100e0f175ddf399b88b13424e5e13ea9b77e588c4373910877465"
     },
     "x86_64_macos": {
+      "etag": "0x8DBF9DA4899E9FD",
       "checksum": "c8daa5277a2989681a2cb23541a4507e7df7e50aebb2c3c052f073a842785493"
     },
     "x86_64_windows": {
+      "etag": "0x8DBF9D9385B0EBD",
       "checksum": "9f238f35a1fa9ab543fadeea66546ee3286048eb499479463e0f9a642f5f686a"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBF9D8D9208AAA",
       "checksum": "58f2cfb43d8cdcda978c0763380516656e00aefa9f0c9bc5d8d7fe0c8a487c31"
     }
   },
   "0.9.64": {
     "previous_stable_version": "0.9.63",
     "x86_64_linux_gnu": {
+      "etag": "0x8DBF44E90B9255C",
       "checksum": "30a77ab6a7cc63263a69becf90a59492d9b4bdcd0c2977d925b4a55c184ce491"
     },
     "x86_64_linux_musl": {
+      "etag": "0x8DBF44EB234BD6E",
       "checksum": "64e2f31338b11196bbf1d56775125f1dde7894d2df70063e48a776c62b6de7e1"
     },
     "x86_64_macos": {
+      "etag": "0x8DBF44FC39C1BDA",
       "checksum": "8e5bcfbdcc5dd62f458bc32dbd40fa08740632017488cb1401a0546fd454a741"
     },
     "x86_64_windows": {
+      "etag": "0x8DBF44F0A16754D",
       "checksum": "e84d629eb97a23d812fd868b4672136b2ee36966bf3b2cdea218be2e6cf7a832"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBF44EACDABB47",
       "checksum": "99d5fffe5b641b56f92fabb65c5ac6f062723d33bba5165fe69602aeeba54fd2"
     }
   },
   "0.9.63": {
     "previous_stable_version": "0.9.62",
     "x86_64_linux_gnu": {
+      "etag": "0x8DBE7A3D07A790D",
       "checksum": "155eb73f99373f59e73ca1d73474f1496428e4d44ecfcbede7a5584238a7b4ff"
     },
     "x86_64_linux_musl": {
+      "etag": "0x8DBE7A3F471EC56",
       "checksum": "da60e565ed86cc214d2285fabc2ba41cb4a54f08ce066d042d0e474efcb56a31"
     },
     "x86_64_macos": {
+      "etag": "0x8DBE7A483F4B95B",
       "checksum": "c9e54b032d261c423675989097584a7c04c18067410e6f32d45c2ba768d1aae1"
     },
     "x86_64_windows": {
+      "etag": "0x8DBE7A44D4A405A",
       "checksum": "4d21b2a7c1e1eb8fc5a0ebfc93dc5e329a34f6155821e60891ce87713ac966f2"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBE7A3F0EB0F27",
       "checksum": "149c213e28e5fc189a4bbd783533c3d02601c6d84bae4644aa4395c92be08ade"
     }
   },
   "0.9.62": {
     "previous_stable_version": "0.9.61",
     "x86_64_linux_gnu": {
+      "etag": "0x8DBE58F7B234C43",
       "checksum": "1dbad9e484fb7691443f88d483ee827e460fbc583b782ea7904a117261dce721"
     },
     "x86_64_linux_musl": {
+      "etag": "0x8DBE58F98149FE4",
       "checksum": "73ff8a7437eb22af17272552d910b01a7dd826bb30f6d108326efc76b38f3912"
     },
     "x86_64_macos": {
+      "etag": "0x8DBE5911282FC96",
       "checksum": "94155602db22ff1c48f78d0aa53a2f2133ba6c49f17f2a6c36ba9bdcb03fe82e"
     },
     "x86_64_windows": {
+      "etag": "0x8DBE58FEFE5B477",
       "checksum": "0426e8deaf596cfd00c9f5d6af51ac31009464a03a948079fd3989c699a47b88"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBE58F9BFC6A9D",
       "checksum": "b5ae4258b5c4881b700ee5055d32d75ffd77d81479b51fe4093f6c17020edc7f"
     }
   },
   "0.9.61": {
     "previous_stable_version": "0.9.59",
     "x86_64_linux_gnu": {
+      "etag": "0x8DBD35B7485BA63",
       "checksum": "92721d305216cafc3db458680e3c24a939be7781327e1af96ea1174243836dcf"
     },
     "x86_64_linux_musl": {
+      "etag": "0x8DBD35B8E168D1B",
       "checksum": "398b61170a61b3d59402f5836e70507369b826165e484cf5e03a3a1b2e0e0838"
     },
     "x86_64_macos": {
+      "etag": "0x8DBD35C19ED0F11",
       "checksum": "a3f78b491581cbed84f679759c7a4c4e617fe23efe9c3fc90ab3753c71919fcd"
     },
     "x86_64_windows": {
+      "etag": "0x8DBD35C31DC98A2",
       "checksum": "5c7b1ec00d0c650f2c87fc87d7f91677a772b25d1b0404b8658a58a6e56e731a"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBD35BA00A19B4",
       "checksum": "8763fafee324503d7c1925346c11844baf3f95c0ae83793eb6c464cf4e4ba590"
     }
   },
   "0.9.59": {
     "previous_stable_version": "0.9.58",
     "x86_64_linux_gnu": {
+      "etag": "0x8DBBF89E3C4B963",
       "checksum": "997f775ea161e91a70516a86c623e55463c9aee31e0da0a01870d0abea17e3c0"
     },
     "x86_64_linux_musl": {
+      "etag": "0x8DBBF8A3628BE0F",
       "checksum": "e41995fab0bba5ae8013f60d2e71e76110e71471f1c1747e2f18aef7ffa221c0"
     },
     "x86_64_macos": {
+      "etag": "0x8DBBF8B0DBD7849",
       "checksum": "3137a3184d1d6d5e4c3f3142f2bbb96cb25a2cc912b1b2bcdd8fc9e1c08c89e2"
     },
     "x86_64_windows": {
+      "etag": "0x8DBBF8AF970BAC6",
       "checksum": "60b20f17ae9a8089691a519b45b43cb247e1640c8454670d1b173b716240ebf9"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBBF8A4DC3FBDA",
       "checksum": "1c4d3c4ec663386c2f374626cea921816cfe96f043cce2a97c9c572bede537a6"
     }
   },
   "0.9.58": {
     "previous_stable_version": "0.9.57",
     "x86_64_linux_gnu": {
+      "etag": "0x8DBBA2A05F625BC",
       "checksum": "a6e75770907174505c5f09e8fb0f14109edf9c0b5f82c6db67c4a72dc7a0a7a4"
     },
     "x86_64_linux_musl": {
+      "etag": "0x8DBBA29FB9EF343",
       "checksum": "172b834d2df890a2e0039b641fda4f7608ba536c4d06b60f4de2d6877d3c2262"
     },
     "x86_64_macos": {
+      "etag": "0x8DBBA2B0E2471E1",
       "checksum": "a8174c1d2bfe57aac1b4bac71d85b7a159315cfae0721b88f1664b0115fac2fa"
     },
     "x86_64_windows": {
+      "etag": "0x8DBBA2A97044933",
       "checksum": "a5b388cd67bb3e4520d7fa0b3175a31308edcd5d22b5808a6b3769cb31c8e792"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBBA29FBBEB391",
       "checksum": "982ce7ec908a07cc429dc91deeed782dc8b7fb7b4252c14aa4f5f337b7c64755"
     }
   },
   "0.9.57": {
     "previous_stable_version": "0.9.56",
     "x86_64_linux_gnu": {
+      "etag": "0x8DB939DAD3CB2C6",
       "checksum": "5fc2416dd001ec89d904a345465da0b91452896b74621a82fec33e33d4856320"
     },
     "x86_64_linux_musl": {
+      "etag": "0x8DB939DF1972940",
       "checksum": "c9275cb47f75936ad9a6ff24557f210c7a248d284f9b9d6953e128e907b1a926"
     },
     "x86_64_macos": {
+      "etag": "0x8DB939ED2EB4E6E",
       "checksum": "8a66df687d857f173ca6ac7773c699883beca09ce558852bc620d023336ee3b4"
     },
     "x86_64_windows": {
+      "etag": "0x8DB939DF0E873FC",
       "checksum": "75e2b29d49b1b86d15f61051620aeffb159322f9c262cec2646a96ec79bfac85"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB939D8B2B1BDA",
       "checksum": "e567e43446969205fd26da6f09c03f965fce20df3a0c476c4f2f77ed30ff2538"
     }
   },
   "0.9.56": {
     "previous_stable_version": "0.9.55",
     "x86_64_linux_gnu": {
+      "etag": "0x8DB9397704A2A32",
       "checksum": "914f380306a7216c8b79ca4408cc39073eaaea9e7b2101e2bfe0c123636a478b"
     },
     "x86_64_linux_musl": {
+      "etag": "0x8DB9397777203A6",
       "checksum": "ec12fa3f52655033aa35581f300bac63cd16b372ca68c85a5621c25255cae759"
     },
     "x86_64_macos": {
+      "etag": "0x8DB9397FE69B527",
       "checksum": "aa748f80fe110e6ea607d5dd264e1fe3513b631a7957605cdd8bb12e5cc878f9"
     },
     "x86_64_windows": {
+      "etag": "0x8DB939814A760F5",
       "checksum": "185cddb1d347c3b0e9e1cebd919297809491394aaa1b2abe5109a6139be5e400"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB93974B052475",
       "checksum": "07bbc36fec9dfbe95b0a2e6fc0446175dfb9d58e24474095768965591625a19c"
     }
   },
   "0.9.55": {
     "previous_stable_version": "0.9.54",
     "x86_64_linux_gnu": {
+      "etag": "0x8DB90A9B4B92CD6",
       "checksum": "b5bab814d720561c002b5cbe899f997c20407689cfba23754b5a6c20ae3cac4a"
     },
     "x86_64_linux_musl": {
+      "etag": "0x8DB90A9F9440B6E",
       "checksum": "2ae6cd6198a60c73e906ed99fcc7254ae6dae68076ea2c24f5acda83c5918ffd"
     },
     "x86_64_macos": {
+      "etag": "0x8DB90AABDB16C37",
       "checksum": "adbcbd9c2c1634e90c0cc8f376633ff76242a722a81938ecda6fe9131cc90aa6"
     },
     "x86_64_windows": {
+      "etag": "0x8DB90AA02FF6571",
       "checksum": "64280ff486b3af59a7c4e095f293f292211b334b9b17c7d4bd45445aabfe15e5"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB90A979B01449",
       "checksum": "0dbd309e53c001a18afb5f3a3839d0427421bc06ba057b28506d08e7ae2fb20a"
     }
   },
   "0.9.54": {
     "previous_stable_version": "0.9.53",
     "x86_64_linux_gnu": {
+      "etag": "0x8DB760600272BE8",
       "checksum": "ed393824489793854193906946d972afc1e3c32a18aed5bc9dafc2cb3547bead"
     },
     "x86_64_linux_musl": {
+      "etag": "0x8DB7606499323D2",
       "checksum": "898bdec39d25f8c60eb984fe440a7a2e677a7f8b881ad7f0bdc44d1236700ab7"
     },
     "x86_64_macos": {
+      "etag": "0x8DB7607CBDCFFF3",
       "checksum": "436c10a0c32aaefe3680a8550903f1382436a7954ecea5156f99c7f207516466"
     },
     "x86_64_windows": {
+      "etag": "0x8DB7606A48CE23D",
       "checksum": "45bb1ac2cbe1286ded194619befe860adde01b14c0f4c7a77352022fb2be254d"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB7605EA77B7A4",
       "checksum": "c62ae5598a857655ba7c6299be5254244c78dfb249d83f6634804221e3f0faa0"
     }
   },
   "0.9.53": {
     "previous_stable_version": "0.9.52",
     "x86_64_linux_gnu": {
+      "etag": "0x8DB559129DEADD0",
       "checksum": "b07def6a5e5521481eb5853e5f17650be406ce8c57ce917a90d2866c788e5967"
     },
     "x86_64_linux_musl": {
+      "etag": "0x8DB5591236ECCE5",
       "checksum": "432af91cae859413b79bd50baea327badffe7d488ce4ffd5d301bd84b007b889"
     },
     "x86_64_macos": {
+      "etag": "0x8DB55930B6434CA",
       "checksum": "ccab0a046538cb86a93ee6f05a1d9ceace7878fc7ca39392b681b01dc27fc54e"
     },
     "x86_64_windows": {
+      "etag": "0x8DB5591F92F8690",
       "checksum": "49605a5f5f3275d1e8a2fdfaa0a45a52df03cfd791ad5b1a093b196df3a408d5"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB5591079BDE9C",
       "checksum": "54e47dc3fcf7eead6307ac06a9e02ce9a0fe3a156a53b062b63f823cd2765bfd"
     }
   },
   "0.9.52": {
     "previous_stable_version": "0.9.51",
     "x86_64_linux_gnu": {
+      "etag": "0x8DB4CDAC1715AB0",
       "checksum": "55bf039be0d14e4266eaacd765a292294c8627787dcb31d503690a9c14ad21fc"
     },
     "x86_64_linux_musl": {
+      "etag": "0x8DB4CDAD124872E",
       "checksum": "7e6b14b379b8315f81d1e2542e6f6de9fffda6ca9c95054ebc0560f52a27038f"
     },
     "x86_64_macos": {
+      "etag": "0x8DB4CDD156AC78B",
       "checksum": "d4638b6ec6e8e8d8f3cf4ff8f039665f0a1d4ff2cf7ef6467bdb243e654c9911"
     },
     "x86_64_windows": {
+      "etag": "0x8DB4CDB481691A0",
       "checksum": "af5c3227e870b9f1719d8993d09dc3f2871c4e34b06d8711679129c370a0fa0d"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB4CDAC62A05FF",
       "checksum": "ee7d4f5264c5be5177b3a0bb8fb0bd2100592a6ea29bcbef1d98b782c09e5dc0"
     }
   },
   "0.9.51": {
     "previous_stable_version": "0.9.50",
     "x86_64_linux_gnu": {
+      "etag": "0x8DB28D3B3BF13ED",
       "checksum": "5cbf80e72737d63a601f139d6ff1c42ca9cf6204cd7991f7d6ce7458f2c12bbc"
     },
     "x86_64_linux_musl": {
+      "etag": "0x8DB28D386B0FFB9",
       "checksum": "2d7def02b6b795b7b44fe2cca9b1b9e77bcb4c8903957ad502f60f45a2f92e9a"
     },
     "x86_64_macos": {
+      "etag": "0x8DB28D54B59D49A",
       "checksum": "607c0cac7d659bb957af12a136756821771b9d91f03ccae24b255363e7fcbfda"
     },
     "x86_64_windows": {
+      "etag": "0x8DB28D400CFA0A7",
       "checksum": "4a97e5ab319af4347549e8414df2af5af7d9f8b4cee8650bad0111d2007711b2"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB28D389827AB3",
       "checksum": "8da18d12f95280bf1a7bde6e13cb8e1e2ea877acc4e826c27ab6c5df653fafca"
     }
   },
   "0.9.50": {
     "previous_stable_version": "0.9.49",
     "x86_64_linux_gnu": {
+      "etag": "0x8DB23E9B9D4FEBE",
       "checksum": "4586cfb628f70f6493d9f861b0c71dbe66622128e935ca3c922010bd460673ba"
     },
     "x86_64_linux_musl": {
+      "etag": "0x8DB23E9EDFDE02E",
       "checksum": "c8b766b6bc28018b8a2c0597b97dd8183fe5a81ddd51fbcc1e9892147887eca3"
     },
     "x86_64_macos": {
+      "etag": "0x8DB23EABD0DE1E9",
       "checksum": "77405db34f1191cc6979b3e291e7aaf587a40ee231cbccbe1885fd89e31ee577"
     },
     "x86_64_windows": {
+      "etag": "0x8DB23E9B041887C",
       "checksum": "6e8a2f4deeb4ade48f4424a65db13bd5122dec73d59a4eeac51c13eb997e1bdf"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB23E9DF874A8A",
       "checksum": "ebb3198673a199518548af5f8c1a5be7e15a85e9ca5c3978caeb7e0cd09f2969"
     }
   },
   "0.9.49": {
     "previous_stable_version": "0.9.48",
     "x86_64_linux_gnu": {
+      "etag": "0x8DAF5D7E3F49F1E",
       "checksum": "5e19c5038c9940da4c47a9ae87f94b352dc98c2ab75b4b9aeae227cdff8440d2"
     },
     "x86_64_linux_musl": {
+      "etag": "0x8DAF5D850AC23CA",
       "checksum": "b09d7870bba824af1acfce505811951f0d81cf21b144490c6a3f34f59bcc182b"
     },
     "x86_64_macos": {
+      "etag": "0x8DAF5D92B4302C3",
       "checksum": "171bc696474667208587c74d9acce0250f3b2eac1faad39458e828a65c3f1c93"
     },
     "x86_64_windows": {
+      "etag": "0x8DAF5D82F134DF5",
       "checksum": "e9c532bb99c6e8e7edb65578f8c251fb3d87a3377bef1128763442dc7f088ebb"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DAF5D7DEACDCF5",
       "checksum": "40ff81ed279e8a6d38ebe06ee75bba47785e8cb006267e35a15c157724e8e437"
     }
   },
   "0.9.48": {
     "previous_stable_version": "0.9.47",
     "x86_64_linux_gnu": {
+      "etag": "0x8DAED25FF3313A7",
       "checksum": "9730218bacb5f6c1697a4f44a94958a3ce708e8cc7ff430ac007075620b49b09"
     },
     "x86_64_linux_musl": {
+      "etag": "0x8DAED2625A27804",
       "checksum": "bc6c52c443469342d9eeed564d78007c8c7aca6c592153d1743b6c2530b195b8"
     },
     "x86_64_macos": {
+      "etag": "0x8DAED27C577E087",
       "checksum": "ee592baa34e0210bc2195a9369e13cc520e926ee6cbfec8727c653c1f8a275c4"
     },
     "x86_64_windows": {
+      "etag": "0x8DAED26117DDEDF",
       "checksum": "3d34a3be1ace82dc33f52a8396743ad19f1f78739d44fc755a927fb1c187c071"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DAED25EEBE9431",
       "checksum": "13af6c207cfae0219f6ec3760980d951292815d26f575f4c099ae1797af7505a"
     }
   },
   "0.9.47": {
     "previous_stable_version": "0.9.46",
     "x86_64_linux_gnu": {
+      "etag": "0x8DADB26F234DEE0",
       "checksum": "8518f212d10ab67ad620bcf8dff755a0f083757440881143c31a3904821f260f"
     },
     "x86_64_linux_musl": {
+      "etag": "0x8DADB2718FDF416",
       "checksum": "879605757d4b7bbb8aa2c108e91a328ea1d5af38a1be236bccc5aec7eed60446"
     },
     "x86_64_macos": {
+      "etag": "0x8DADB29A9852849",
       "checksum": "23ad7efe005bbbc686eabdc4be6f471fabc64ef6caf161d92ec8f0ef9dcb38f5"
     },
     "x86_64_windows": {
+      "etag": "0x8DADB276CF840EC",
       "checksum": "22d838040a0106c0fbe06a0f13bc0995c92e81898f2355421c07fe2f856dd2ed"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DADB274621E6BA",
       "checksum": "98260769d5762f35f2e2d7b1812372f4639d2ab4078e1967d1daf659331b879b"
     }
   },
   "0.9.46": {
     "previous_stable_version": "0.9.45",
     "x86_64_macos": {
+      "etag": "0x8DADB141AA63428",
       "checksum": "938fa847ab1d7d0fa94dbeb9bdea817187bcf89c59d2a871b24042b09ad17944"
     }
   },
   "0.9.45": {
     "previous_stable_version": "0.9.44",
     "x86_64_linux_gnu": {
+      "etag": "0x8DAD678D3415F0F",
       "checksum": "fb7dd79b1b16e2c8a4476c72091988852966ad42dd969eaf3469b84bb996f08c"
     },
     "x86_64_linux_musl": {
+      "etag": "0x8DAD678C87FB965",
       "checksum": "6ca9583d08da02bc8b4e6c4d94d341cce4784057fb27730e64e01b70fe004afd"
     },
     "x86_64_macos": {
+      "etag": "0x8DAD679D46BC7F3",
       "checksum": "dc50fb656120753932f88b5c9de0ed64d3bd738d1615d1d5b9849c393328cdd1"
     },
     "x86_64_windows": {
+      "etag": "0x8DAD67914B27214",
       "checksum": "8222d7f4ba8d4d62bb21ecf2dac3695025e77d00ea711bd8043a0c4605250b4d"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DAD678FA409F25",
       "checksum": "e8aef754b393369cff845ffe1a0acba569b04f4747874320e71bb15593c8235d"
     }
   },
   "0.9.44": {
     "previous_stable_version": "0.9.43",
     "x86_64_linux_gnu": {
+      "etag": "0x8DACD929CBCF743",
       "checksum": "544e15a10bdea2e98da6762d062a61fe1e1a24235200895c9f1c4817d3d9fec1"
     },
     "x86_64_linux_musl": {
+      "etag": "0x8DACD931E82F884",
       "checksum": "5174ecb5f0fa699dcf2c90f2689b5d6e32e0d5b9ab24fd309c00d865710fa8b8"
     },
     "x86_64_macos": {
+      "etag": "0x8DACD94C1DBB34C",
       "checksum": "ae20bb213ca44898b49b30fad9eb90b00f4997032bd0815f11571109c3e675b2"
     },
     "x86_64_windows": {
+      "etag": "0x8DACD93216B520D",
       "checksum": "1c6d5e02ac53495d1efd7754337a64d362bc917b7a063de8cb560352696d0167"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DACD9329591681",
       "checksum": "7293c00fcc3a1f77e2b12438aba0de8612b4b5ed6b6eaa5b1665db9d84e99ba0"
     }
   },
   "0.9.43": {
     "previous_stable_version": "0.9.42",
     "x86_64_linux_gnu": {
+      "etag": "0x8DABED26BD20D1F",
       "checksum": "448e6700d5b0e459b9dcd73f6ebc76fd57bd1c621f4ac5f2c915ac90d6e89c84"
     },
     "x86_64_linux_musl": {
+      "etag": "0x8DABEC696D3A7E6",
       "checksum": "b40f83e6093ba0822daf43caa5fb3f64fc098cfbb1b2b8b704a1b82d280b93dd"
     },
     "x86_64_macos": {
+      "etag": "0x8DABEC83F726902",
       "checksum": "8fef2947e22891a8f668aab33fa05ebbf0138df6703fcc2ca963a257e6441d29"
     },
     "x86_64_windows": {
+      "etag": "0x8DABEC6AA255E90",
       "checksum": "4fc0f4c3e255dea1a07d43592056d71d19660abcfd11711e1bb3732311ca0dc4"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DABEC6AD057C26",
       "checksum": "79da74c38d6ba1381058fb5d1318c6b318b47869349b8a80806e09596abc8017"
     }
   },
   "0.9.42": {
     "previous_stable_version": "0.9.41",
     "x86_64_linux_gnu": {
+      "etag": "0x8DABC60F357018D",
       "checksum": "baaed41d21ff120fed927e022c9bf74e8d31dc50a4342e7849894fc341f31c53"
     },
     "x86_64_linux_musl": {
+      "etag": "0x8DABC61262F45B3",
       "checksum": "1b4c4442d5ca6329d5c04697fad70355569d738f37c713411c6fcd0195aac457"
     },
     "x86_64_macos": {
+      "etag": "0x8DABC62C8FD9701",
       "checksum": "12d9e8ebf0ab5cf2596dea35bee183310348d5c9625f2bda64cfbf4c342e3730"
     },
     "x86_64_windows": {
+      "etag": "0x8DABC61CA5D9F08",
       "checksum": "bf69c7055f5c45f38a4c63538c8b367122557d1dd49414e62f8c38a76f31f88e"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DABC61514B504A",
       "checksum": "f2de3914236041d7aa843c3d1d2304cf25e032dad2a3cd2e3fd4cbde12202b64"
     }
   },
   "0.9.41": {
     "previous_stable_version": "0.9.40",
     "x86_64_macos": {
+      "etag": "0x8DABC5792206089",
       "checksum": "1d2983bed390e6e5fb13222dc0724bb54a3f67226e87e7a304c7dd3f0003ca61"
     }
   },
   "0.9.40": {
     "previous_stable_version": "0.9.39",
     "x86_64_linux_gnu": {
+      "etag": "0x8DAB6DA83889910",
       "checksum": "d9ab201015d93bc1e47b0c9da0a778d746fb7f22c610cdc9f2dabd441dd7fc76"
     },
     "x86_64_linux_musl": {
+      "etag": "0x8DAB6DAA33C7F99",
       "checksum": "04772ba51706ddaffeb05688bc2a77719321aadfa31b70249c894ad85ce0fe36"
     },
     "x86_64_macos": {
+      "etag": "0x8DAB6DCA6455D10",
       "checksum": "55c9c77885f8fed495bd1da06d00d676b506ea35a5c1825ff3eda0b83746b0e4"
     },
     "x86_64_windows": {
+      "etag": "0x8DAB6DB049748DF",
       "checksum": "49d80615ee2cbd213abe8bd110f5bd1990050dcefd17a34014e4d3b924339fe9"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DAB6DA7E39B2FB",
       "checksum": "e20dde1b62b5be9c76782b3c6521682621b04e483f4029f69c05b5f44a133704"
     }
   },
   "0.9.39": {
     "previous_stable_version": "0.9.38",
     "x86_64_linux_gnu": {
+      "etag": "0x8DAAE1EF71F60BD",
       "checksum": "759d6766f4686af03c99d9d641286b313b8acad01f5795d825eb33014ae0867a"
     },
     "x86_64_linux_musl": {
+      "etag": "0x8DAAE1F84362EA9",
       "checksum": "1c0a1ff68ddf1e2a9acd201c12a4dab451fc3a8d1908d33e7bda406de757a689"
     },
     "x86_64_macos": {
+      "etag": "0x8DAAE208557F45A",
       "checksum": "563d491a51d3ec4a133b83b979cd4d4ed654e5fd65bbe9ca2fd9f3021a8dab1e"
     },
     "x86_64_windows": {
+      "etag": "0x8DAAE1FFC84CA9E",
       "checksum": "d9cb5b2a7a52b43f53f2c4afbcb3ae56d029b98342101b78d84fdfa569988eb3"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DAAE1F08178B15",
       "checksum": "bc4300207ca8365348f6a4c5d2122873bf6ca12652b4c58c455a339e79118568"
     }
   },
   "0.9.38": {
     "previous_stable_version": "0.9.37",
     "x86_64_linux_gnu": {
+      "etag": "0x8DAA7291F6453DE",
       "checksum": "ce6a30df41bc32158d0136b59757f41e9da9b9633ca00a5f96f03c4586ea7bf5"
     },
     "x86_64_linux_musl": {
+      "etag": "0x8DAA7292ADC460A",
       "checksum": "6fadc213ccf08a3cc3149d784d13452cfb74cea5e68885e31d5853d4b56c6dc3"
     },
     "x86_64_macos": {
+      "etag": "0x8DAA72C99E4385D",
       "checksum": "1c5923ed413d82933e45dfa6ad16c08901216f39c67d2836e45048d768f91bd2"
     },
     "x86_64_windows": {
+      "etag": "0x8DAA729AD2257CD",
       "checksum": "fbf73b5e8bca59784b11fd526068ff01b5e456d66b19be6706ce93e4181e83b6"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DAA7294F016D7D",
       "checksum": "b7fc94e638e82075286190ba696222a6768f4144ea7384ea5a25292ca5534fac"
     }
   },
   "0.9.37": {
     "previous_stable_version": "0.9.36",
     "x86_64_linux_gnu": {
+      "etag": "0x8DAA3125FDA5159",
       "checksum": "da51679397ed055a0cc2f2e63ff934d179372bbd88f937f71f7255fd5c528755"
     },
     "x86_64_linux_musl": {
+      "etag": "0x8DAA312F2F822BA",
       "checksum": "6ea9ce5726ea30ac6186dcf063dc5a4595c6779b8530200618d291ac95944e53"
     },
     "x86_64_macos": {
+      "etag": "0x8DAA31746FDD2C1",
       "checksum": "01386d1242a6656eb1239cd5ce59b383f60167f687e3eb9bfd180fab86f58e47"
     },
     "x86_64_windows": {
+      "etag": "0x8DAA312E6E85F04",
       "checksum": "9f3be2d8a85b2dedaad7bccefa45dc430f9a76bf99104a44bef3fbb8553e3e5c"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DAA312F7007E9C",
       "checksum": "41ccf7273be37af8ea466b2dfa35fe922cdd1d1b45716407f2951fb38d97a748"
     }
   },
   "0.9.36": {
     "previous_stable_version": "0.9.35",
     "x86_64_linux_gnu": {
+      "etag": "0x8DA913D1CA5F5DE",
       "checksum": "d2b0f7b0773e60a93aba72a9ae5c11fc348e58f38fe25d6e1877725d9e6ae475"
     },
     "x86_64_linux_musl": {
+      "etag": "0x8DA913D4A1FD9E7",
       "checksum": "e1b90e4bcb12ab3839eca75ef6de6a3ed46936d68037958f7a7167e4653896da"
     },
     "x86_64_macos": {
+      "etag": "0x8DA913F14418124",
       "checksum": "4332636324d9ee0e786cfdefae3ee383a2a0b3ddde6fdccab212e0c09671f7fc"
     },
     "x86_64_windows": {
+      "etag": "0x8DA913DCE82DF64",
       "checksum": "7f0c7211671e1fdea76136c06110df6acca23e4e32f53c3ef6e8a537efae73c2"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DA913DB31D3D95",
       "checksum": "b266b330fcfc7223825b46a07cdd072df3e41911515697000508baf019e64dea"
     }
   },
   "0.9.35": {
     "previous_stable_version": "0.9.34",
     "x86_64_linux_gnu": {
+      "etag": "0x8DA80912AD42172",
       "checksum": "fa6fbc8d848e595d847eaeddea432dad6944a4cfc4ac3156ef91173772a1c4ab"
     },
     "x86_64_linux_musl": {
+      "etag": "0x8DA80919D0C65F9",
       "checksum": "9d11ad8ed2d6401b51196d4b0c78924b0f78df323458b096c1adcdc899c8fb66"
     },
     "x86_64_macos": {
+      "etag": "0x8DA8093C1603D37",
       "checksum": "0cbc3a22be5511ff0365499f6d0e38b0aaa62f33c8e25792a71437dbdfd0af43"
     },
     "x86_64_windows": {
+      "etag": "0x8DA8091CE810955",
       "checksum": "1026b2d19604d745c61635bf9fd5105c15f36bebef1cd6de2b0fc0a455de0b27"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DA8091820286B9",
       "checksum": "866db5b1b39032055eb2cfb0a62f5a5a23899ce0abfba0129f44bf826b81adcf"
     }
   },
   "0.9.34": {
     "previous_stable_version": "0.9.33",
     "x86_64_linux_gnu": {
+      "etag": "0x8DA7C912F40411F",
       "checksum": "a96acb41a9ca14d5cd5aef9e8a12c1be8f8a3362bafe4f3a3da32c56b9c1abc5"
     },
     "x86_64_linux_musl": {
+      "etag": "0x8DA7C9188D99628",
       "checksum": "f1ef0f528e09dc2ae9dea3fb6cf234f279772170cddc1fc8a603c4733f7675cc"
     },
     "x86_64_macos": {
+      "etag": "0x8DA7C92EB14389F",
       "checksum": "406ae94f8e8ae81e7f00080449c045bee01ee569721e603f7e6eb685903dde66"
     },
     "x86_64_windows": {
+      "etag": "0x8DA7C922A0B398D",
       "checksum": "7b096f12a97ca2f7f194c25e88a2459bf078997157af85dc77603df277f63d7c"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DA7C9192EDBF3D",
       "checksum": "008927576704b0650727539daa435d1636f01516bad5f45d27c21afe992fdc01"
     }
   },
   "0.9.33": {
     "previous_stable_version": "0.9.32",
     "x86_64_linux_gnu": {
+      "etag": "0x8DA733C180E650C",
       "checksum": "6bfd0f9f156dcad38f40282320b38cb513f19023617b9df327026cc8e41a2795"
     },
     "x86_64_linux_musl": {
+      "etag": "0x8DA733C1F352A54",
       "checksum": "2e5b1819ebfc8c6da370ef07e9487dd42bef7ad28949aa6235dd127ad49cd064"
     },
     "x86_64_macos": {
+      "etag": "0x8DA733D1F007F64",
       "checksum": "bee61898fdaa523b4ebfbeeacfd3f6051a77cb307b3c5ece4f35f26802e7469c"
     },
     "x86_64_windows": {
+      "etag": "0x8DA733CD3166BF7",
       "checksum": "425e9be858d5b66410cdb8ac9b9d62fc80a196aa5a9cc7c8ee7f0a5fe7bdf6a8"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DA733C3567A53C",
       "checksum": "1b016e421493e11a5272bd9a24fa1515d7fad2962d41393261b5823fd1c8dbf4"
     }
   },
   "0.9.32": {
     "previous_stable_version": "0.9.31",
     "x86_64_linux_gnu": {
+      "etag": "0x8DA7281419CFCDB",
       "checksum": "3c4688160d7055494ba4343b6f84c80d229576df6acf6c4caf955b01e52a67a9"
     },
     "x86_64_linux_musl": {
+      "etag": "0x8DA7281B6E1A6F0",
       "checksum": "86d4e3a57e99c1806315c4df1337b0044eea9fe1d57331428f79d3c1686a2187"
     },
     "x86_64_macos": {
+      "etag": "0x8DA7282B0C95B82",
       "checksum": "a5747af15b4620dcf51b166e866a6421858becdd7ee07db1b05cf9fc3e9fa7eb"
     },
     "x86_64_windows": {
+      "etag": "0x8DA7281BF07B569",
       "checksum": "f75dc137cc4826a276d9d9dc38ce3ea93b69e4fc2fcfa13af9dd060ae9db1f9a"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DA7281B6A061BF",
       "checksum": "c50cedfbf8c5ec41c8777e9b18f082f0cc789ee7a47de07bfa6f4549e84d8bed"
     }
   },
   "0.9.31": {
     "previous_stable_version": "0.9.30",
     "x86_64_linux_gnu": {
+      "etag": "0x8DA7031B01392AA",
       "checksum": "e086b4d84f08ff750afc917dbe89803e3aece8ff166ab380d2c4437cd459da72"
     },
     "x86_64_linux_musl": {
+      "etag": "0x8DA703222567267",
       "checksum": "272593752ad3ce5eca51cd071efbdc463914ee091f38007f5ae684ae5d7b2733"
     },
     "x86_64_macos": {
+      "etag": "0x8DA70338C2AE542",
       "checksum": "dda665e39e889bafee6ccfcfc8b63ad510abac9cc0d0673fe7bc928135e56055"
     },
     "x86_64_windows": {
+      "etag": "0x8DA703257256BE7",
       "checksum": "c72779cee829009550668d7da2ad1a1fc9081e8d14782818b8fa17c6aa763ac6"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DA70321B928112",
       "checksum": "a5c23e61574f938d1b9e0d71425b9b01a9af5dd5000a79489b5f256fb48d174e"
     }
   },
   "0.9.30": {
     "previous_stable_version": "0.9.29",
     "x86_64_linux_gnu": {
+      "etag": "0x8DA6E91213F1308",
       "checksum": "6607736082fa6557012cd1b388cc63d3ec4b5eb344d41404c0726bfaa37c108b"
     },
     "x86_64_linux_musl": {
+      "etag": "0x8DA6E916732B197",
       "checksum": "fa3117e40bbb888a81da73b7ddc1d0b545ccc5684fcabc99761589c33c90ae24"
     },
     "x86_64_macos": {
+      "etag": "0x8DA6E92BB651499",
       "checksum": "5e0f12f783dbe64343ddc168d36ee8bde961149a92883c0b7813b7831f4c33ed"
     },
     "x86_64_windows": {
+      "etag": "0x8DA6E91D53C2615",
       "checksum": "bc3728cb1a8fb34378005dc5c2e849e1ecad5c9df7be368c968d3125b895b8db"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DA6E91AD0336AE",
       "checksum": "2bbeea2fcb0a84b4349c735bafe4575a85d2c080e1863347601bbbec17f7602f"
     }
   },
   "0.9.29": {
     "previous_stable_version": "0.9.28",
     "x86_64_linux_gnu": {
+      "etag": "0x8DA6DC80CEE3EF6",
       "checksum": "b57d1662827d85be4ea37e9e4ca0bc53b96dc564fb8d8ab2300fda3b53423895"
     },
     "x86_64_linux_musl": {
+      "etag": "0x8DA6DC82B4D9C17",
       "checksum": "0af9af9f9f278becd87f203fab31b9f0ef8ea69c7c9227e30a41c6c9311526dd"
     },
     "x86_64_macos": {
+      "etag": "0x8DA6DC90484C1E1",
       "checksum": "3706c380fdf87bf0547b51a29c2880efcfd1c5f8839dcfcc455fc40de1ff3a6d"
     },
     "x86_64_windows": {
+      "etag": "0x8DA6DC84C6438BF",
       "checksum": "5a5c3532872a1006b61e0422d6f6cc89de2ed80273f76888c9a68b2f4e039cae"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DA6DC858B1F4E4",
       "checksum": "fa32a8c8951b4f6ea19fdb97799188fc8c8b1fba06afc0240a005d72b685915a"
     }
   },
   "0.9.28": {
     "previous_stable_version": "0.9.27",
     "x86_64_linux_gnu": {
+      "etag": "0x8DA6C2BC8B8078A",
       "checksum": "fa0f8843469cf3c541b6dedb9321ba04573d9ba75bf8608a028537ba924f0bd8"
     },
     "x86_64_macos": {
+      "etag": "0x8DA6C2D96C7796C",
       "checksum": "d99f24fe2ec8887fddd6b8a7b39cc1f0c793504d8f61f965a71b3499801e6aec"
     },
     "x86_64_windows": {
+      "etag": "0x8DA6C2C4A566403",
       "checksum": "cd519077fa9dad077644ea3f0ea28455cb320c48bc0577e33f61169d81aefc4b"
     }
   },
   "0.9.27": {
     "previous_stable_version": "0.9.26",
     "x86_64_linux_gnu": {
+      "etag": "0x8DA6C09EFE23EF9",
       "checksum": "da3054259e0aac51d3a4392778a594fa22cef2ae22494c2cc109ffe1b895e1f6"
     },
     "x86_64_macos": {
+      "etag": "0x8DA6C0B802B0B05",
       "checksum": "215594fb9dca749cc7dabc5727d6e6aeacdc4f4f835aee330cfa1d5b26a3102c"
     },
     "x86_64_windows": {
+      "etag": "0x8DA6C0AC4D3B6A6",
       "checksum": "bb78880018da246a18d5654181d3ee7a7755fe27773502147e64938ba9400634"
     }
   },
   "0.9.26": {
     "previous_stable_version": "0.9.25",
     "x86_64_linux_gnu": {
+      "etag": "0x8DA65C130A2D4C2",
       "checksum": "fda7a9d8964d87da648fb2336957a5ea4c3584671eeac4d378a258873395814a"
     },
     "x86_64_macos": {
+      "etag": "0x8DA65C2C11F4EBF",
       "checksum": "5d13fe035eb40aa1963c9434e23cff3dc26a9644ca09ed9271f18a1b40559006"
     },
     "x86_64_windows": {
+      "etag": "0x8DA65C212D0026C",
       "checksum": "f0c0dba573b8f486a3b452a4173f14bd3cc52dc0801f98a74ec81c86b6d46786"
     }
   },
   "0.9.25": {
     "previous_stable_version": "0.9.24",
     "x86_64_linux_gnu": {
+      "etag": "0x8DA6514A464D1DC",
       "checksum": "5a0af54644702a17690d3e9bfe5b007f5eb04a423a31560011818f6e6b828011"
     },
     "x86_64_macos": {
+      "etag": "0x8DA6516794317C6",
       "checksum": "012199680a32ea1834662e558a7455a4a92bbfd3825f48809fea4ccf5ad6427f"
     },
     "x86_64_windows": {
+      "etag": "0x8DA6515119CC52F",
       "checksum": "23c3ce0f92098016651832f44f6b27d9c9d4031db421ea5afdb43dfdeb643d93"
     }
   },
   "0.9.24": {
     "previous_stable_version": "0.9.23",
     "x86_64_linux_gnu": {
+      "etag": "0x8DA5BC1DDAAD039",
       "checksum": "a51b6fedb9b7a4d1616bed1e84a9c001a7b74f1c238d0f82fd06f2c2c1852a15"
     },
     "x86_64_macos": {
+      "etag": "0x8DA5BC420E8B0FF",
       "checksum": "3b08a166428ff53d129bdce9a55a4b84c46328e91cdf6a97fe5db2070fdf4548"
     },
     "x86_64_windows": {
+      "etag": "0x8DA5BC27E41133A",
       "checksum": "6d5ae9d933af826b7cd9fce6f803c92740a48ccd1a6a9899bd3e5878cf9d1f09"
     }
   },
   "0.9.23": {
     "previous_stable_version": "0.9.22",
     "x86_64_linux_gnu": {
+      "etag": "0x8DA57B8923E9820",
       "checksum": "e55ea8d86b2667fa630e1b3cf61eb1d5f079619ccc63c193b64545a2b6bc5cea"
     },
     "x86_64_macos": {
+      "etag": "0x8DA57BA29F22468",
       "checksum": "3464080829d1989b1ee0e8ab99c30cba06cfa7dc413dd0d553e9197434240e4f"
     },
     "x86_64_windows": {
+      "etag": "0x8DA57B907A2B279",
       "checksum": "c8fa3e1f0d235f93d9cd6b76e6fc75bf9d7d82929b91e3d6cf6a15975907defc"
     }
   },
   "0.9.22": {
     "previous_stable_version": "0.9.21",
     "x86_64_linux_gnu": {
+      "etag": "0x8DA53CCE4E008F5",
       "checksum": "b0d05e3fc88b0fb8320a05fc860f2f5030e8f6ee2662e62750a194e8af5546f6"
     },
     "x86_64_macos": {
+      "etag": "0x8DA53CE07A0ECF4",
       "checksum": "9fb9d314ffc646d4537950f0cce30b4f8ac06865d43e6b4c5eb1235f657a6351"
     },
     "x86_64_windows": {
+      "etag": "0x8DA53CD0A7F53E5",
       "checksum": "3f92c2cbe12f50f03032c3724711c2e5e537167413c3b671203d367eda16f79f"
     }
   },
   "0.9.21": {
     "previous_stable_version": "0.9.20",
     "x86_64_linux_gnu": {
+      "etag": "0x8DA50A72D3ABB77",
       "checksum": "33b905ef2202b97e7103ff7765a42547e25b2d6b781f6f985442e2b438d1aa62"
     },
     "x86_64_macos": {
+      "etag": "0x8DA50A91203F3AC",
       "checksum": "cdf95d3a0f990e74c4c2bd1332ccfc5b500067c50ff6f0b8f5862f979ce093ce"
     },
     "x86_64_windows": {
+      "etag": "0x8DA50A7E68ADECC",
       "checksum": "004845877d74734b2d7465d34d4cd512fe4e81e0c407ba03faf0517cf4cef7cd"
     }
   },
   "0.9.20": {
     "previous_stable_version": "0.9.19",
     "x86_64_linux_gnu": {
+      "etag": "0x8DA4D73999D2EAA",
       "checksum": "d1de19dc8e5d46aaa5fc00394e1a7ccb04160761a4d262f58d1eb6b73b80d73b"
     },
     "x86_64_macos": {
+      "etag": "0x8DA4D75618C8BB7",
       "checksum": "74122e64f063169c068f6e0126ca320e686b09dc2114eaca0e3425e94e596f60"
     },
     "x86_64_windows": {
+      "etag": "0x8DA4D74B96B83AD",
       "checksum": "4cb7eb9b6bd94340929b3b517360d24353526f98b19e6706e244f220f2651185"
     }
   },
   "0.9.19": {
     "previous_stable_version": "0.9.18",
     "x86_64_linux_gnu": {
+      "etag": "0x8DA4D6EA4D727C6",
       "checksum": "fd351b31fdb2ce547027928918820d7f07e3a1782e419427028f4993ae7be8ef"
     },
     "x86_64_macos": {
+      "etag": "0x8DA4D706BC45E69",
       "checksum": "e455850453292f2f4808b176f8c01759df81d8b9ed388aa145c0692bbe4836a3"
     },
     "x86_64_windows": {
+      "etag": "0x8DA4D6F65419209",
       "checksum": "18071ab9afa62e1074991e07034b2924a9af69fe1be846276999f0f1df18d5f4"
     }
   },
   "0.9.18": {
     "previous_stable_version": "0.9.17",
     "x86_64_linux_gnu": {
+      "etag": "0x8DA49B8DA914E76",
       "checksum": "acbeaf13acdf5913dae7c628eaf834e2ad166567fdfbb8fc5bb1a7e3fcf1ea0d"
     },
     "x86_64_macos": {
+      "etag": "0x8DA49BA2DFEC355",
       "checksum": "66b6420a1c03522b7ff1a986095a7253dacd0caa81dfadd9af4394373261274b"
     },
     "x86_64_windows": {
+      "etag": "0x8DA49B95D4CFA7D",
       "checksum": "79e8e2e45d493e99e536f5155e709831084c9071a0d90d0d1bb367ae3c83e8b9"
     }
   },
   "0.9.17": {
     "previous_stable_version": "0.9.16",
     "x86_64_linux_gnu": {
+      "etag": "0x8DA48D8D0EB24CF",
       "checksum": "2ac1d189f8efdc3ef6f487b1230c41f4f417b26caee07fef2845828cd5282ee6"
     },
     "x86_64_macos": {
+      "etag": "0x8DA48D9B8BFFE9D",
       "checksum": "72bb8422383d3ae97988e7bdc5b8bae2a62e9ce3e313dc6a3ecb402c7acdd5fb"
     },
     "x86_64_windows": {
+      "etag": "0x8DA48D935785C0F",
       "checksum": "980bfca9db2ca58b8b6e8e5542863523b63deb29bff09c5dfee698aea90dab64"
     }
   },
   "0.9.16": {
     "previous_stable_version": "0.9.15",
     "x86_64_linux_gnu": {
+      "etag": "0x8DA44CEF151588A",
       "checksum": "64889b60a9d13082b2848c262072bf113635c70a71b89656e7d9848dbb10f58b"
     },
     "x86_64_macos": {
+      "etag": "0x8DA44CFF9AD8A24",
       "checksum": "ce7b3cba9267ba10dfed2416ae2cf9f2c3e5c5c328f4bf80818cd7c1dbd8db24"
     },
     "x86_64_windows": {
+      "etag": "0x8DA44CF6421D05E",
       "checksum": "e14b2295530642d70cd327d119300ed566bf58daa2a05176c2c8ff213c3c3df0"
     }
   },
   "0.9.15": {
     "previous_stable_version": "0.9.14",
     "x86_64_linux_gnu": {
+      "etag": "0x8DA434192F0D2DC",
       "checksum": "d80d666195a97d0e41c371f7e763855475d08d9a5209aa5302598d926bbb590c"
     },
     "x86_64_macos": {
+      "etag": "0x8DA4342887477DA",
       "checksum": "db2f8277edeb9f41016422480d120c6c98390fd4c5551b1960ac2e1f04466499"
     },
     "x86_64_windows": {
+      "etag": "0x8DA434226DE3F90",
       "checksum": "2ead3aa0a4bfe8a400240bd71b6e512c5c344c2e678dd6fe5b2c99b70ddc7b28"
     }
   },
   "0.9.14": {
     "previous_stable_version": "0.9.13",
     "x86_64_linux_gnu": {
+      "etag": "0x8DA217A62B7FFC8",
       "checksum": "42bcff26fec36c213371108cbf1c7d5baeccf3ae84f4f177db222d59268db417"
     },
     "x86_64_macos": {
+      "etag": "0x8DA217B5264C916",
       "checksum": "a4de96f85fe863900f297639c4acdc3bd0b3bed2de181bb9a0a83b80bca090dd"
     },
     "x86_64_windows": {
+      "etag": "0x8DA217ABEE30F5D",
       "checksum": "03e5185732b1807629510e5d8c29764a144af3ffe81b0ab0c8522ad91a492653"
     }
   },
   "0.9.13": {
     "previous_stable_version": "0.9.12",
     "x86_64_linux_gnu": {
+      "etag": "0x8DA201D4BAD6CA7",
       "checksum": "299338ee9dba31b1b1df06142ce6fbfb3388f42b5047b33bc6f83db1b903a6b8"
     },
     "x86_64_macos": {
+      "etag": "0x8DA201DF8E7B437",
       "checksum": "293d07de124fe58b19e464b4234554d7d24ad46c7131a029588525e95813bd27"
     },
     "x86_64_windows": {
+      "etag": "0x8DA201DB7C12968",
       "checksum": "f00b5fa66b4677360c3849069b91c25b580d3980609fdc5dc0cef3174402fa10"
     }
   },
   "0.9.12": {
     "previous_stable_version": "0.9.11",
     "x86_64_linux_gnu": {
+      "etag": "0x8DA0C5418DCC2BE",
       "checksum": "62a3bd60304f031a9e8de2eb5359ac709bbf43c979b2885cf719ee6982925a1b"
     },
     "x86_64_macos": {
+      "etag": "0x8DA0C550D812026",
       "checksum": "59a98b67718f57878f034562fbcfcccdad38cd276cb989eaf66197c3194aa20a"
     },
     "x86_64_windows": {
+      "etag": "0x8DA0C54AA97C2B1",
       "checksum": "bc0d2c77602fae21981ca5ea1f7577385c7bad6becd40d02a7e8f850ec647a3c"
     }
   },
   "0.9.11": {
     "previous_stable_version": "0.9.10",
     "x86_64_linux_gnu": {
+      "etag": "0x8DA025D843C4DE2",
       "checksum": "edf8b5de7ae39fc1f7c1a5696f92fecee67ea40eb2937b707c026421cd2b0ef7"
     },
     "x86_64_macos": {
+      "etag": "0x8DA025E588DBB70",
       "checksum": "13062f0d363bdcfebb6711726f3f376f6b96f6d618f003bc9deb62eff177b5c6"
     },
     "x86_64_windows": {
+      "etag": "0x8DA025DC2245652",
       "checksum": "f50546bc2e870a6d700866daed0e754f7911070f3bf15168e22aa7e394006d68"
     }
   },
   "0.9.10": {
     "previous_stable_version": "0.9.9",
     "x86_64_linux_gnu": {
+      "etag": "0x8DA00A7898A6C8A",
       "checksum": "72f2452beab162849800e451f002b7b666599c1fbf48ba0f1e4e1f66d1a3f964"
     },
     "x86_64_macos": {
+      "etag": "0x8DA00A84F643934",
       "checksum": "9defd432c28d0c4639722e18f2d0b30cfcbc3d40d0da979484029bf3fb37bfe8"
     },
     "x86_64_windows": {
+      "etag": "0x8DA00A7E48238AE",
       "checksum": "a0b3f050813f9c4e9342e96806fe3f58b40cd21070bf6e975c8b9c32022f0c7c"
     }
   },
   "0.9.9": {
     "previous_stable_version": "0.9.8",
     "x86_64_linux_gnu": {
+      "etag": "0x8D9FD462AD7D9A0",
       "checksum": "a68f660fc632ba9f56d34c108e12268c776b3a4af12e4a57919defea2749a4fb"
     },
     "x86_64_macos": {
+      "etag": "0x8D9FD47191F0B3D",
       "checksum": "68fabfb452ea3da2631867528342d76c7d22e65eb5729dcf2001b529377465ff"
     },
     "x86_64_windows": {
+      "etag": "0x8D9FD476DEE52CE",
       "checksum": "cfb61967039f6378e78ceb494212782ef484b4014cd267fd48c3aa6562b9ed9f"
     }
   },
   "0.9.8": {
     "previous_stable_version": "0.9.7",
     "x86_64_linux_gnu": {
+      "etag": "0x8D9F744AEE898C3",
       "checksum": "9f2bcac8b65bafb12573b0106db48b29d9ceba4acaa351cc5f2504d38245de61"
     },
     "x86_64_macos": {
+      "etag": "0x8D9F74541A1A772",
       "checksum": "56962fcebf7af87de9c3c24d161a4849fa5274e4ca1d5efa4901849f15efae1d"
     },
     "x86_64_windows": {
+      "etag": "0x8D9F7450520DED3",
       "checksum": "0ed3100d1b29c0475f5784556ac024556b7984a95abffc10c4e80300d525b31d"
     }
   },
   "0.9.7": {
     "previous_stable_version": "0.9.6",
     "x86_64_linux_gnu": {
+      "etag": "0x8D9F6F70D4C1BB9",
       "checksum": "f837faa4e747a82f73f01e735dc9304e64bda55adcf857b9448158d1817cafbc"
     },
     "x86_64_macos": {
+      "etag": "0x8D9F6F7ED0E1B99",
       "checksum": "59d144fc093c344a82ebda600c06c97ae423a0ce1346a0bab44d38e220843a59"
     },
     "x86_64_windows": {
+      "etag": "0x8D9F6F761C0CCBC",
       "checksum": "1a248d7ee61fc353638b249c2ab57a5f34ee06a1b31ad181a1d82c7d7766079a"
     }
   },
   "0.9.6": {
     "previous_stable_version": "0.9.5",
     "x86_64_linux_gnu": {
+      "etag": "0x8D9F6605B4E6147",
       "checksum": "de73c56b53a96dbdbb0625727cd7296afebfc3b3b561310330732aefd20808bf"
     },
     "x86_64_macos": {
+      "etag": "0x8D9F66135DB0FBE",
       "checksum": "90bad8022768b6a5a8980cc715208568a578b88305ff3b11bd06360fe1398429"
     },
     "x86_64_windows": {
+      "etag": "0x8D9F660FBE32EDF",
       "checksum": "a8963ab448155f49476bd27f8e47313de5b5c4fea01ae1e08d493aafbaa6d086"
     }
   },
   "0.9.5": {
     "previous_stable_version": "0.9.4",
     "x86_64_linux_gnu": {
+      "etag": "0x8D9F4A4855897F9",
       "checksum": "170abd2e313faab81ff5f9a029feec552fed6f9131790206554870a8e33ff6ab"
     },
     "x86_64_macos": {
+      "etag": "0x8D9F4A5976254BD",
       "checksum": "714d8406f729b776a6dd50f3e48e1ca7d45481a7ed172bcbfe6feacd08074d8b"
     },
     "x86_64_windows": {
+      "etag": "0x8D9F4A4F1614F7F",
       "checksum": "a4b56f8b88c9d4a2f0aeef5f07e80029eaec5df8a5f996f4bcad8cf258c25283"
     }
   },
   "0.9.4": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9F1C61801F84D",
       "checksum": "08b9c483c5a7a1fdc15375a1ea061f79e1a08670e77912f7943852215e3da4f6"
     },
     "x86_64_macos": {
+      "etag": "0x8D9F1C73E425C8F",
       "checksum": "58ec77643a8f395a989491763841434863fa1f9c5d622b6dcdf5278512217995"
     },
     "x86_64_windows": {
+      "etag": "0x8D9F1C687F3AEDE",
       "checksum": "1eb8ebd4d1790e18ace38436549ac14c9cbc7c42431fcd6de5a04c3db753155c"
     }
   }

--- a/manifests/cargo-no-dev-deps.json
+++ b/manifests/cargo-no-dev-deps.json
@@ -29,261 +29,339 @@
   },
   "0.2.12": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC40C8E02F39EE",
       "checksum": "dc8922c69564dae3b8fb61c92c9f54d0b54fe5280950e05c9e6fed0a82ee66fb"
     },
     "x86_64_macos": {
+      "etag": "0x8DC40C9CD764DF0",
       "checksum": "ecc61dc31eb42cf8b5bbb37ad0f52e269d881712fb8a54344eef64a91a2f0b56"
     },
     "x86_64_windows": {
+      "etag": "0x8DC40C8E0D23C7B",
       "checksum": "6f354aafb4d3140ca5e3cfadcdde83f4d5d380598bb1106506dbcbf3d096d089"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC40C8DFF2754F",
       "checksum": "8a0a2411f8d86dfbf3999d0f2533d1324ffc84a91feddcaac07154a600ee0e49"
     },
     "aarch64_macos": {
+      "etag": "0x8DC40C9B59D6060",
       "checksum": "7e73edade320c92c729eba3264f49679c3bf8267bf57aa5b7bcf7912f645bd18"
     },
     "aarch64_windows": {
+      "etag": "0x8DC40C8CB8CA98A",
       "checksum": "a0f77f2b48cef8c6370b380f5720eeefab53865ee4305a8c587d82ce6bfc8105"
     }
   },
   "0.2.11": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC2A451118C8AF",
       "checksum": "f5678f25fbc0cd4791edbb51e24e6b4dd4044c33813a3e97b851439216cb017e"
     },
     "x86_64_macos": {
+      "etag": "0x8DC2A45E234EE51",
       "checksum": "486f150583db8a596448995220b7d534329ca132d49a1d8ef28b07d51a014382"
     },
     "x86_64_windows": {
+      "etag": "0x8DC2A4529E95264",
       "checksum": "2519519c4ba0648130d28df0ef26f66c6616f9fac2ec05f36ae976da3acb7440"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC2A450396C70D",
       "checksum": "340ef16a56c0a000ffaa9dd09760232c618860e5bc71be914f08d84896cde2c6"
     },
     "aarch64_macos": {
+      "etag": "0x8DC2A45D29CEEF3",
       "checksum": "6d0a2d3578e43a817197da5179c6d4986caa6686877f20c8ac3468403b928a2a"
     },
     "aarch64_windows": {
+      "etag": "0x8DC2A451F0A4C6B",
       "checksum": "99c685250293fe01f08ef2c5869eb2d77dd0b36bb1196d038f5bf112c19bc4d8"
     }
   },
   "0.2.10": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC1CF06B189A71",
       "checksum": "886b8169ef9f30ae07b3a6d1f7944001e880af1a3bc3095d30f2ad0f6a70b4b6"
     },
     "x86_64_macos": {
+      "etag": "0x8DC1CF0DBB252C9",
       "checksum": "cf78bd12230ba164470a3367654363ede82bc7d5dc54c7e87ccb9471e40bf508"
     },
     "x86_64_windows": {
+      "etag": "0x8DC1CF09278FDD6",
       "checksum": "142260bf210a4c3cbb084b6d771538a994b5c29bf33111cae6790d62704ac6eb"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC1CF063800508",
       "checksum": "5a0ff3c710440c2c27cdf2bdf55beb1082ca767956da426879c9f06d48bc7ff6"
     },
     "aarch64_macos": {
+      "etag": "0x8DC1CF0CEF3FAE7",
       "checksum": "7df9b01f479e966c3d06a8578e9d84bd5a209b070e941550fe8c3d0422e0eb86"
     },
     "aarch64_windows": {
+      "etag": "0x8DC1CF0B8ED994D",
       "checksum": "0dc335c5d01432d2f7c0a96c3278cb9183b3a9e1ac49f2e15ed1ff6c1ec6d756"
     }
   },
   "0.2.9": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBFE361F749414",
       "checksum": "7d0ac6d8d850c5ea45f90d9c5d8b2c9c753928e3794661c27faff205fb8c2603"
     },
     "x86_64_macos": {
+      "etag": "0x8DBFE3661C48338",
       "checksum": "d4feacc15a40e99b71c0e9ca2f4611cf6f95ff78dd92f423c5d8c76640d03161"
     },
     "x86_64_windows": {
+      "etag": "0x8DBFE365BACBE9D",
       "checksum": "d78415bcf815513946b22cff10030a49e43626614edce80073188f83e5cac832"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBFE362179B7D5",
       "checksum": "6b8cc624be49466a12c917ecc2c1c1ad175b3910f3dfe04059c14636d4dcc441"
     },
     "aarch64_macos": {
+      "etag": "0x8DBFE365AA4B4EC",
       "checksum": "23328e114992d0ba1987692d27ac22df355bf3fd6a23ff27147f188d60abdd3a"
     },
     "aarch64_windows": {
+      "etag": "0x8DBFE36354F86A7",
       "checksum": "8159c0a99fc16307e53ff2b487858e4c0bcd0600286cff28e7c81fbef7684266"
     }
   },
   "0.2.8": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBF5983E4590E5",
       "checksum": "9758f7c3561dbb51397862f54d13cde4ed5dc1dbb5b18415316eeec51847ad1d"
     },
     "x86_64_macos": {
+      "etag": "0x8DBF598F4731D95",
       "checksum": "d7e7a8a3d8500ab64c4e19d8c3756d5d4bf7a50c92fa5b9e4bcce0bb47207645"
     },
     "x86_64_windows": {
+      "etag": "0x8DBF5987554D4CD",
       "checksum": "386c53aa959ee1b0a7fe78a1b4685b3dafbf5fecc1fb9e0896d84ca28701e3a7"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBF5983303247E",
       "checksum": "60b5752c8a0aeaa71117f293c2f49d8356123eb41e0306db51a6382d0d21a7c5"
     },
     "aarch64_macos": {
+      "etag": "0x8DBF598D8817035",
       "checksum": "c838c166e668ec0ce5bdc69de19954314749a98e590118c174e921549babc23f"
     },
     "aarch64_windows": {
+      "etag": "0x8DBF5984375ABAB",
       "checksum": "31bffb78b63dcc0bd5f1938f576c2c2cbc56a161168e7bf038eace8e19d008b2"
     }
   },
   "0.2.7": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBB2EE90C5B1F3",
       "checksum": "c513030b5c33de29c5d414801a61c64ceca9f58b3a021cd41339e13ef3335abc"
     },
     "x86_64_macos": {
+      "etag": "0x8DBB2EE96EEC86C",
       "checksum": "88ce1a4a6fafbce491cb9037af499ee7dc85a6d3ac7f3c0592114a87782ab90f"
     },
     "x86_64_windows": {
+      "etag": "0x8DBB2EEC5FEB176",
       "checksum": "ff6814dde2441a5c4ca60a5cf0571e907a5691fb4cbdc3dd0b32bb33966bafdb"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBB2EE90C62691",
       "checksum": "20b5a9e7936fe855877bb6d55090600f42bcf5ef2d86c720ef59e0a12864bd7b"
     },
     "aarch64_macos": {
+      "etag": "0x8DBB2EE8DA4297B",
       "checksum": "8d408a5c9d8276e4e168b92b4a41c9e80bb352eabd431f93e8c147377b637328"
     },
     "aarch64_windows": {
+      "etag": "0x8DBB2EEA320E733",
       "checksum": "2cbfa80772909a7195db75713c170f3b91afe8b37b7c7917ccb893b977545c24"
     }
   },
   "0.2.6": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBB1B148E5A300",
       "checksum": "95a00b9a7bac659c273422f68e6bb38e9e69fc0d1c163552ba7bebcf8c4915ee"
     },
     "x86_64_macos": {
+      "etag": "0x8DBB1B16D793F9B",
       "checksum": "412afe1fdc554ffdc155ba89e573b5c44cef8e5417440f29bf9ae4e9452bccb2"
     },
     "x86_64_windows": {
+      "etag": "0x8DBB1B163E53F1E",
       "checksum": "8d818e8d66bf5bfea09070377d7f7830d888cf45392734abecb18ab75c837060"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBB1B1444FBFD3",
       "checksum": "dcb7de74155818329078f4e0693e71c684e8088bd411bd9c310d40291540b60a"
     },
     "aarch64_macos": {
+      "etag": "0x8DBB1B16095881D",
       "checksum": "e45592ea2e8b9b1e8c00fea545543d5b62229e6159a32f1c11000c2cd680c693"
     },
     "aarch64_windows": {
+      "etag": "0x8DBB1B17AD52749",
       "checksum": "7d35cbcf17b3114313f4cc19dbce84fcc51cb3949c0bc1f48110915a8aaac919"
     }
   },
   "0.2.5": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBB12EB80A7E47",
       "checksum": "4c609f8d62669a8ecad8a83769e3a3adf5faab94820e69fd73473a37bfd39be4"
     },
     "x86_64_macos": {
+      "etag": "0x8DBB12F138764FC",
       "checksum": "82aea3272e74f49f10afd04f8e7451831408b006dc97a6d36b56bb81bfe862ec"
     },
     "x86_64_windows": {
+      "etag": "0x8DBB12EDE8B5EBA",
       "checksum": "a91f0c5f46b479c8e9ff84469a2e9dc5252301696db25900688b8180fb6436a5"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBB12EB79EEF12",
       "checksum": "049696e69c9a1ed571dc93377e944c37e0c886517bc517a84de03a9591b0e013"
     },
     "aarch64_macos": {
+      "etag": "0x8DBB12EE05A6C17",
       "checksum": "125813b967068757faf1f9733ef018de0850a5e642e86d436b47b317202244ea"
     },
     "aarch64_windows": {
+      "etag": "0x8DBB12EEC8B29C4",
       "checksum": "1cc8c6d9b2dc7619c45dd19fadc5f7465b8993d3242e402bdaac6eb5026bd500"
     }
   },
   "0.2.4": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBA8067FD29DD7",
       "checksum": "5dfabc9d10e6eefb6c4847307c7b757a0c5ff20bbc55ba4c156e8ca941130122"
     },
     "x86_64_macos": {
+      "etag": "0x8DBA807156BE8FA",
       "checksum": "1e3f1feed216477022ed2fcdff2019de896d6d179e432722009f507822028979"
     },
     "x86_64_windows": {
+      "etag": "0x8DBA80693EDF5EE",
       "checksum": "09ca80f82b52ed1cd312d5aa2901c4b12b25ad557c5e39e40566de62914cfc7c"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBA80651721715",
       "checksum": "f358eb55bff29666df98b8b850f44c1dc47fd4f1c35c3f91bfe7173090afeaaf"
     },
     "aarch64_macos": {
+      "etag": "0x8DBA806A83A86FD",
       "checksum": "b181d0ec01a93ba4909a8fefd9d4d533647448046fbae28fc81edd902d0658f1"
     },
     "aarch64_windows": {
+      "etag": "0x8DBA806763FD901",
       "checksum": "a19cddb696f1bb0890c3d26cbe5cbdc12d3a489126941bb10b7fe4f48f6a4b64"
     }
   },
   "0.2.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB8FA0A693DEFE",
       "checksum": "ccd4ee0b1cbe122657d5968ad27712b9ecb291aa58e5ec6e1b2964e78f9f00ee"
     },
     "x86_64_macos": {
+      "etag": "0x8DB8FA1595E47AC",
       "checksum": "2b7670703e8daaf854f373da5eacd3c9ea26ab28f9ceac6b24351fdf8e2e98df"
     },
     "x86_64_windows": {
+      "etag": "0x8DB8FA0AA51E0A2",
       "checksum": "f745b034340885a721fcf7c2eb23e4ef57809cf7304d411b434173c0e7085457"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB8FA091B8582A",
       "checksum": "2b012dabefa62da7e97e426f0dbf45bb38218b5570e32057aa732551fccad8d4"
     },
     "aarch64_macos": {
+      "etag": "0x8DB8FA0EEB3C0A0",
       "checksum": "5af57c8f508d1fe04ec7ef74af6e6689c644ff2a0fa0ce36befe68920f819c52"
     },
     "aarch64_windows": {
+      "etag": "0x8DB8FA0CBA7F975",
       "checksum": "a63f26daee3de974ecdb1cea8c3e0918000acd1098c0a63b34c73ae4362b043b"
     }
   },
   "0.2.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB1996111FBC4A",
       "checksum": "06871d1243c12568ec1df16d1fe663413b86ac4b9993f208e8b683a9d6fb2c95"
     },
     "x86_64_macos": {
+      "etag": "0x8DB19960F927940",
       "checksum": "cd0570a4f415b30d31f48b12c8ccc1f3d197c9b552177a6402519cbcadde178b"
     },
     "x86_64_windows": {
+      "etag": "0x8DB19963D55807B",
       "checksum": "88cd59cb5d1983778ade830346ab9901d1843ec9a3b098191f465cf31a9e6c47"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB19960BA050CC",
       "checksum": "c9abe175390970139bf2afbc0fabab414c6b9549dee4216514513ce03643a8b7"
     },
     "aarch64_macos": {
+      "etag": "0x8DB19960491CDD1",
       "checksum": "10514a7ef5bfc29e6bfe2ffbb7130f80f30b7a2d63faadd2f5bddb36ec66d922"
     },
     "aarch64_windows": {
+      "etag": "0x8DB19963D5D9597",
       "checksum": "daa55434f81cc7711bef1f0f938540647bcde18458f429a0d03ccde617ff7144"
     }
   },
   "0.2.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAFE20F6492B26",
       "checksum": "decd3116739cb5bc956ea467864e18742b012e1b5368ef30e748bb23fba11d53"
     },
     "x86_64_macos": {
+      "etag": "0x8DAFE20E53FA5E0",
       "checksum": "51972e477141bb41c88d1764ab8508611dec48cf8696377fcf934f65f10974bc"
     },
     "x86_64_windows": {
+      "etag": "0x8DAFE2102D12C78",
       "checksum": "ab0292fd031d9b5c56c9a286164a142c3102c91c6ed60ad384d47179c79dc671"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DAFE20DE525E98",
       "checksum": "3f79f885377e24d1adcb809fa1b134d9061ae84c6e8dd6541687fe24d508244b"
     },
     "aarch64_macos": {
+      "etag": "0x8DAFE20C0533232",
       "checksum": "8c1c7791a8aebe5250dc47a6a893ffcfef3e1f0248f78e82a5f072d49b6682c9"
     },
     "aarch64_windows": {
+      "etag": "0x8DAFE20DDE38065",
       "checksum": "9325a564ff1db835449081feec4160d35e1c9793bebdb74b5175de6542988db8"
     }
   },
   "0.2.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAFA826DCC151C",
       "checksum": "446d7879e260d1a6170ee105c211255e0729d2db50d4d6378c60ebc19b26b056"
     },
     "x86_64_macos": {
+      "etag": "0x8DAFA828213D460",
       "checksum": "7eb91033a29c16c02a67162858adcd592804b3f393b981a3f0e00c1c3ce7a29c"
     },
     "x86_64_windows": {
+      "etag": "0x8DAFA82C2A5BA28",
       "checksum": "aa49deac93a3bf7d29809f5b687e1e39ad5dcb21d7f227c9690a400846dda144"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DAFA8287EB8F71",
       "checksum": "085738eb7b1377034c2f569bd6a6402499a1f2e71d5e89bccaa5d85303c32627"
     },
     "aarch64_macos": {
+      "etag": "0x8DAFA826AE936EA",
       "checksum": "9854154d4f044807dd1ad06c9b2a94f93e0f8551f44c90cab1a955eb909457a2"
     },
     "aarch64_windows": {
+      "etag": "0x8DAFA82B6FF4378",
       "checksum": "8fafabd875be78457349ad2c860793d28a92efaf881de16fcda3e68bf9286baf"
     }
   },
@@ -292,21 +370,27 @@
   },
   "0.1.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAF3D1FF333E6B",
       "checksum": "eef6cd49bd2a70cf27dc5573fb5881c0908f0848777f717d17a6512bb589dc53"
     },
     "x86_64_macos": {
+      "etag": "0x8DAF3D28AC3C38B",
       "checksum": "1e4399f81a9018b45a087b4fd60c801503d2931c6e3bc9a8f60896e2999bb1d3"
     },
     "x86_64_windows": {
+      "etag": "0x8DAF3D2138F7483",
       "checksum": "7b3aa24b2cc01fa92fd9160b564ace599367b0c83362bc667a4fb3044a253a35"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DAF3D1FEC460D7",
       "checksum": "1e5ca7c2c0659bb4ca036cf6ac4f779f88806a73bf0bda64aa6acb3c7438429f"
     },
     "aarch64_macos": {
+      "etag": "0x8DAF3D1FAF290DF",
       "checksum": "8bbd83c11331d39dd811d817074a8a237bc7176616a2d7ae32ecd2e7049743d8"
     },
     "aarch64_windows": {
+      "etag": "0x8DAF3D23547727E",
       "checksum": "3c3166694500e84e2f67029407236a49b6f8877c4a09429062a552f259bf651b"
     }
   }

--- a/manifests/cargo-rdme.json
+++ b/manifests/cargo-rdme.json
@@ -23,44 +23,55 @@
   },
   "1.4.4": {
     "x86_64_windows": {
+      "etag": "0x8DC897D83E337FF",
       "checksum": "ff9b7a4d56a89451e8e0ae40716d47534fb08c5723a08fd560a66227b49e2694"
     }
   },
   "1.4.3": {
     "x86_64_windows": {
+      "etag": "0x8DC2BFA5B345CC9",
       "checksum": "408ffb657c99bf4142521632306edc4ed130dd991a0cd4b62cf370c28b307daf"
     }
   },
   "1.4.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB92D680D05305",
       "checksum": "8555ae93237e1702e79542c810657afc1ff76282c9ecd7b21aa22f5f3b3c21d2"
     },
     "x86_64_macos": {
+      "etag": "0x8DB92D668BB8C91",
       "checksum": "2c6996d2b6ec150275436bc8d0969d75247b4ac7400c43c63d24cfc843266f47"
     },
     "x86_64_windows": {
+      "etag": "0x8DB92D6AF4F93C7",
       "checksum": "a6333997cb418b369a3ed005eebf30313942bd824456f26d2834af87c8449475"
     }
   },
   "1.4.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB922121D34267",
       "checksum": "cbcb893f585def07cb64486063cc9d490fb2eb2b06eaec7e2beb70a47bfd004c"
     },
     "x86_64_macos": {
+      "etag": "0x8DB9221272EF35C",
       "checksum": "053236ff190a3601230886679c8fb3405fcbc7f49188eef0bda75a72bd78b9a7"
     },
     "x86_64_windows": {
+      "etag": "0x8DB922180C93706",
       "checksum": "83f38b7299c785e9712e7aab3461eea131e79f13bbd45953514019cd75412b1d"
     }
   },
   "1.4.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB1D2360EC8AFB",
       "checksum": "2aacb472abeb943a8c4676aa4e4603ab4b037ee9d43eda611b4e8d65c8162100"
     },
     "x86_64_macos": {
+      "etag": "0x8DB1D234DD1FE4B",
       "checksum": "0664ef1e0d70b5dbe68c8ad896e5d59972440b4dd46d970d0adf94e5bc5a1768"
     },
     "x86_64_windows": {
+      "etag": "0x8DB1D233CE1EFF9",
       "checksum": "8df835d817813252502a28d01e6352b5141660e914b89baf72956a2274d4d1a7"
     }
   },
@@ -69,12 +80,15 @@
   },
   "1.3.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB17A01D58FDE6",
       "checksum": "811341ec9724388660bcd4d1a8c6d04947252ff44adaef7d75ba19a58dc25bfc"
     },
     "x86_64_macos": {
+      "etag": "0x8DB17A050AA3218",
       "checksum": "a8d4dbe536b9b3389e9db9ff226384705defaed3c2d09f2cf2ead21b5bcd2e4e"
     },
     "x86_64_windows": {
+      "etag": "0x8DB17A059C2FCC4",
       "checksum": "6b2988694fc870e6071ada84c94d03736daaf0706daed21765e898235d927296"
     }
   },
@@ -83,12 +97,15 @@
   },
   "1.2.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB15347F4132A5",
       "checksum": "e2cea84cd1c7f7c2c03662396a6ef268474c66faa471a6e755c4bda8d35ef0e2"
     },
     "x86_64_macos": {
+      "etag": "0x8DB15344FACF90C",
       "checksum": "4226504f45e96dfca35a72b4631dde717cf2f5fed0f87a3cb71d58d6055a1b60"
     },
     "x86_64_windows": {
+      "etag": "0x8DB1534AFD1F51B",
       "checksum": "0119712829cd6aaef12094441b574d759c45d62bab069224d21dc1af52df9390"
     }
   },
@@ -97,12 +114,15 @@
   },
   "1.1.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB0315902DB0D5",
       "checksum": "1e645bca96bb5c497e6af8a6d7249572709a6fb45b7b7afa789440d7400a61a4"
     },
     "x86_64_macos": {
+      "etag": "0x8DB03156F780628",
       "checksum": "1487f7cf5e795b08f56e29dfdb542343ae5b4d74805b6bfb7726da5f6c0dc99f"
     },
     "x86_64_windows": {
+      "etag": "0x8DB0315B19C2EFA",
       "checksum": "82f224eef98778d36088eac8a7bdd4b4640b4d10429150718bc3975e4f16daa8"
     }
   },
@@ -111,31 +131,39 @@
   },
   "1.0.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAFD789C824BDB",
       "checksum": "85d3b8c5fd247557b90357718f156a9d2cb637f82a77a7bea800d1fad4b870b7"
     },
     "x86_64_macos": {
+      "etag": "0x8DAFD789F9272FA",
       "checksum": "0f4d749a397b33d41295f74f005534a4c1a785dfcfa6dc4b5df1016d289cbec6"
     },
     "x86_64_windows": {
+      "etag": "0x8DAFD7903B01D84",
       "checksum": "2416fe0cebcde091138882f45044d2e057940653194d2474139967b6e7e09cb5"
     }
   },
   "1.0.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAEF4F7F7C70AE",
       "checksum": "ef601c5773119972e67cfe61518b46faaf993037ae7caaf455178e8a6466be67"
     },
     "x86_64_macos": {
+      "etag": "0x8DAEF4F6A5C49C7",
       "checksum": "ea1bccf8a3290c7a1fd2f30e27bf2005f264f7219555b2131a23fb5ca91d0105"
     },
     "x86_64_windows": {
+      "etag": "0x8DAEF4FB886BD2D",
       "checksum": "3abe728bb5bb983683698189110ddbc8b72b0ca965d5a75b802ef981e10ef437"
     }
   },
   "1.0.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAEEAB93981AE2",
       "checksum": "ff0c7e7adcaf5dc0943d5ca075a49f77e5a9a531e6e3fbb8e04aa8708d93199f"
     },
     "x86_64_windows": {
+      "etag": "0x8DAEEABDC175C8E",
       "checksum": "51e755b5a0613408e1d42de561ad88f80e44c9494bc02f18d92a6d9cd0c4cff8"
     }
   },
@@ -144,19 +172,23 @@
   },
   "0.7.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAB50795D95CEC",
       "checksum": "11b1eb91e95f5fe014b6c0ba7850fb677015a1f4c76aa94beca16f6278cbb690"
     },
     "x86_64_windows": {
+      "etag": "0x8DAB5082F15E565",
       "checksum": "ee60b8fe9a0f00fe7e6d75ed31ed6cc566d666a9ca27765654250715016aeb7c"
     }
   },
   "0.7.2": {
     "x86_64_windows": {
+      "etag": "0x8DA91FD3176BB59",
       "checksum": "fe6ca1d38381ed9f8f87359fe8fb50bb87787cb058ed8efe2ebbc72ed03cff80"
     }
   },
   "0.7.1": {
     "x86_64_windows": {
+      "etag": "0x8DA88E943BA0032",
       "checksum": "a19a756f13d46bb5ee96f8d24696541a494cb38bb726397f06df848b183c49ab"
     }
   }

--- a/manifests/cargo-semver-checks.json
+++ b/manifests/cargo-semver-checks.json
@@ -23,15 +23,19 @@
   },
   "0.32.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC8EE9D6CAE46C",
       "checksum": "c8202b26e84b06e9d6a40e8b28d04d72fed10a178403f323644c0af6b5c37c24"
     },
     "x86_64_macos": {
+      "etag": "0x8DC8EE9AE2108F2",
       "checksum": "0540e6ef4f3f8f42e2e4db0e9efb49d4e4c32bc7becb16379e85c38aac500105"
     },
     "x86_64_windows": {
+      "etag": "0x8DC8EEA5793DCDE",
       "checksum": "cecbbab97c8c0b47070038ba4f585fce79dd397b47e0bca0247bfa2967cc8017"
     },
     "aarch64_macos": {
+      "etag": "0x8DC8EE9B25D49CD",
       "checksum": "59a9bbf1ae898725085854d4f618a3c958f6fa67a0573f393a42c2ee3990497e"
     }
   },
@@ -40,15 +44,19 @@
   },
   "0.31.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC62EEAA3DCC22",
       "checksum": "4b40df7c8877451b3c31d33399f54bc1d988cad3a2712764ce632a7425cc57df"
     },
     "x86_64_macos": {
+      "etag": "0x8DC62F056AEAA72",
       "checksum": "58809b0e431d19d6216552b222eb746b510b11dddb59dec93ae3efe302091748"
     },
     "x86_64_windows": {
+      "etag": "0x8DC62EF476E0C5B",
       "checksum": "6a819e7ef26590d78ce6c127b6c0d966bd2c5012ae823455e4370f01e5e22167"
     },
     "aarch64_macos": {
+      "etag": "0x8DC62EF06876D49",
       "checksum": "9e272af3f52835470d4f31e3791c83ee9dbf05a812af5d2f2077ec1e3c67aa67"
     }
   }

--- a/manifests/cargo-sort.json
+++ b/manifests/cargo-sort.json
@@ -23,56 +23,71 @@
   },
   "1.0.9": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DAAF84DD4D12B1",
       "checksum": "e7ad1db1b20e0a382f6a77ba3725fdfdf939e6f14d7de6a021b5c38113723186"
     },
     "x86_64_macos": {
+      "etag": "0x8DAAF8542C43C73",
       "checksum": "fa6d5fa6281e0a2f930ef8dbadc88408bd209379b21b96c9525e25adc2f720b1"
     },
     "x86_64_windows": {
+      "etag": "0x8DAAF8515F51ABE",
       "checksum": "163494e1df9ebedb92d9600986d77497b32809df752ef2667859bd029032c1aa"
     }
   },
   "1.0.8": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DAAF84BA407CDE",
       "checksum": "c6f1c50292835a00b51c5576a9289dae8a3ef319d6f16df9af97536251227c88"
     },
     "x86_64_macos": {
+      "etag": "0x8DAAF8514793AB3",
       "checksum": "746d914cc4ce825b9ab0dd96b5121298883000580350cd681798ff3f1d966541"
     },
     "x86_64_windows": {
+      "etag": "0x8DAAF84F0FC194A",
       "checksum": "a6bea6439e933c2b012b015ccf052519879f5c5837274ddcd6d21dda8ca48a78"
     }
   },
   "1.0.7": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9C4D4FBCF076D",
       "checksum": "b9ac1726277f3375344354f7b6af35fd068189af3ebf233b0f1a953100e6b934"
     },
     "x86_64_macos": {
+      "etag": "0x8D9C4D52FAAE99C",
       "checksum": "02b4111c44e2d0d898b77cdb265b98bb4c78da93ec6f73ce896a458786df6470"
     },
     "x86_64_windows": {
+      "etag": "0x8D9C4D521E42885",
       "checksum": "e624d3e04b79a4f88774101358a9ba6cf0c50e852785f4b5925cd3c9ca7fd41e"
     }
   },
   "1.0.6": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B94241714F1F",
       "checksum": "21e7d09f6ac6481a7b2643dc654fc07a496a12720d58619b7ba071055e0c5a2e"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9425B0AD963",
       "checksum": "fa235d7a566b454c696922f972853cb3a8b37f5c2d08106a5431751f44e194b0"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B942579FA6A6",
       "checksum": "85cba2de979f7c7b26a710f9fdbedab782966781ebd35e4f1b5e493bc60e40a8"
     }
   },
   "1.0.5": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B942523963CD",
       "checksum": "a1470cd446b602ea6aa5b3d4782f3cb49aac15d5ae68e797ed80da947c608fbc"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B94256633697",
       "checksum": "df32404cd5da6a15675ce3980a1633d27b83e08362d7250d76807f344cfb37f1"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9425033CDF1",
       "checksum": "d56044541234fb8709ef9be6ed1e767c7b242a022f9891a40d0fc73ffdc80626"
     }
   }

--- a/manifests/cargo-spellcheck.json
+++ b/manifests/cargo-spellcheck.json
@@ -17,9 +17,11 @@
   },
   "0.14.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DC6466EF3038F3",
       "checksum": "6f35073843f2eb87990ef19c841c61ded5263e3a7ff38f885cfab22193b84f13"
     },
     "x86_64_windows": {
+      "etag": "0x8DC646705A424A4",
       "checksum": "ad97a1471b7e718902ec385c3ad045a6afbc986f736d0c4986855ec99a79c80c"
     }
   },
@@ -28,25 +30,31 @@
   },
   "0.13.2": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DC0E0760B5DD94",
       "checksum": "f547b8f992dcc43f8a4106bae8b090ecb3fcb7ef6ce336081c22636f70e876d9"
     },
     "x86_64_windows": {
+      "etag": "0x8DC0E07751C8D13",
       "checksum": "f54fb8243497258115d1eb55b99bfc94ab3e09636c78665d3b6410885ba9190a"
     }
   },
   "0.13.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DBC987279A3734",
       "checksum": "17af34dbefad5c45d23df3e4e81b0addc78782db0ed2e8e491a1532761463e1e"
     },
     "x86_64_windows": {
+      "etag": "0x8DBC9875250341E",
       "checksum": "d18c19a3c5e7eb9ea516e691b54a4517a60517b6b1fb75b7f56a0c1dcc9b177e"
     }
   },
   "0.13.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DB98F2A6C10BCB",
       "checksum": "41e99240e55f38cc6d43d7ea9f2ccd448f584eefdc262129e4238f057d995923"
     },
     "x86_64_windows": {
+      "etag": "0x8DB98F240CB78CC",
       "checksum": "57d45d5942d7ccd49599aae549c0bd5d906868eaeb39481088e55001d65f4784"
     }
   }

--- a/manifests/cargo-tarpaulin.json
+++ b/manifests/cargo-tarpaulin.json
@@ -26,18 +26,23 @@
   },
   "0.30.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC714120675B42",
       "checksum": "7adaec5afad826e8b758fffe3b9804d3a371553fa4cdb56ddd9a3592c08a03ac"
     },
     "x86_64_macos": {
+      "etag": "0x8DC7140EF80C035",
       "checksum": "cc2b8b84c0f19db57f00b5e2e322c3115a744d2fccc823700f3b7f60dd13a289"
     },
     "x86_64_windows": {
+      "etag": "0x8DC71411EB1105E",
       "checksum": "fa1dee30c073f72b03303c3d6479d0198eb0f8079e1b65582a502f411247754d"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC7140F5C13D78",
       "checksum": "e06ef0e98fc78da0a447f8560fbfe797a57cebe1b71a7161e0810f6d65151758"
     },
     "aarch64_macos": {
+      "etag": "0x8DC7140BAAA4BE9",
       "checksum": "a7f582a21083f2be93aeb3f7d13d534ee5d63c1aec9e1f8c570253a970f4d18e"
     }
   },
@@ -46,52 +51,67 @@
   },
   "0.29.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC6F3D58A8CCD4",
       "checksum": "d6ba7a39fa27c1792741860dc28225daaab9ba74f7ebdd5cf4f175009f079167"
     },
     "x86_64_macos": {
+      "etag": "0x8DC6F3D190A953D",
       "checksum": "e489e193d0d520002ad10673f6027ff80cd516a5ffbc8f8e4269f2181428ae0d"
     },
     "x86_64_windows": {
+      "etag": "0x8DC6F3D76653F30",
       "checksum": "f3e7bf5ea970d543b9b47cd4ad62fa9f6316fed61e57132abf085ddde6e60692"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC6F3D1E2BF05F",
       "checksum": "3c8b9db1d5f38e741ee84e15e038216c7a74a5b550770f8a273296aea65e7292"
     },
     "aarch64_macos": {
+      "etag": "0x8DC6F3CE9D59432",
       "checksum": "15bc3f52422c8e72f1385a113d35a9e7b4ab6a15503fceef2155fe0fe5bbcb4f"
     }
   },
   "0.29.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC6B50A49338B0",
       "checksum": "be2be986abde1f7b9544f217acce4d1699a04bc3b09e17c05b3fbd239d52456a"
     },
     "x86_64_macos": {
+      "etag": "0x8DC6B505DC3211B",
       "checksum": "6809df4fb7f559e30ed4134abca203fcd92cbe1db5117fa17a7e9c64933ee80b"
     },
     "x86_64_windows": {
+      "etag": "0x8DC6B50B99AD5BE",
       "checksum": "a8827dfd6cbe3280bd474d7f49ee58544016ad8eaa11769edaa05936c91ae882"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC6B503999D647",
       "checksum": "9e3791c191fa8224d038e54d988c3937e446c9e8673f5db5c0e43cc76af1ab16"
     },
     "aarch64_macos": {
+      "etag": "0x8DC6B4FFBA9B4F4",
       "checksum": "2e4eac469f93ac46721d527958a6ec690d4084ed6893900214c504cce6a3303d"
     }
   },
   "0.29.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC6A111981248E",
       "checksum": "7f5fda7ace039963e0413b5949c40292e0cb1c0ffc4e1b6cb60aadab167b1725"
     },
     "x86_64_macos": {
+      "etag": "0x8DC6A10BFC863C9",
       "checksum": "df21c946c69b6d653bb59e6ddb0e99c1f184e74f1b2a077a3654427171a37497"
     },
     "x86_64_windows": {
+      "etag": "0x8DC6A1148544A3D",
       "checksum": "1d7f4b814d1757438ddce75ddbd12b02c54d681803f9aa7703a8087e3a391d34"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC6A10CD9FF1D3",
       "checksum": "4d33d6072976c0b9c717b18ff12ee283ae4b38a0b4ec50f1ef208bf47689f2a4"
     },
     "aarch64_macos": {
+      "etag": "0x8DC6A10CE7D4B1E",
       "checksum": "36dbfbd7ebaad25372fb7faa9263bd3e5b07316be95fc0bb450deb2f4791b255"
     }
   },
@@ -100,18 +120,23 @@
   },
   "0.28.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC5BA027E2CB36",
       "checksum": "c86810ef9638219f70db16e9e272584b1365c2edfb63fe0e03f7254954c0a717"
     },
     "x86_64_macos": {
+      "etag": "0x8DC5BA022CD4B73",
       "checksum": "6bc2f349c837042fc90b3841d9ff5e657c7f5d9ebb2a15a4ba70ab5040587bf7"
     },
     "x86_64_windows": {
+      "etag": "0x8DC5BA04FD4894B",
       "checksum": "6ae64d9ebb91fe26bd8e2cb61c0a3604c0aa53c080d99921cc95d05d31e866f9"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC5BA01876B20A",
       "checksum": "6c023e176798e78c81cc4ba15d66c5f4f4f21c8000e69d469075b5927a1a8644"
     },
     "aarch64_macos": {
+      "etag": "0x8DC5BA0E5D731E1",
       "checksum": "b2fee8ce9cb93cab5b467459cf4b63dd80ea372dac36c98fccc35660dd454fd5"
     }
   },
@@ -120,69 +145,89 @@
   },
   "0.27.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC143FEF0A4268",
       "checksum": "87ff6d7b2a6a009a7176d772afaf37feb95dc1c104a78df57f753129ba057b09"
     },
     "x86_64_macos": {
+      "etag": "0x8DC143FEADA4E92",
       "checksum": "ed139aecf50388999d4f724d836c25168cc534939618c4ca085532d5b8f220cd"
     },
     "x86_64_windows": {
+      "etag": "0x8DC14403CC19A9D",
       "checksum": "831d42984024be94babfab09867a9c1de12eedfb9a8f31aa0b3b817165d81dfd"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC143FF52F65DD",
       "checksum": "5fc234b9fb868150a14664ff138064228d1a15ca7715e22b0454750769cad17e"
     },
     "aarch64_macos": {
+      "etag": "0x8DC14408E746E36",
       "checksum": "db8a40886f1edcde126d901e4a5f3c1afaf581ce95c4444d0ab57fef6bd281ff"
     }
   },
   "0.27.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBF027A45646AC",
       "checksum": "ebe7d38c7045cf396cb67b45d9b0e4bffc74f2dfa2df428a3190cc9d38c47fe9"
     },
     "x86_64_macos": {
+      "etag": "0x8DBF0280981BE53",
       "checksum": "6d577a7a21881fd5a57e0e4aedd61c4235f5bacc1e645f3acdd7c8ceceee5115"
     },
     "x86_64_windows": {
+      "etag": "0x8DBF027D8A69015",
       "checksum": "ff90bcc5d757b7cb765d5e3e5f5a2010a0b7e97a348f0470a9c93a4fcd9ca941"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBF027703FB26B",
       "checksum": "aa82c2010a53cbc1ede58123db3ccfe2fddd2441d4b0454ad5ff4103603a84c1"
     },
     "aarch64_macos": {
+      "etag": "0x8DBF027FC11CD80",
       "checksum": "3c0b0cd6b6f676fe4b7ab07077f9d186cbcdb57ec4d11211a1a12ac91ae479e1"
     }
   },
   "0.27.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBC3738DC24F79",
       "checksum": "a32bbf4da747a61348aebfd3dde141506e372618f85149536972c7e6f713e1c5"
     },
     "x86_64_macos": {
+      "etag": "0x8DBC373A0927C7D",
       "checksum": "9c833aa8ec463d3825009ebd509e015a479de716aae89bd78ca76bc45607304c"
     },
     "x86_64_windows": {
+      "etag": "0x8DBC374853EF607",
       "checksum": "f885b42a00f2af183d2a62a2746133c155f6aab6fd4be99d7a6ae062da7b227d"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBC3738DF22A51",
       "checksum": "5a48b3e552172dc868ea88453d92bad94f716815c9b225af03029d0209c26499"
     },
     "aarch64_macos": {
+      "etag": "0x8DBC3737F2C1C42",
       "checksum": "60b79c029d99a57dc1b7ffa6823436796f176a515cca088a6869a8fe50af9ee6"
     }
   },
   "0.27.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBB76C2387FD5F",
       "checksum": "b0cfcb086131773fb8a6a2cf8090c9416a8f233c2ae4bb887500f4e17d39fe7b"
     },
     "x86_64_macos": {
+      "etag": "0x8DBB76BE0B272DC",
       "checksum": "84c77137ca762c0cda3d4e8330ef3312efe72220da6470e8d657e5e545a11d2b"
     },
     "x86_64_windows": {
+      "etag": "0x8DBB76C5AD7B2FD",
       "checksum": "0114eef8cdb3c8466861dd64d7e16fd430cc0380406f230e16aa9e9c32af45e4"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBB76C073573F3",
       "checksum": "6e4f5bc5adafd1730c82ec816b89279d5cdb8255180488fc560e646bef624687"
     },
     "aarch64_macos": {
+      "etag": "0x8DBB76BD55C78BB",
       "checksum": "375e7969d10faf76ec2ec29d11cbfa266e268357514cd05ed2a24554df7a8183"
     }
   },
@@ -191,35 +236,45 @@
   },
   "0.26.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB8E7BF4058FFC",
       "checksum": "d8f07d68b2739a545ffa6f45b093922cb23d0726d086b3d4c405aa374b154186"
     },
     "x86_64_macos": {
+      "etag": "0x8DB8E7C222138DA",
       "checksum": "6000aa742b2ec44d4c9a2ab5873847703b53597f0ff296c4ae1096c572ce5565"
     },
     "x86_64_windows": {
+      "etag": "0x8DB8E7CB0005FAE",
       "checksum": "c464ab2e356dfbed8d530925de3cbe7fff2313ecf269d6674ab726d2a49b96ed"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB8E7BEF331150",
       "checksum": "51c2984b15a60e1d9bbf537d56354379abc428240855137b8ab8cd0614211c58"
     },
     "aarch64_macos": {
+      "etag": "0x8DB8E7C1A1BBB44",
       "checksum": "aac56df882fdf69030c7e4317eefa8ba8f9c2a184c8e66ff88dc6cae2093243a"
     }
   },
   "0.26.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB8E7BF8217349",
       "checksum": "c0c89310eecf34ede08e4c82a3be34ae5982e7a751b48290b05c5e829ae9c948"
     },
     "x86_64_macos": {
+      "etag": "0x8DB8E7D444CD10A",
       "checksum": "34560cde275396114a850141356f2fbb712fff74182d5e020dd8f133ed1eecec"
     },
     "x86_64_windows": {
+      "etag": "0x8DB8E7C50B0303F",
       "checksum": "296bb32608c6f1a983927e2d8284f3cc2ceb6129fd218dd5f0512ccc0e18a835"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB8E7C099CD5ED",
       "checksum": "63203c4c4cb135bdb82cf33429adac8d277963dde42439481ceb7b5849422d85"
     },
     "aarch64_macos": {
+      "etag": "0x8DB8E7BF66CFC99",
       "checksum": "f58ea996d2216fe0c218e7f8fd7ce050149f1b766243d1661c4431087c7901a2"
     }
   },
@@ -228,52 +283,67 @@
   },
   "0.25.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB3559808A534B",
       "checksum": "89f0f28baa818f445336da35c204206544b5e1160892ca0d5f50fe034abff771"
     },
     "x86_64_macos": {
+      "etag": "0x8DB3557BD3259AF",
       "checksum": "fac48ad01a87435b35a0d04dbb5452929c72e3e28633ab0fb5740a50d113bf64"
     },
     "x86_64_windows": {
+      "etag": "0x8DB3557A55A167F",
       "checksum": "36cf0c7fcf1c1d589720e7409673535e46d734f9abf89ff179c964dbf24f56cc"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB355770A83772",
       "checksum": "2600c6a6e8f6cdaf374fa492284ade31c4582f40f9c5ede1f726b743e144f9b6"
     },
     "aarch64_macos": {
+      "etag": "0x8DB3557A5E43FB0",
       "checksum": "3f615f38c18c32d10fdf85b73e5c5ee05c0308566d00d0b117c10175f659c504"
     }
   },
   "0.25.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB1838B10A26B7",
       "checksum": "3af89e49bb98caf0ce01f87bbe4493dd4219e0e47aa577149fb3d9046b39965a"
     },
     "x86_64_macos": {
+      "etag": "0x8DB18389E9F93D9",
       "checksum": "8db642f0bcc15e1ad76794addd4e82911b79c7721dbd01f6113aab6636a36d41"
     },
     "x86_64_windows": {
+      "etag": "0x8DB1838F7F2ABB7",
       "checksum": "a82851fd9bb3520acfd33073b6a01363f80fb8fdcf5bb5334e288894d939d5b4"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB183884B0BE85",
       "checksum": "87cd75d72a83009cb042e5a844f265e455ff8525dc77c0806a52a824702ba259"
     },
     "aarch64_macos": {
+      "etag": "0x8DB1838FB87F711",
       "checksum": "cf45f5f58432aaf861a7ea051e01d9f9f08d1548bcab331f3eeea29d0f82f060"
     }
   },
   "0.25.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB0317369404C0",
       "checksum": "e6ae2d11e684ee20f3860b1833de6fcb6ac44db5fc49a82a179bb969924870f3"
     },
     "x86_64_macos": {
+      "etag": "0x8DB0317A1F87818",
       "checksum": "94039bab671b054781df301191673c651bbe03cdf04d2f5cb4b7ff0055c0d08e"
     },
     "x86_64_windows": {
+      "etag": "0x8DB03173C6335AF",
       "checksum": "a3eb302b531a4b4efd3456e54b4a2f3c921aabcb9d54d81334fdef96f00170aa"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB03172ED3375F",
       "checksum": "59d55dc3070ac2b297ad3695f9a73398392c2446678c616688635e0c4bec6574"
     },
     "aarch64_macos": {
+      "etag": "0x8DB03173C69C46F",
       "checksum": "65d03b2414b12f4fbfb1e1014ac42fa1deb9d91e69b29cd68952ae97722a1165"
     }
   },
@@ -282,18 +352,23 @@
   },
   "0.24.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAFE4884377303",
       "checksum": "34969bccced3bdd7c34672011b7088beb3258bb27554294709171c394b04b40f"
     },
     "x86_64_macos": {
+      "etag": "0x8DAFE48E0CA6DF3",
       "checksum": "82f8dae075b18a2783616f35f03a999986ea6a7e0b581c7df97d74a68d172e76"
     },
     "x86_64_windows": {
+      "etag": "0x8DAFE48AFEF46E1",
       "checksum": "26f639abbacf829a1e1c1ee966828c97c92606a132cd32b4e7e2c4406f6a5a36"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DAFE4801F0BA72",
       "checksum": "c06411dd38a095e3ce8f085aeaa6adc802094ea0a2c88fcf89a59e17f2a21597"
     },
     "aarch64_macos": {
+      "etag": "0x8DAFE47F8228BD2",
       "checksum": "e7ea6ff1c427ab262df5490eb15b49dfecf11ec557d90609de0898f94baba3b2"
     }
   }

--- a/manifests/cargo-udeps.json
+++ b/manifests/cargo-udeps.json
@@ -39,471 +39,603 @@
   },
   "0.1.47": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC411F8985474D",
       "checksum": "906d6f7292231b79d2db04ab04d5e188b6ac789bce7fbb3013130edb82f683c9"
     },
     "x86_64_macos": {
+      "etag": "0x8DC411FAD5FD0DE",
       "checksum": "5395256cef3f879018851af1864218e28bbb3fad823fff6c02357a6ccac68ab9"
     },
     "x86_64_windows": {
+      "etag": "0x8DC41202EF231C9",
       "checksum": "cc621c60fb055d6849edbe2592be908c5ad0c04508392d7d28c487734a8e4791"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC411F8E621C2D",
       "checksum": "b242da4b7c24c647e210fbacabafe7dd86161d04e261bd81ed07a0a466a06fee"
     },
     "aarch64_macos": {
+      "etag": "0x8DC411FFC2F0650",
       "checksum": "f10a2a8197ecbae3e778d1a0b7ec10b080e389203f36a3d68366f57d80bdf3af"
     },
     "aarch64_windows": {
+      "etag": "0x8DC412017FC97EE",
       "checksum": "202a0f1b27cc67f17e001d8bf8af5a92dccaf1bb9852de0b89f3b9ad4827a5fd"
     }
   },
   "0.1.45": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC0806F586698A",
       "checksum": "0cd882efe77d32cf41c688231ce5be875f213aa8fd5bcdb663edbe64055b6913"
     },
     "x86_64_macos": {
+      "etag": "0x8DC0807AF895CB5",
       "checksum": "fe09b1baf8323c575e82aa7a9c2b87ea0bebaee985bdf9672a56443d09364607"
     },
     "x86_64_windows": {
+      "etag": "0x8DC08078A09E063",
       "checksum": "99f80ba7a33f105c759c896ea8388efe4f3c224922db7e417352b29a7ef7541f"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC0806BABA0EF0",
       "checksum": "0472186612177ea8b1045689299bbaa363eee4a8af23f4354bb0a30f2f82098f"
     },
     "aarch64_macos": {
+      "etag": "0x8DC0808901F357E",
       "checksum": "a1f9c85c783f664a613cb5d256330f026febbaadd4239419594152157b6f9d53"
     },
     "aarch64_windows": {
+      "etag": "0x8DC0807DA25EE13",
       "checksum": "736de3b69340c4cf1e3d350047500dfeb39843cd664fb82065d7a2dcea8401e7"
     }
   },
   "0.1.43": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBCEFF3D163C01",
       "checksum": "325d25f63df833d2fbacaee71997a628088ddc2c5f73c0c0a93ebacb3b773d16"
     },
     "x86_64_macos": {
+      "etag": "0x8DBCEFF7F61489E",
       "checksum": "f569ddb4c5a3ca5b881219df860bdb589fb9fcdf091a7eac69dc69ef2b69f39b"
     },
     "x86_64_windows": {
+      "etag": "0x8DBCEFFD500809D",
       "checksum": "d25982e539042e919a4a8da82028f5922ce8d891c89ea7e3754545beb383b94e"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBCEFF7EE026FF",
       "checksum": "456b5a24f702bf33ddb96d96e79fe22b60d295fd4777de4b46b91807bfb3c50e"
     },
     "aarch64_macos": {
+      "etag": "0x8DBCEFFBC9B678F",
       "checksum": "29896a416e4d57426ab67df05d50a909ce749c727b7d6c041116e5254e97e882"
     },
     "aarch64_windows": {
+      "etag": "0x8DBCEFFF7AED113",
       "checksum": "75782b445a16311643a31d68e252a526a21c9d525923fdd8b09f5e0bd6f7107c"
     }
   },
   "0.1.42": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBA69E6FF93B9C",
       "checksum": "87566d3ef73ab818f64b078de211772b488a536e502b0cadf52d0aa72c98df4e"
     },
     "x86_64_macos": {
+      "etag": "0x8DBA69F3E99BBA8",
       "checksum": "2bb16d6f823e76bae2c80f19327d80defdbad94da56af215a113fdb1ca2a723b"
     },
     "x86_64_windows": {
+      "etag": "0x8DBA69FE16962F9",
       "checksum": "2042993093509a11f4f630f4d3dc0a1d48694f15890d6d2fbe1a8c3b1e1662c7"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBA69E9E0A01F6",
       "checksum": "c9d93d0114dda2f4992c284ab61a3be57aee5e02cd9a1a9911cfe7c4a93441f8"
     },
     "aarch64_macos": {
+      "etag": "0x8DBA69EA722C946",
       "checksum": "6ba990fea6cafbb305f731c903903aeaa730dee35afd93b4e9ce0efac1fc5d92"
     },
     "aarch64_windows": {
+      "etag": "0x8DBA69F9079A719",
       "checksum": "9e8fda00a0e495a0ed38a327379076ab305041b2fba65649dcb7dd5821463680"
     }
   },
   "0.1.41": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB88F6C40A4EB6",
       "checksum": "9895062bb4563c6eb6f0d1134f443d95550e3aefa51c9dc65a716550ef12fa74"
     },
     "x86_64_macos": {
+      "etag": "0x8DB88F72B2BF9E4",
       "checksum": "421fb935f2a06f42e99ed8fa6b25514f5a724427d30321a5460ca471676da6fd"
     },
     "x86_64_windows": {
+      "etag": "0x8DB88F7F4625515",
       "checksum": "58d7f7555adfe0a6137662ba8446096c866214fc268a18906e7ba5670e587161"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB88F70CB8DE71",
       "checksum": "f527129f91703dab09fa0bb139a6f9020bcb9598dc43ca010f59ee9886055eb1"
     },
     "aarch64_macos": {
+      "etag": "0x8DB88F7E88993AD",
       "checksum": "a3aec3ea5356d232a670b112170dc46ac7285419886aa693045907094b030f09"
     },
     "aarch64_windows": {
+      "etag": "0x8DB88F7BFFAFCDA",
       "checksum": "da3a695bcd3654413873e8f1df0389d0d3d478ec13317676a29e2e05d520ce3b"
     }
   },
   "0.1.40": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB64A4019D8B1B",
       "checksum": "6bb8bc63de21e47afb44e9b1fcc2f5444120a0658bfe7b2b64a0eb575667ee59"
     },
     "x86_64_macos": {
+      "etag": "0x8DB64A4EBFCB25A",
       "checksum": "39ddc8f18f51d429f0a5adc0bdaa416532ba70e7dfd3d5200c5fcf8f981ea656"
     },
     "x86_64_windows": {
+      "etag": "0x8DB64A4374DAB64",
       "checksum": "d532011810db834c7a3dfc580a6754a0204ffd146e0b29a62c508f6d89544d9f"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB64A4623979CD",
       "checksum": "cebdbfee26548375c3f2000b6fae46ba80bff7cbfa33c8919525e3923b004f1e"
     },
     "aarch64_macos": {
+      "etag": "0x8DB64A516168340",
       "checksum": "6a022039c59cf273b9764bd74e991f423e03e80ddd0eaa25648207b622ab3547"
     },
     "aarch64_windows": {
+      "etag": "0x8DB64A49A21E47B",
       "checksum": "6b29f3a9b0b710d9f9a2544f7bd101997845eff37836fa50edaa92fa3e5a6ad7"
     }
   },
   "0.1.39": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB4E53030EC9BE",
       "checksum": "6476cf5711a150c53b563ecb1680b45365c86b054079b483333a961e14dd2c8a"
     },
     "x86_64_macos": {
+      "etag": "0x8DB4E532DF6DF6B",
       "checksum": "c93e5e03c64ac351ec69a62d22c119e8b2f612fde5bc7938aade549bc38f4d49"
     },
     "x86_64_windows": {
+      "etag": "0x8DB4E53B7BE01F2",
       "checksum": "02e5ce690d027a28e323e753ba03f4ce164bd106d98afe437871778f1b166c8f"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB4E530DDCEE68",
       "checksum": "f5de7ae1fb82ea797be27a56a0cfe80d2724a4ae4d380dd49f1d5ac221f45f4a"
     },
     "aarch64_macos": {
+      "etag": "0x8DB4E53CED97541",
       "checksum": "d605026264208372def2a3d62498070b02cd3e10fc74ffc7448e8b626fc7fd90"
     },
     "aarch64_windows": {
+      "etag": "0x8DB4E533DE65E37",
       "checksum": "dc026ed1fe5ba3147eda788df31c9da660942b959c3f6b1441752f0f886aef53"
     }
   },
   "0.1.38": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DB4B4421C4991E",
       "checksum": "5993f873ae46a94237b8e9be7bf990f9da165fc516b1ffa17ec680a0f52d07c3"
     },
     "x86_64_macos": {
+      "etag": "0x8DB4B45161A03FE",
       "checksum": "612dbbef16edc916d4755616c72d70c2d0db46d7f3426423f5dfb32703dc4baa"
     },
     "x86_64_windows": {
+      "etag": "0x8DB4B44BE3D5E0C",
       "checksum": "df7bcf14a531466b219829880b6204e014c0f9462fb8343ed58e34400ee33fb6"
     }
   },
   "0.1.35": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DABDEE2613045B",
       "checksum": "a2291a214210d5c658697abc6a183dbb28f14dbb2757be364e6465c315561160"
     },
     "x86_64_macos": {
+      "etag": "0x8DABDEEDB497036",
       "checksum": "c2677a9217a77299a049ce5ffb2da734f5d47123fd848dfb95e3f0fc1620101c"
     },
     "x86_64_windows": {
+      "etag": "0x8DABDEEB25D20D8",
       "checksum": "fd39c8e7f92ec7bcb8a776162811133d6e9d7bac091c22b757cc1c4edcab179f"
     }
   },
   "0.1.33": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA972D5AAB8168",
       "checksum": "3f861a2c9be2b3b2333a2a37d6fc5914c5aae4b02a824c97e221c46f08252c7b"
     },
     "x86_64_macos": {
+      "etag": "0x8DA972DE5DABC15",
       "checksum": "a82c1635490914a4da5be5644198549c14fbae012e6716b36002034c0e0e710e"
     },
     "x86_64_windows": {
+      "etag": "0x8DA972DAE84C716",
       "checksum": "7265d7f8d79eeb965c98d61f55e7e918ad06beda43932584af87db9afde70be3"
     }
   },
   "0.1.32": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA842A477BC8A0",
       "checksum": "dbb1a726366dcf07b0ae4ce3edaff518b15d04a8e90063ca0b13b4afea7b95d9"
     },
     "x86_64_macos": {
+      "etag": "0x8DA842B1BB568C0",
       "checksum": "9f16542c2de47f19d9d0fa1a849517d77a34fd9592ea1dbfa7e363dea78c62d3"
     },
     "x86_64_windows": {
+      "etag": "0x8DA842AFC0BC8BA",
       "checksum": "05ffe8d3e9423449ec6030ef806d4b2e4baaa6f00df539e1d88642b438f963b0"
     }
   },
   "0.1.31": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA83D00AF6187E",
       "checksum": "46e6253a81db1a7dbe4712852e24094eba65057d74051941cb9de8c6a4a0e457"
     },
     "x86_64_macos": {
+      "etag": "0x8DA83D06AEBFC2B",
       "checksum": "302241aae21b69fb4280da575ed5039180dc7ab7f2fed04113075b463f110881"
     },
     "x86_64_windows": {
+      "etag": "0x8DA83D0EBDAAF5E",
       "checksum": "e889200f9e8881f0fa82104fab7f09e31230331e257b7c984dbdc3ddea7115b5"
     }
   },
   "0.1.30": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA5EF171BC4CAC",
       "checksum": "369e270ea2bb14d3ab92e99a1f12334efcac27d5c1714b74aacc956550780575"
     },
     "x86_64_macos": {
+      "etag": "0x8DA5EF25F432158",
       "checksum": "296e652fe14fee79f6e5a1e1cb3758869b849f6592f382d74edbd667939c2c2d"
     },
     "x86_64_windows": {
+      "etag": "0x8DA5EF1CD1F0C91",
       "checksum": "5abc0df40f2f517eba0427b3d9797e7c6d7217069b63d5b9dc7091156cbd0873"
     }
   },
   "0.1.29": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA3A1318FF93C7",
       "checksum": "21e88dce237a69fb5b36771b83cb6b6fca20c09a2b5c576ea8efaf7218a5c641"
     },
     "x86_64_macos": {
+      "etag": "0x8DA3A132E8CC066",
       "checksum": "acd8f916b8a29659b2b28f7c2af2a02c112a8b7e0ed9e3b2876b1defb6deee41"
     },
     "x86_64_windows": {
+      "etag": "0x8DA3A139E5EFB12",
       "checksum": "5652ff990e2e2899a3d9fb69f1f5ba4c35991419e618e47e0469d75a7c57e1ce"
     }
   },
   "0.1.28": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA31D56393CA27",
       "checksum": "d916d8915e8175f1fcc5e949662367a71835ecd7f6bd998ad8c474ad1224c2de"
     },
     "x86_64_macos": {
+      "etag": "0x8DA31D61708FC60",
       "checksum": "5137db61f155f810e056df721e0ebeae35433009921c276bbaf1e1b4a4662c27"
     },
     "x86_64_windows": {
+      "etag": "0x8DA31D643EE3F3E",
       "checksum": "fb0ceefb5e93561464a5f46ca33114d472cdd8d71e3b2b3e148bf08e204c6e14"
     }
   },
   "0.1.27": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9F828045DF134",
       "checksum": "3cfa4a13aebe2db7002dbfed48e051945d109d9dc0eb8fc2a58ca0034509afb7"
     },
     "x86_64_macos": {
+      "etag": "0x8D9F82876B46341",
       "checksum": "4d40392285bde414a50cd110130c6fdef7712fed1991b0a18aee97a7635cff2a"
     },
     "x86_64_windows": {
+      "etag": "0x8D9F82902934382",
       "checksum": "4356331d794a192212da643b65a7122d687424b1b98021085be1ef6d37f631c5"
     }
   },
   "0.1.26": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9DC66E5988186",
       "checksum": "a6afb71254ffa24aff510efe393ba948750c2382e88f385b04e00013614d9908"
     },
     "x86_64_macos": {
+      "etag": "0x8D9DC673D707839",
       "checksum": "13cf99903727ac1b028196dd513aef2529fd2412713f57155357438b5345dd40"
     },
     "x86_64_windows": {
+      "etag": "0x8D9DC6770928D16",
       "checksum": "53c97086663d24357488e8d6ce97b87db664e9072ee02a92d8194a7f2a03ab22"
     }
   },
   "0.1.25": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9BBB84D3D0612",
       "checksum": "6ea23ee2cda4490d131c915474601343757283c979017dbda93b820a895ffdcc"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BBB88F3E9DEC",
       "checksum": "713d8ce3b4e1bafd42ac8f8c6ef0537a80a52734953272963c9dd089335ac416"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BBB9007DA49F",
       "checksum": "a13d64671b9ae8651658b1d38ca78516c6688531e26db8e6bebf98579b7d5750"
     }
   },
   "0.1.24": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B94BAA194861",
       "checksum": "c0fb48dc24923ad9595a7e1de870713c02791d7ac36de3c37070748b604674eb"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B94BA6D743D8",
       "checksum": "82f2e368ed82d150bdde50ae107ce9589cc29d5f9de92bcaf10c5d4b070375ca"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B94BA3AC4651",
       "checksum": "5013df810bfc8120745a76306cac66cdaa02ca5c22c7ade07265cb14e78fd76f"
     }
   },
   "0.1.23": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B94BAF208721",
       "checksum": "a88fb952d257536c93d53a45d3c343428a887d92e0f2f5b1fa27c9ef82e3ef24"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B94BA905B78A",
       "checksum": "5da34b029a7f4cf9c2049ae035c237e61b685f7ef38bbb39634e264c2c9e1ae4"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B94BA2F8EF8A",
       "checksum": "102e814ac80b95719c97163718919457cdefc63b508f41fe98be51b346fdc82e"
     }
   },
   "0.1.22": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B94BA72383C1",
       "checksum": "6f787362cad3770f08727f62221f4108ea7cfc2b7d69d6d7fc98164042e3a12e"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B94BAC2D0C11",
       "checksum": "50ad17ee22767ae3b5f41ec1611bf9e4407ad5514fc4d42adf5eff38248791c5"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B94BA895C852",
       "checksum": "b0175ad16c0f7b5f3d9e32d4544b292a1bce653839d7bcf2aca536b04167b8d2"
     }
   },
   "0.1.21": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B94BAE17F120",
       "checksum": "63760a60a8d248495ea92bea7d7a159c43c7c2260797b553e4cbe0dff339e38d"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B94BAEEB7546",
       "checksum": "5711a693f22ad610f80b92a278116f326927db96529654f25692aeb9afff7e39"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B94BAAFFDC86",
       "checksum": "e74ae634507279573ea09591b68854b93abcac305df5573e1514d489a65efed6"
     }
   },
   "0.1.20": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B94BA56A55A7",
       "checksum": "d6cfbe77f437cdf43af05f2405551900fc26051b02063e6967f08d772ffd55d5"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B94BACD7FFA9",
       "checksum": "88c64c6699e76d538cf42b4b4281abd86c4daa0cae6e4479dc923d89b6644a43"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B94BA4A352C1",
       "checksum": "7706ba3da4d092d0bb756a458c3aaa6278be88e826dbd3931f69f393bd6f336c"
     }
   },
   "0.1.19": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B94BACD25B31",
       "checksum": "e00e15b4c0b92e5022deb3e3233cce0ad672e2115409617336596509a0539ff0"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B94BAE03A8D5",
       "checksum": "38fe129e2a7be7fec82edfd74c63e1597901367d32ccd425d12ec7d9775ad13a"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B94B9E660C20",
       "checksum": "1124eae09270c4c2d83de25ef6b3971b5b6a5c1ea8f08f19230e1c70a84a58ba"
     }
   },
   "0.1.18": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B94BA951F75E",
       "checksum": "c4d46673bfa3e3ca776c1e05551e02cf03feb811cbe5145cbbf6a6656392e1d7"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B94B9D0CA2FD",
       "checksum": "0ff553909bb750348fcced274b5c2db695e7a4b2a2ff0d4719bb2b6a200f521e"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B94B9F5F140F",
       "checksum": "324280e9269d8894d3656451c002dc89501ced96a9188fad1ad29c58f0f98946"
     }
   },
   "0.1.17": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B94BA562197F",
       "checksum": "45f8d023bf4eb1f256a0f14df46ab3d4d95ec1d1dd613e84c6fca9efa9ae078b"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B94BAA8C927E",
       "checksum": "09b95b66c7e85f580f410838ac0360dfea777677faae974ecccf81384573accd"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B94BABF8E47E",
       "checksum": "91c843baef416d7c546f27f8adc6be5489e7b5ec341ffa58d7bb4c2c11c57a41"
     }
   },
   "0.1.16": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B94BACC3694F",
       "checksum": "356998cf01dfa46bbed729cd622a8c27ba299a0597e13d3ff2279b60466e6177"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B94BAD6B9E2B",
       "checksum": "50b178ea0113492c00edc990baf2b87f77b7fd77de25d97864948a1fa119e2a3"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B94BA5C27AA3",
       "checksum": "dc61b650c20e828497cba1be3c525107f992dd68675e46a6a7405d3ffd4cea57"
     }
   },
   "0.1.15": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B94BA254B1B5",
       "checksum": "40b21ac14657b70cb24e322cc21b23fa1225048651c7babcb3b0089036f33272"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B94BA57D3EA2",
       "checksum": "b9de0a9c37046f721264077a065e54bfc9c53da75665ffea228bc89ca86e9267"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B94BA2A0556C",
       "checksum": "57bc884e475d1944335d63915601e54584e1abc7887a55e6f09bda2604a228d8"
     }
   },
   "0.1.14": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B94BA6C93C2E",
       "checksum": "44ae26b5b1334458d3f3624fab610d78ad73815b23b51825641366652c1730b4"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B94BAD8DA00B",
       "checksum": "38097b2c07c57ade1dbbe81f0bcb5f2720791c9506603f9c199b899f0cb75081"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B94BA8142880",
       "checksum": "64b21bbafd1d5a99db2c9fb0dd2cf76c491cf7d498f66a01dd3dd388205c2057"
     }
   },
   "0.1.13": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B94BA9607436",
       "checksum": "8c3ba8017c52ab8579de0df4f16ac15dabbe070b2040f21a89e4c7d5819cfa9f"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B94B9D3581A7",
       "checksum": "5fdcba8572a3b019adf487397261dafe063898a878167d1492f7cb0031860c63"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B94B9ECDBF27",
       "checksum": "18e026ee3ae124c5c5afc081fae1c1af4496d43f5977ea8fe6379685ab123ef0"
     }
   },
   "0.1.12": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B94BADC87D68",
       "checksum": "1e9c5b7034cc74482bdf5ac3e03155b7041997be05902517abf4aa1ee5b243ad"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B94BA64FD892",
       "checksum": "f9e7f6f10ba51507fc33b58b5149352a041523eb89b1d6f3309309cfc519bce5"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B94BA1BC0AE1",
       "checksum": "ff89fe55d6d0dbba7a2676caa23ff8bfa6c8ea69e71738608281b1556e2ff530"
     }
   },
   "0.1.11": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B94B9E25D855",
       "checksum": "5034f09ef5afabc65cfe1577bc067d849f5d2f08936df67d7eddf0acf5126825"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B94BA3BDCFEA",
       "checksum": "2c1b34cfe252da51bfa46906c0a7e604ead0275b283c34f6c35def195d89be57"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B94BAF76FEAC",
       "checksum": "6b822b2512be7d9417ca414f134f86ac42b6ee664d045a828dc89afcc80c523b"
     }
   },
   "0.1.10": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B94BAB6AC366",
       "checksum": "2179f38ed4265af2584e4bb6510d98579ab61a3c3bd6e44d1be377297758a90a"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B94B9F49E18B",
       "checksum": "69c93b55f4f4b68f199b4763ff728e29f09dc6ff876db7f243a238d7c9fe2327"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B94BACC209F4",
       "checksum": "486491f68d3c7a9c52401aa36930dd6c28f8d9826a6f30d079e5f3cc799011bd"
     }
   },
   "0.1.9": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B94BA21DA459",
       "checksum": "222c0babc34825bca02ea9459095af45caeaef0f4bd98fd80f14c4aa2d9a6f67"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B94BA53D7FF5",
       "checksum": "7b4c568bbff1f15c422f0e4beee973428adb526f30f8d4974014bdafd128fa54"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B94BA2D84D06",
       "checksum": "8d7464fa79959ff4b9914a4769c1a0578172f74cfea90839855855ab070d4d0d"
     }
   },
   "0.1.8": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B94B9D1F3DD3",
       "checksum": "db00d972d14376ea059f84fc411576f8cec2ad4ad29a407374266294d6758e3f"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B94B9C1D849E",
       "checksum": "abb8d205f1f9d8e890638fca23b3d960326b7aa94eb3c98cd31f72bc1eeb4a70"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B94BA4A0E21A",
       "checksum": "7e35d28f7de7f56fa5cfffff4471fe24c72b7da15956fd0a81176cdf68ad12e9"
     }
   },
   "0.1.7": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B94BA1DC3845",
       "checksum": "469915bcdc5daca376b1296a04207163cc03a3eea5f142463a3ccbf180e49c63"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B94BA9EB8873",
       "checksum": "c8ea15dfbbcadc62fd3cef1f93d285cfd400ad9ea90615a020e99f69ddba5890"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B94BAA74EF4D",
       "checksum": "aa25c1329693bc167daf704ecc9e3b93a7d28e3e01d9df8a760370ad861ad155"
     }
   },
   "0.1.6": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B94BA2C1E22D",
       "checksum": "645d77a5111f5ff807f77d19d23dede026c37738a1d163faadebc7f8ea90ff7c"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B94BA6E43A3D",
       "checksum": "041170b474e5790da18f2d5ce11f4936071511c365e460e4347109b6e3e7689d"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B94BAD1B403A",
       "checksum": "578d74e874c372a7abe62a84c4c0143bd8f3229bb59464682d4e3492ca21d474"
     }
   }

--- a/manifests/cargo-valgrind.json
+++ b/manifests/cargo-valgrind.json
@@ -23,12 +23,15 @@
   },
   "2.1.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA70B724C7F3AF",
       "checksum": "eaca63383f6efd2532fd1708d0de9e0bad3bebec53d6a2fd106924277a870bf1"
     },
     "x86_64_macos": {
+      "etag": "0x8DA70B724C66D4B",
       "checksum": "654578f72d1224876a276780fd96c9cca28b2432d2485dc3871dca46966d2359"
     },
     "x86_64_windows": {
+      "etag": "0x8DA70B724D33CA8",
       "checksum": "43c3cc0472e4b3887db06cbd042706fc193eec6d274590b1c6d5e1aaf274f3ab"
     }
   }

--- a/manifests/cargo-zigbuild.json
+++ b/manifests/cargo-zigbuild.json
@@ -26,18 +26,23 @@
   },
   "0.19.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC9119E4DF0AC7",
       "checksum": "ab2e2f3a22409470ec7d71badc22ab89351a6ddaba5c4785a39689856809404c"
     },
     "x86_64_windows": {
+      "etag": "0x8DC911A1AA0FEBC",
       "checksum": "640b03357f568deb976cd0e0732db04f723498a0d4706d71ebaec05f8fc35db2"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC9119C072F83B",
       "checksum": "edc3d0966ed8c80056d36ace8998eb75ed2f3a71342e0825960d98c9eb3398a0"
     },
     "aarch64_macos": {
+      "etag": "0x8DC911B3D433D97",
       "checksum": "9173594204eaacadd62e2f26a3c2365887ec24a4fa15f309023b8d4bbbc09dec"
     },
     "aarch64_windows": {
+      "etag": "0x8DC911A3FFF6228",
       "checksum": "6affe535f6d37768cc20be30b8b65a1bcc196ae1efdad71d2a5c44049a081b7e"
     }
   },
@@ -46,18 +51,23 @@
   },
   "0.18.4": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC64512B96B7E2",
       "checksum": "bfcef631fe5ec5c0381d0028d47765dd4cef54ece10ebf2d76e62de6e7941d4e"
     },
     "x86_64_windows": {
+      "etag": "0x8DC645155E600B1",
       "checksum": "5a5ea2b4d2dcd6d9196d5ca72e76c0d0714dae1ad287d313b89b1d78bcdc8364"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC64512690B73D",
       "checksum": "8271acf32a08fc6073153fffeca5d9289dce7ae13a3a9d64cacf0600904fa7f5"
     },
     "aarch64_macos": {
+      "etag": "0x8DC645162138D32",
       "checksum": "b04e989f6df22d46be292af8c4f799467d6e60305fe6ab55f9bdf1c795a0c70f"
     },
     "aarch64_windows": {
+      "etag": "0x8DC64516B51DB3B",
       "checksum": "f5166b64a037508c4698e03bde3a57a53fde530fe604866050e1fef43cd5df6d"
     }
   }

--- a/manifests/cross.json
+++ b/manifests/cross.json
@@ -11,84 +11,102 @@
   "0.2.5": {
     "x86_64_linux_musl": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.2.5/cross-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DB06D51EBF8F43",
       "checksum": "a486cefa6cb486971b97be321ea9dfc2e90c1979550295314a368f53fab6d588"
     },
     "x86_64_macos": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.2.5/cross-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DB06D51EA94B65",
       "checksum": "84a664edbd5405efc985e9423804cc63d12e55691b9c7e9729355fdf7b9af015"
     },
     "x86_64_windows": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.2.5/cross-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DB06D51EA13643",
       "checksum": "3d4d6dbebf448b1f6856c662b2b342db0a7f6827e91ed88e2bf0e5ca00a30a81"
     }
   },
   "0.2.4": {
     "x86_64_linux_musl": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.2.4/cross-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DAA51E5DC66756",
       "checksum": "7ed556a4f3d68adbf679724b839853393d44c86321c4cf0636e8aef5610be556"
     },
     "x86_64_macos": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.2.4/cross-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DAA51E594F44B5",
       "checksum": "307614d82b19fa6a3fa9486a15454e39c02b849d3b39607bc92a07698bff4123"
     },
     "x86_64_windows": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.2.4/cross-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DAA51E5B85318C",
       "checksum": "8c45330126ba0a560fcf585690d1fa397fe1b749832811795b8cb819f712296d"
     }
   },
   "0.2.3": {
     "x86_64_linux_musl": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.2.3/cross-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DA61D9B423EA72",
       "checksum": "1bfeeef09259e9e15995c6f429970371714735415f64b9a4463da0867b7961c5"
     },
     "x86_64_macos": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.2.3/cross-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DA61D9B41260F7",
       "checksum": "2954bc1a5c108d0ca70ee568f8921d81a3ecd2bbb617c754c7bfad279be8d7fc"
     },
     "x86_64_windows": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.2.3/cross-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DA61D9B41D0DB0",
       "checksum": "d44674b63f85bd86497347d0d64fbc0b1aa329ee1354843a9ba4be3e7cbe76ad"
     }
   },
   "0.2.2": {
     "x86_64_linux_musl": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.2.2/cross-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DA5643AD4041B3",
       "checksum": "e31df42dc18659ef3caf0f6b41a8fabb0c7356ba95c87516625271791a113439"
     },
     "x86_64_macos": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.2.2/cross-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DA5643AD3AEB4D",
       "checksum": "c0d5b4269a5954211e0893c9c519917b0b6cd1c7c8ac9c1881341d3e10d41e1e"
     },
     "x86_64_windows": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.2.2/cross-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DA5643AD356DD6",
       "checksum": "216c5f19cb8ceff571fa29c6876c8d39b672739f45edc1046289e31049a58c4f"
     }
   },
   "0.2.1": {
     "x86_64_linux_musl": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.2.1/cross-v0.2.1-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8D9BA17E2831340",
       "checksum": "b2e2ff0c25cb1787c0e44984136c2243b14df20023adcc7cfb9170ecfde7ad68"
     },
     "x86_64_macos": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.2.1/cross-v0.2.1-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9BA17D2314E7A",
       "checksum": "589da89453291dc26f0b10b521cdadb98376d495645b210574bd9ca4ec8cfa2c"
     },
     "x86_64_windows": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.2.1/cross-v0.2.1-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8D9BA17E1AE07F6",
       "checksum": "3af59ff5a2229f92b54df937c50a9a88c96dffc8ac3dde520a38fdf046d656c4"
     }
   },
   "0.2.0": {
     "x86_64_linux_musl": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.2.0/cross-v0.2.0-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8D9BA17E391C3C6",
       "checksum": "53a05bacf658e4572b7a3d233259f1093d7243152af564ac3e9e96873b6e5d5d"
     },
     "x86_64_macos": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.2.0/cross-v0.2.0-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9BA17D4BEC620",
       "checksum": "5d0322b6b0c70056f3d03357dc0b2382cf9c62f58bec9e601f8de13119558e77"
     },
     "x86_64_windows": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.2.0/cross-v0.2.0-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8D9BA17D234D065",
       "checksum": "f57d657526eb6a31022ec9c6b6fe83d29050166c6086930aee92a89226eae6ec"
     }
   },
@@ -98,154 +116,184 @@
   "0.1.16": {
     "x86_64_linux_musl": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.1.16/cross-v0.1.16-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8D9BA17E104E84C",
       "checksum": "bc9ceed6ad99137c06f8e8ca8079f736b4752a575bc80cbdf4a99236685d0045"
     },
     "x86_64_macos": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.1.16/cross-v0.1.16-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9BA17D92EC13D",
       "checksum": "6c143e7891186f0903c2d780b5cee54c13305fea60fe8e983b847da59ad57849"
     }
   },
   "0.1.15": {
     "x86_64_linux_musl": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.1.15/cross-v0.1.15-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8D9BA17E583874D",
       "checksum": "cefa9bb181e15b5f1b58be49e21ebddaf38938d23f051caf59fe363657180a8e"
     },
     "x86_64_macos": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.1.15/cross-v0.1.15-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9BA17E131BE1F",
       "checksum": "4437f570abe3a248f36b9defaa3bd1f2b7607e6979ab36d160c149395bd707ec"
     }
   },
   "0.1.14": {
     "x86_64_linux_musl": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.1.14/cross-v0.1.14-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8D9BA17D5362EB0",
       "checksum": "495c38aa910083ce1acadb0f5d2753089ca86e53473f1957b8f9ef8855307f2a"
     },
     "x86_64_macos": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.1.14/cross-v0.1.14-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9BA17DD0F146F",
       "checksum": "07c5ca64ffe63601806f138539c7da9f32a9e8a6c54eab53d41b5a14cfc1f909"
     }
   },
   "0.1.13": {
     "x86_64_linux_musl": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.1.13/cross-v0.1.13-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8D9BA17E4A5A3AB",
       "checksum": "749fd8fa5de62ede0ad64f770199b3a1222449542c9ebd29460ad8574d068754"
     },
     "x86_64_macos": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.1.13/cross-v0.1.13-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9BA17E485C43E",
       "checksum": "c29b0a51f3f37b58b8300a79dbdb08cecedcf9f5767691f3e4dcf17949f1a09f"
     }
   },
   "0.1.12": {
     "x86_64_linux_musl": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.1.12/cross-v0.1.12-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8D9BA17D3ABD078",
       "checksum": "cbc08f5ed2ccea4ca5260c5b036c492031ede2f0951ba654fd8fa7f9ca2e2732"
     },
     "x86_64_macos": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.1.12/cross-v0.1.12-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9BA17E4D22B70",
       "checksum": "fe9f34211d7e5e7bc804e93b8be43f5488bc36065d583537fc31f96bc6faa8a0"
     }
   },
   "0.1.11": {
     "x86_64_linux_musl": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.1.11/cross-v0.1.11-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8D9BA17D45CB730",
       "checksum": "d8fd0337e1c06728a0a098d4b54a300f297f2248c5d6e199b7a7769b8f8268a2"
     },
     "x86_64_macos": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.1.11/cross-v0.1.11-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9BA17E098EFBF",
       "checksum": "0af262a4081817ded72d7288673f0029b594164fc5c352ce4ef7d3e0ca7480ce"
     }
   },
   "0.1.10": {
     "x86_64_linux_musl": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.1.10/cross-v0.1.10-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8D9BA17E2CDF405",
       "checksum": "73054fa744c4edf0be458a78a1ebbd1ebf62b4d550e53027302ca690c169daea"
     },
     "x86_64_macos": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.1.10/cross-v0.1.10-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9BA17DCE2B3B0",
       "checksum": "a92aee7a0be3ce83296575e9ba9e53756d8de2cfc70b44c92efee8c6832f544e"
     }
   },
   "0.1.9": {
     "x86_64_linux_musl": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.1.9/cross-v0.1.9-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8D9BA17DEB33873",
       "checksum": "0269bfee8b75d4b08963ea66f5c2651b3cbd0f6e4eba1158cd1409b6761cef29"
     },
     "x86_64_macos": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.1.9/cross-v0.1.9-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9BA17DF855DF1",
       "checksum": "e0161e5f07fce04250c3a5eb26fa3913d4c8ca6287af822f18bf2a6196495d8a"
     }
   },
   "0.1.8": {
     "x86_64_linux_musl": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.1.8/cross-v0.1.8-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8D9BA17D3B98A16",
       "checksum": "e58286e05d7f22b0f537d0dab9a631831044d9116326b18ad0980397e9ec7885"
     },
     "x86_64_macos": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.1.8/cross-v0.1.8-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9BA17D7BC7B6D",
       "checksum": "e38dcb2e1949c28a1c8e7438bc483124225602b0a3df3ae6c9a012c2d6fc4640"
     }
   },
   "0.1.7": {
     "x86_64_linux_musl": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.1.7/cross-v0.1.7-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8D9BA17D7898BFE",
       "checksum": "6095ee63f8438b12ef197310f53de7a587eb9894140c0ecf55eed810cf3886a3"
     },
     "x86_64_macos": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.1.7/cross-v0.1.7-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9BA17DA520839",
       "checksum": "9498145ea96c3c083489d8c5afac401ce65e7a5563629b0956733abe79570402"
     }
   },
   "0.1.6": {
     "x86_64_linux_musl": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.1.6/cross-v0.1.6-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8D9BA17E4E1446B",
       "checksum": "3182adfca3b1dd5d9001118955f0919dd4819e236c7d9f48d9cfc59567e08165"
     },
     "x86_64_macos": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.1.6/cross-v0.1.6-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9BA17DC143727",
       "checksum": "8b07fa221d6691eb8883731576da31b9a504e13621ad10794d01d3e95d23fb53"
     }
   },
   "0.1.5": {
     "x86_64_macos": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.1.5/cross-v0.1.5-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9BA17DDFE81B4",
       "checksum": "4edf23abbab77000f3b2dbf6e8b2fe235484df46c720efdef882cc04f7aa162c"
     }
   },
   "0.1.4": {
     "x86_64_linux_musl": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.1.4/cross-v0.1.4-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8D9BA17DCE6D1C3",
       "checksum": "cf233a80ef89003b8b4a60da39742753df5cc7280e8fea830dd7e95dc2c404bb"
     },
     "x86_64_macos": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.1.4/cross-v0.1.4-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9BA17D7AAF1CB",
       "checksum": "0486bf301af5f2525ab7c27296f575a3743cf01680f8fd6016ce60293ef1dce9"
     }
   },
   "0.1.3": {
     "x86_64_linux_musl": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.1.3/cross-v0.1.3-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8D9BA17E3CB900C",
       "checksum": "25772e17ccb25b88be3eb764456f49ce46474520b9657044e0da20d00c7b28c9"
     },
     "x86_64_macos": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.1.3/cross-v0.1.3-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9BA17E4C7F3B8",
       "checksum": "0c8413cf62c17bf977a25f74b03cd38154ea59e4ec343599ec56e7454c2d554f"
     }
   },
   "0.1.2": {
     "x86_64_linux_musl": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.1.2/cross-v0.1.2-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8D9BA17E515BA4B",
       "checksum": "de1f4017f042e99e688b9bd1ed0b8708652e1df91ad2325638a40553425ba8e2"
     }
   },
   "0.1.1": {
     "x86_64_linux_musl": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.1.1/cross-v0.1.1-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8D9BA17E0286407",
       "checksum": "4572d4da5ae7f87da7ab06f5148f246b30e512b2aeb51028041f2455c2c68e66"
     }
   },
   "0.1.0": {
     "x86_64_linux_musl": {
       "url": "https://github.com/cross-rs/cross/releases/download/v0.1.0/cross-v0.1.0-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8D9BA17D26ACCA1",
       "checksum": "b77db37f7d034ab811ca17ebf4f219f44bb95a7328f0c2b9a88d1d39e4b6ac40"
     }
   }

--- a/manifests/deepsource.json
+++ b/manifests/deepsource.json
@@ -26,18 +26,23 @@
   },
   "0.8.6": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DC27C9A2553B84",
       "checksum": "40490fa8403496d354ac5e69ba4a71c287bee579d4413b62ee54c5c3038792ca"
     },
     "x86_64_macos": {
+      "etag": "0x8DC27C9A2421736",
       "checksum": "0970061b4755ecce8736f1d9bc8932cdafb452528432267ce33a0d566a3ecdeb"
     },
     "x86_64_windows": {
+      "etag": "0x8DC27C9A708BCEE",
       "checksum": "10d7bf2d6d8073a20f47982fd1db4f285666c1a6be2d89f555b097676da106d2"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DC27C9A2FA5E73",
       "checksum": "9f4f2a22ec412ed826e011afca3bb49979e4ee89434abbf8086324c5b9ccc074"
     },
     "aarch64_macos": {
+      "etag": "0x8DC27C9A3A4101B",
       "checksum": "b4223a8a03f16853cdbc4d5d40a586fa9291167e55d21f051ae3bf0c359f693a"
     }
   }

--- a/manifests/dprint.json
+++ b/manifests/dprint.json
@@ -32,69 +32,89 @@
   },
   "0.46.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC8F231600F195",
       "checksum": "b3968388c27fcc0853d54e57f8a00c1bd6134395d9657ded3088f365304bf90f"
     },
     "x86_64_macos": {
+      "etag": "0x8DC8F2315E93E85",
       "checksum": "a9f4c71f1e32e99152e8278ccbd27c059246dfa1c3d8b3cb1fa0837bdd269b3e"
     },
     "x86_64_windows": {
+      "etag": "0x8DC8F2315FB2BB6",
       "checksum": "4e024b2e626b2eabf923a62703cda3beb90ecacfaf2d737454ed6025779e3811"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC8F231603FB6C",
       "checksum": "868a478307416f845f11dff9d9d6e94547dc826339fb6d5740f5b7795d9135af"
     },
     "aarch64_macos": {
+      "etag": "0x8DC8F2315F42EB6",
       "checksum": "f051c3b3bb5e8f936c1b5ad6e3659bf408a8e787b6dca48e6f95baf261f6e84d"
     }
   },
   "0.46.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC88052AC8B1AF",
       "checksum": "bbe9fe8eae9abdcfccdeca97fd8c524efd6137de702ee96e82b0ecb4ad432ebf"
     },
     "x86_64_macos": {
+      "etag": "0x8DC88052AB1E804",
       "checksum": "88abd8a6f416b624fdfae338ae6fca440f4a36b35199f0d03438caeb7715d820"
     },
     "x86_64_windows": {
+      "etag": "0x8DC88052AB235C6",
       "checksum": "53ab1991d23be9de8bf3b920f8605aee55629321fcacccfc5df38d49b2eb5160"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC88052AB8E4F5",
       "checksum": "d7b6f88c320bffcbb1dfeb6030d5a1ef23d18d81721e39abdbf4b8bdab389ba4"
     },
     "aarch64_macos": {
+      "etag": "0x8DC88052AB0630B",
       "checksum": "a331d1c9ad2abb96d46c33d25f1166bd5497dde0c48eb8a8f3d98143cd4bca5b"
     }
   },
   "0.46.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC7DB9E9A6330A",
       "checksum": "4a7d6fa6b920ab150f580965556086cdd7992e07078e627ab9a9d1c3bd30ba85"
     },
     "x86_64_macos": {
+      "etag": "0x8DC7DB9E99C2C2E",
       "checksum": "cdea84bce1d84c26e8eced2265d246b79a849ec2e7d1377d98dd7bdb21c7ce83"
     },
     "x86_64_windows": {
+      "etag": "0x8DC7DB9E99CEEA8",
       "checksum": "74e5ab38c744d5903862c2b5174d0fef9759b5506da775e1fb93b6a68c63101d"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC7DB9E9A30250",
       "checksum": "e2b6d87167d21f1f01571790e79526ef9caff3b8b75f5cac348c4f06f60a8c16"
     },
     "aarch64_macos": {
+      "etag": "0x8DC7DB9E9963F72",
       "checksum": "f3ff4faef83d14c3b4ae262e79a40d4e0fc3fa1903d0b6e9b82f0b25b00e9499"
     }
   },
   "0.46.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC7CCB4CE5BEDB",
       "checksum": "7a2c12edc868259be890174c4ec3bd51c81ec8773aa294e12fac0634f36d15f5"
     },
     "x86_64_macos": {
+      "etag": "0x8DC7CCB4CD07A03",
       "checksum": "e339f1f891c60087676d72f70ba5f80dcaedde4bdc58730b9cb68a5483b3abfd"
     },
     "x86_64_windows": {
+      "etag": "0x8DC7CCB4CDE4D3E",
       "checksum": "786201545938f6f7c6d407e6404b31ae9bbf9e5a4abc4c88dc9bd73da369a906"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC7CCB4CE10940",
       "checksum": "e52c0a3398e34e88ffe560e719bf8361ba3f35b4e0927ab9ba0761796884ce24"
     },
     "aarch64_macos": {
+      "etag": "0x8DC7CCB4CD2E849",
       "checksum": "4b608b3676f10e04328c3d8be396bded96328ebca9b95b70bf5baf67bed7b135"
     }
   },
@@ -103,35 +123,45 @@
   },
   "0.45.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC55161ADB78CF",
       "checksum": "eaf2690b7414d11bc33fb2a81898f285748a7a6a7983f965b569e536fb67b815"
     },
     "x86_64_macos": {
+      "etag": "0x8DC55161B673D14",
       "checksum": "83cce6b82d8674dbdddaf911bc117f1c866aaa4712aa381e54ab9466526026aa"
     },
     "x86_64_windows": {
+      "etag": "0x8DC55161ADBC69E",
       "checksum": "71fef42ad86017a50bee977836dfd387d8584d6a9c4c03354d62977eaa1f135b"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC55161AF5734F",
       "checksum": "c05d839d1f187d68d55effc60add4e66afb373015a1d1126c310b5c8669a8563"
     },
     "aarch64_macos": {
+      "etag": "0x8DC5516350CED43",
       "checksum": "be6e4bcf9aafeb4ef34f27385717004cc0dfd06f8bce8e67b18937b53285d436"
     }
   },
   "0.45.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC0594642943FE",
       "checksum": "8fb959aeeb441e0038217a7973f3a8e246e7aa46b77b33ba5f5e2f38d86f531b"
     },
     "x86_64_macos": {
+      "etag": "0x8DC059464192985",
       "checksum": "6df01e0357049ad3bc62bbd2f60c9c448bd747b650ebf20f7ab5a38cefd36b44"
     },
     "x86_64_windows": {
+      "etag": "0x8DC059464288189",
       "checksum": "0a5a83b521f152cd83cfb95ef119286e472b3b43077b3ffaeb4b3297fbb52e7f"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC05946469393F",
       "checksum": "48ba9f0910e32a66c869cffc6fd96d2d8f000ffb3d11234e71ae952f322dc849"
     },
     "aarch64_macos": {
+      "etag": "0x8DC0594641EA192",
       "checksum": "cf23ab2785ca25f27ed5ca5127663dfe0131ae146d0b8d5159b06e0694ad74ac"
     }
   },
@@ -140,18 +170,23 @@
   },
   "0.44.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBFF67D249A6BC",
       "checksum": "1407c11d0855d6eb5ed4b2891b4fc7effcdaa276a7d77b5b20b65540ef90f58f"
     },
     "x86_64_macos": {
+      "etag": "0x8DBFF67D241E743",
       "checksum": "758f501e3f47be0d880e79449dc3ebc269a8c52efc4a7fc53a5756fd1b673005"
     },
     "x86_64_windows": {
+      "etag": "0x8DBFF67D2339F7D",
       "checksum": "7e100d917a6c2c76458acedf7b9745ceb8cd380c56a5b1f09f6e27c8f41a94d8"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBFF67D2C4B4C6",
       "checksum": "7ec71a031c7374b43122c065d49768cacf6561ae8980d0aa09202d7de01749f6"
     },
     "aarch64_macos": {
+      "etag": "0x8DBFF67D229E66B",
       "checksum": "68fc1abebe70b3947ec7e019bb3c3d47939cb71a8c0877f1a632b552edfaf6e0"
     }
   },
@@ -160,52 +195,67 @@
   },
   "0.43.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBF206B645A620",
       "checksum": "68bfc2e1c46ebc1794a76dfb99e971ad7461892a875bc3c5ac6da80f871e16e4"
     },
     "x86_64_macos": {
+      "etag": "0x8DBF207B771E1A7",
       "checksum": "f860091eb4be0958b23d9aed2010e2a225ccc8d99ad79e408005d4f132d51d4b"
     },
     "x86_64_windows": {
+      "etag": "0x8DBF206B51FAEF2",
       "checksum": "3a0b473ece37be2b61ecfbe8480cf4af8fb5936c1f2f3125bd12c797950b79c5"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBF208CD34192A",
       "checksum": "f8dcf95da927ada9c0f8c360bc5f2644d6f012d37fcc1563a6da26b2a4d95dea"
     },
     "aarch64_macos": {
+      "etag": "0x8DBF206B571DF48",
       "checksum": "de523a8df01b2843d89ddd145463d70c10d813b5a0814b7094022daf14e2b9e7"
     }
   },
   "0.43.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBEE147039BA08",
       "checksum": "069c27da39ebb3c7227643cec6e4efec38f4e3ad8cef61290482e8a3e2702655"
     },
     "x86_64_macos": {
+      "etag": "0x8DBEE1470551277",
       "checksum": "b4c937c76038ff3198b9e3494119fb6405e54256a2c0ee7db797486cde4eef9f"
     },
     "x86_64_windows": {
+      "etag": "0x8DBEE14707F276C",
       "checksum": "ce017e44244ce0dc837a9c6536d50ef5de6e24c07fa6d0c915b14a1b64082c3e"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBEE147042B093",
       "checksum": "e4fb458f1affc0c8e81cb2e158144672eb5c6bc3064a48bb32f0fbd57c2c9aee"
     },
     "aarch64_macos": {
+      "etag": "0x8DBEE147051462E",
       "checksum": "ea479f5ab3a2c8933256e61e77c5a68ffda8d6c77be968b87d80374121686959"
     }
   },
   "0.43.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBE8936C50A555",
       "checksum": "a73e3ced32b4b82f4e462e4cb4c8206e87d649715b974ed17f90986856498255"
     },
     "x86_64_macos": {
+      "etag": "0x8DBE8936C1F457E",
       "checksum": "8687ddffc00197807ca37934bdf392fa7f7441b8124a6679c9fcccb862c5c5e7"
     },
     "x86_64_windows": {
+      "etag": "0x8DBE8936D44C853",
       "checksum": "dc36df4049633e0bb281a1cdb64ad95e593f299e560b664958457478267e939e"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBE8936C507E6B",
       "checksum": "76270d79c923c14fdbd617d46765ab4299cd5966532bf3c602a5eb414cd6e755"
     },
     "aarch64_macos": {
+      "etag": "0x8DBE8936C21DAA9",
       "checksum": "fa5f29ab77fb32742aba7d5cd1cb01d1e8f84abda5ddcddb5c4489fbad231390"
     }
   },
@@ -214,86 +264,111 @@
   },
   "0.42.5": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBD816CC29635A",
       "checksum": "f4326c24117bfc06cc8010da940e85be817c8c798b0e72243edd60066c88dbea"
     },
     "x86_64_macos": {
+      "etag": "0x8DBD816CC2DA451",
       "checksum": "4b1d1fd868a39dd6c8a1641ed774d1b25ded18694a3c7e585f7af4bf74ac00ec"
     },
     "x86_64_windows": {
+      "etag": "0x8DBD816CC29635A",
       "checksum": "6eeb4b17eb7492f8e89cb8334581159686bb793c5e4dff6ecf029aa786f5e88c"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBD816CC2B83D5",
       "checksum": "6a99b4ed259c82487993dc17d488f21dd495f6b2fb59d99408734e51ea3c7377"
     },
     "aarch64_macos": {
+      "etag": "0x8DBD816CC042AFE",
       "checksum": "93c995332cb927cebd5b0937fc23939ea5f18b8a24a76e8535486abb9da4a68b"
     }
   },
   "0.42.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBD6F6B1CBB426",
       "checksum": "35aa7262e93fa568ac7afa8de1068068defbcfa905555c6c31bbdb816af0534b"
     },
     "x86_64_macos": {
+      "etag": "0x8DBD6F6B1E03676",
       "checksum": "d447e7439fbef636bde01dff7fe19efae6605b08d153e4476f26e7d98751fe31"
     },
     "x86_64_windows": {
+      "etag": "0x8DBD6F6B1C77330",
       "checksum": "c08d355ee0cbc5c33bd49502dd9d69c72e91c1855735767ab5eb81f1894c2396"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBD6F6B2246CBE",
       "checksum": "74eee7801a5bc48d159523cda484e745b9d12cb42a8c347de0a2c6a92f22a823"
     },
     "aarch64_macos": {
+      "etag": "0x8DBD6F6B1DC434A",
       "checksum": "3ce841fa02d5fcdd03e749ca14dac783470aab4a1451b0aad7428c86bce79bb6"
     }
   },
   "0.42.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBD6A70AF8DFBA",
       "checksum": "ed6a584698e4a79ba5694fdf61960caf51889c53814c903ac01aeb341ddce699"
     },
     "x86_64_macos": {
+      "etag": "0x8DBD6A70AEA2342",
       "checksum": "d29cc3cfaead4871333138b2cadda56b9b46f579480f7ce6ac444d50588e5f45"
     },
     "x86_64_windows": {
+      "etag": "0x8DBD6A70B292F28",
       "checksum": "fa893d7285768451c3e730d8e10c61919a9d5ef22055e9705ea8dff230691525"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBD6A70B00C615",
       "checksum": "0659af955bec3b03a9472ad85120720a2edc5d8ef965f7274aee94fcb8fca723"
     },
     "aarch64_macos": {
+      "etag": "0x8DBD6A70B1CBA0F",
       "checksum": "01b5200222056218ec56b57ce796c8f54156062e2de14970f75fde6d352a6aad"
     }
   },
   "0.42.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBD69732608EB6",
       "checksum": "01a6d42876a9794b7896f97afc362b8f57697834e86b1e78b91a730668f01543"
     },
     "x86_64_macos": {
+      "etag": "0x8DBD69731D25C4B",
       "checksum": "4277e14d1cfd72e261defe0d40c8c39428cdbce0816b5d86ceac8993dc88220b"
     },
     "x86_64_windows": {
+      "etag": "0x8DBD69731B5CCB1",
       "checksum": "c9763cb6d3ecd3b6ebd0ef53a75c4d79658be50efab72c5f1188f8279873dbee"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBD6973293C11B",
       "checksum": "cf630e1ec446ead8043f9ef1eb21fd43ad26a7240eb97ad47d93eb334250ac26"
     },
     "aarch64_macos": {
+      "etag": "0x8DBD69731ED1978",
       "checksum": "df5cf0451c114881ed9c4b0402cf0a57d020a2f4f524004b14b896af478e1863"
     }
   },
   "0.42.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBD68D4D1D5970",
       "checksum": "4518f8c97f336b3b985ba51c515ccf1ff1e4b5d10543e2b0184588d1236d7ae5"
     },
     "x86_64_macos": {
+      "etag": "0x8DBD68D4D30091E",
       "checksum": "4e3fbcfddd2e4329c73d7d45959efda40531db5f82f8e1244bbbf550dfc0761d"
     },
     "x86_64_windows": {
+      "etag": "0x8DBD68D4D27AE13",
       "checksum": "47657889206a8351007df84a370cd9a91df7362d83197afcef0a7d057884ed50"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBD68D4D002E42",
       "checksum": "e7da4e806bfdbed6ad4936f8ef2e334410d3b80c4bad106058bf3d4c3928f2ca"
     },
     "aarch64_macos": {
+      "etag": "0x8DBD68D4D3470FC",
       "checksum": "b99413a580b1bf24eac8b593d230cb9ce3038ed6ec6c5aea480a14d0b7bd8fd3"
     }
   },
@@ -302,18 +377,23 @@
   },
   "0.41.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBB19FB732A925",
       "checksum": "a22a0b771327e14bcb2508303502fa325bc85b2ca1c099ec49324c736be37fad"
     },
     "x86_64_macos": {
+      "etag": "0x8DBB19FB60822DE",
       "checksum": "28ef80b29135b428c4b87d0b6468b9280f2dea97fd4bada27cf247c7b8870f2f"
     },
     "x86_64_windows": {
+      "etag": "0x8DBB19FB588FA7B",
       "checksum": "f0416f1418d512066178c123daa5bf3dc061bcebd3e344906087762e3e6bc250"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBB19FB5D12413",
       "checksum": "736bae33b5ed619eafbb5f6bdf65f5806f728a7b51e229ba6732afd3117b8f89"
     },
     "aarch64_macos": {
+      "etag": "0x8DBB19FB5738EBE",
       "checksum": "3edb4521887bae5afe5ced25b5a540fc0f889b61cd335b3b4aab80b4d391981f"
     }
   },
@@ -322,52 +402,67 @@
   },
   "0.40.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB9237B6C20D87",
       "checksum": "5c8418466937191f711ce4ba59e9ec28036daec01a08a505a17570a5edaec4c3"
     },
     "x86_64_macos": {
+      "etag": "0x8DB9237B6928097",
       "checksum": "e4089c699a09ac725337f2f00f1de2798fa93e2cd7c739c81fdd85c3259b61e5"
     },
     "x86_64_windows": {
+      "etag": "0x8DB9237B68D2F72",
       "checksum": "ede70ca91ae7983f8365aa59c477246f9595c9f32536c359abf3a706c68801c8"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB9237B69FDF08",
       "checksum": "66e51be4b1882f504beca45067fee39226b81c23c7fed0b71de629cafa51b7da"
     },
     "aarch64_macos": {
+      "etag": "0x8DB9237B694C7F8",
       "checksum": "d1e7517270c7a04f38ff6659d0a20482c5406e66b2ae8e9c15abd4674e74c127"
     }
   },
   "0.40.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB91D74A7AE9B8",
       "checksum": "0bc9cf7e191bd0c9a3e0ff84c77837da1a14f399220246d1955774135c0e40e6"
     },
     "x86_64_macos": {
+      "etag": "0x8DB91D74A8BBEDC",
       "checksum": "a510053186e3cc9a802807cccf3e5eac3427fa1ceddd3e6f9ccb59dce7051ac0"
     },
     "x86_64_windows": {
+      "etag": "0x8DB91D74A7E397F",
       "checksum": "a51788272cf3412f7cdaecde1c570e22f93f01f89ae14587712b0f8f321a47e2"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB91D74A516D4C",
       "checksum": "53056d49e4c4394f52de95a3910a9d4a8986287f728886f0d768d2908975e92e"
     },
     "aarch64_macos": {
+      "etag": "0x8DB91D74A610E4D",
       "checksum": "8b8826460309a6306a3bab9150bd84344eccb59ca0e8c38ca551dfea6c1efc9b"
     }
   },
   "0.40.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB9169B161EDC1",
       "checksum": "4ca464e5d57d2fcffaa724a4fcecd4b75a8a264df8e673feda0ca94267d07416"
     },
     "x86_64_macos": {
+      "etag": "0x8DB9169B1802927",
       "checksum": "7da589860a440717b7d1e6153394509fa2a2b74d1c0b24a669920da172c805ce"
     },
     "x86_64_windows": {
+      "etag": "0x8DB9169B14CF6C1",
       "checksum": "372c6cd7665f1526a821cc3676d36036a6137609c6dcbfaa2601a7da8b0d0bb4"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB9169B154DD17",
       "checksum": "693b5d943a0f705be6379c79135f7e9d9bcc590d2b237e6344196fed62d817c7"
     },
     "aarch64_macos": {
+      "etag": "0x8DB9169B47D130B",
       "checksum": "a0b67859e733330d99809c8307095f56723ba9c3af01b1ffb7a03f1290e19c92"
     }
   },
@@ -376,35 +471,45 @@
   },
   "0.39.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB833F541901A7",
       "checksum": "5e6ff56f68d31ff8411367fa021a15b29092d0d48bcd8b2741953927652da953"
     },
     "x86_64_macos": {
+      "etag": "0x8DB833F54170813",
       "checksum": "f4fb55f4361d70a43fd6cefd25328accef0cc52790950261f1d21aabfe97132d"
     },
     "x86_64_windows": {
+      "etag": "0x8DB833F54469508",
       "checksum": "6e7f87393fadd04bee062859c00f71bd7379960c15cebd673b35f3c810a0cee9"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB833F543A1FF7",
       "checksum": "3a91d748c57d8510399d17eb14181c8f2803d9e67f7403ad7043a2c7a30c3568"
     },
     "aarch64_macos": {
+      "etag": "0x8DB833F543ABB8C",
       "checksum": "63aa28e5ee984c029da74f51b53d4b3f979d9b70fce3800eb82486af389d3a99"
     }
   },
   "0.39.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB7FD87C90FD6B",
       "checksum": "85a05abe62b607b0b632dc2dfb70f1f0c25d0ba1c917ec5c57e4aba226617d42"
     },
     "x86_64_macos": {
+      "etag": "0x8DB7FD87CA68FF0",
       "checksum": "79d1bbe2f811ddd4f9da83cb827abccc2a2fa851709886c8df9e1dd264d348a6"
     },
     "x86_64_windows": {
+      "etag": "0x8DB7FD87C76675E",
       "checksum": "6e7726628ae1a656e9a889926c49b0d0dc213867e310112e550579512bedac40"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB7FD87C9B78E0",
       "checksum": "d638ef063d33e12e4ee6ebb501655179c2be2a25800e6e8fa53c8d4413f08df4"
     },
     "aarch64_macos": {
+      "etag": "0x8DB7FD87C8A4E2A",
       "checksum": "78a17f1697e12b370c5c8f49665ff81bc97407c54f77d3f6ceae226c323a1c58"
     }
   },
@@ -413,69 +518,89 @@
   },
   "0.38.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB7BE9EF3A7A65",
       "checksum": "51616da543b45d07a8da2aab1d2072f5b301078b70b1039da63a84749e0e3a65"
     },
     "x86_64_macos": {
+      "etag": "0x8DB7BE9EF549BBC",
       "checksum": "e0ebae88a4c5789426e80ab26dcf52f8640c77cd5599b71a5112a62284ed5cf1"
     },
     "x86_64_windows": {
+      "etag": "0x8DB7BEA00CB73FE",
       "checksum": "089c2b15990e541f033159476e3dbcf308ea424345e95b51e716227a1d2eb2f7"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB7BE9EF771813",
       "checksum": "99a1a2ac0bd010fb898ad143f2cdcf50975f21ee2b4e2f4145088f689f974e6c"
     },
     "aarch64_macos": {
+      "etag": "0x8DB7BE9EF467ADC",
       "checksum": "587ca5ba726435b12d66c98750124a8bbcef7b1d8ff2940fba21f122a5813176"
     }
   },
   "0.38.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB7B75C195A9E1",
       "checksum": "d57cdd843412c4a8b16a12c7a8b021494093eb011352aefe4f440592bdbfa37d"
     },
     "x86_64_macos": {
+      "etag": "0x8DB7B75C177BC47",
       "checksum": "99da7486ed705ab88323093dca2aae337dbc201da047130bc12b87f8b798402a"
     },
     "x86_64_windows": {
+      "etag": "0x8DB7B75C18F4875",
       "checksum": "bc7244fd98431a859a24a4959e8871ca5bf3a8d083d729b8e0796d6834d8b55e"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB7B75C18D9C9F",
       "checksum": "1d72a2f199a2e69b5aa2eb75fd18b07f964346c89aa2f584c981c6f70dce1ed0"
     },
     "aarch64_macos": {
+      "etag": "0x8DB7B75C1A501F0",
       "checksum": "a9e89b89d84db129fb4e98694196230322378a50e3cac6cce41c08c3542d64c6"
     }
   },
   "0.38.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB7B323F388332",
       "checksum": "6da012131c66ddea1437a3cbe50cbfaaf070fe0c1ecd6942a198c62d6982d9bd"
     },
     "x86_64_macos": {
+      "etag": "0x8DB7B323EF8401B",
       "checksum": "ccce324310deb9025e97c617ae31ecb8dddeef25aadfff567d63eb73ccd3279c"
     },
     "x86_64_windows": {
+      "etag": "0x8DB7B323EF8DBAC",
       "checksum": "7e2919877f73baea8048f7bdc78b356ec80740b1a6dc8eb443547db10c270eea"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB7B323F0A7B15",
       "checksum": "ce5e02182e4bb975fb217eb567d2e8ddc3447376d4924dca525085956735814a"
     },
     "aarch64_macos": {
+      "etag": "0x8DB7B323F4042A6",
       "checksum": "2fd93b24ccfac269a7a29658b2cc3b69182f23f5a4a5044ac45add1ff42b5ef4"
     }
   },
   "0.38.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB7A9E9CD573A1",
       "checksum": "a518a2e3dc29b7db1af4b463feaee605657acba5cef6b846117bddbcec579400"
     },
     "x86_64_macos": {
+      "etag": "0x8DB7A9E9CE760D4",
       "checksum": "bb65e3a3aad6989705a69e12872f2d9609d0087239b05448d81c129ba7b081bc"
     },
     "x86_64_windows": {
+      "etag": "0x8DB7A9E9CB1249C",
       "checksum": "0fbd229d3399212518b855b05eff8934e1b32c5829075a5263f504e1770c184a"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB7A9E9CE2D214",
       "checksum": "be954f41b39b12f094750b68e084f61ee9dc1e8801133593331be110e2ee6173"
     },
     "aarch64_macos": {
+      "etag": "0x8DB7A9E9CC752C3",
       "checksum": "28f88275dcc3661fd1de3ff0b264853641fd9c030e7e31f6772528df3f90e283"
     }
   },
@@ -484,35 +609,45 @@
   },
   "0.37.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB63CC2AD44EDE",
       "checksum": "a8a824eed75f1030c721a7e91ae79cbd5f48f8c19470d92ec5fd0dff2715add6"
     },
     "x86_64_macos": {
+      "etag": "0x8DB63CC2AFD5389",
       "checksum": "1de7aea5ead649d97c19814d856fab616965177cd77cccc998f4953aa3d8c7c4"
     },
     "x86_64_windows": {
+      "etag": "0x8DB63CC2ABF57EF",
       "checksum": "7f25e3cd03aeee23341174f50ceff7d09266d991298b44353883a98cb1b8f67e"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB63CC2AEDD4A3",
       "checksum": "17d108c5b27df6233fa63c4f78b8b67c040cb3325a7372c9428da62f09ed8f61"
     },
     "aarch64_macos": {
+      "etag": "0x8DB63CC2ADAB054",
       "checksum": "a2c5c7a61ae4ca51140779b1bcc2766d8fe0fad0589828752b29b172f20c083c"
     }
   },
   "0.37.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB63C773C2276A",
       "checksum": "714abf53b00f536bbd8ef1abc88f21fe4172952d39ea87bc5d139f8cbba28be1"
     },
     "x86_64_macos": {
+      "etag": "0x8DB63C773B6C28F",
       "checksum": "b50c4c812eaee6b9797d441f41961cbfbf9d040a6dbe86e1deb560b290ed28b7"
     },
     "x86_64_windows": {
+      "etag": "0x8DB63C773A71CC8",
       "checksum": "c0fe6b6924d493fbea6bae983a5e93219f328919d616a19235161bd31be05dcc"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB63C773E6C434",
       "checksum": "0c77ecf2e889c37b823f0dc856f49a657dc09b9912a586fca267e09f378eb747"
     },
     "aarch64_macos": {
+      "etag": "0x8DB63C773AC6E1A",
       "checksum": "6a23f96288d6733de1cff7d8349dda73df1bcf24a963fead5551059de7f1e6d9"
     }
   },
@@ -521,35 +656,45 @@
   },
   "0.36.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB4C4EA310DC9B",
       "checksum": "da2597babb5948f3eb03939d9d96916db3e164b5c4f4dcf82303ba71356a8181"
     },
     "x86_64_macos": {
+      "etag": "0x8DB4C4EA2E25FC0",
       "checksum": "b5bfb20def399efdf57c4a895db5b0b31d900a7932ad713f1bd1f4bf9ff723f8"
     },
     "x86_64_windows": {
+      "etag": "0x8DB4C4EA2E2FB49",
       "checksum": "8b86ab1663202c434e0062e0d4d48de453f5938b1aaa8f7f5803a1788f3362b3"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB4C4EA320D035",
       "checksum": "6175f249472c1dcedd8edf4a838b3424fbbdfd130bc7871b1dfb2bd5cd3a0bdc"
     },
     "aarch64_macos": {
+      "etag": "0x8DB4C4EA2EA1F35",
       "checksum": "0dc3cbd57a0acce2234505b917020a7e65e93156707211e68b18cf8ca41e5633"
     }
   },
   "0.36.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB3F998134E70E",
       "checksum": "fd5dfb6f63389413984166c05754274d2ac9685f2a54e80619b016d7f527ea17"
     },
     "x86_64_macos": {
+      "etag": "0x8DB3F99812B2E04",
       "checksum": "c55f6410fb879e2fad53ee9599172c40ee9446c5e69c04abc123b3d8346e63e2"
     },
     "x86_64_windows": {
+      "etag": "0x8DB3F99812CB2EF",
       "checksum": "beb17dc24c4e847334f7b4d06400e4de5d7931827f64ea43c1eb2c08f3cb9410"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB3F998156EEBE",
       "checksum": "eda55e333246c6c22dcf624f1e8d38fa154ca460e705dd3f819449ba369fef5d"
     },
     "aarch64_macos": {
+      "etag": "0x8DB3F998135A984",
       "checksum": "9220f02afcf6c016156695d9cdf9914e47bab8e8a29678d39f27387080940be7"
     }
   },
@@ -558,69 +703,89 @@
   },
   "0.35.4": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB39E2BC912CE1",
       "checksum": "a061268da99878970993d988b42de6324aea4cdce437fc1ca46ec51add4162dd"
     },
     "x86_64_macos": {
+      "etag": "0x8DB39E2BC0B218D",
       "checksum": "179234c542ffc1f26e2dffc62884809d1fd0e781b49f95b938410b1b6450c20c"
     },
     "x86_64_windows": {
+      "etag": "0x8DB39E2BC3DE998",
       "checksum": "50ac0366c5c20ace37fa2bef11f8826a5f68c1a28412b7751d89e38d7ce6c709"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB39E2BCE0EE53",
       "checksum": "1a810a4c28934b6e281686ae53fe0e1eba973caec245df8004d4452ffc61d306"
     },
     "aarch64_macos": {
+      "etag": "0x8DB39E2BC1DE365",
       "checksum": "be2a5b698a0a4837a76a7626288a16e1c1f4153463f630845f9def43057f79e2"
     }
   },
   "0.35.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB23832D700413",
       "checksum": "05c109b7174c76345d04903fb6e16548de6ae684b24fc3849dccaa9e940fe5f0"
     },
     "x86_64_macos": {
+      "etag": "0x8DB23832D3A2F0C",
       "checksum": "1a80a4156e86c3d3d6ad4725bc0638a2456363bff4216d1cfd52cae899544cc1"
     },
     "x86_64_windows": {
+      "etag": "0x8DB23832D16CDC9",
       "checksum": "720bdac6fbd322908d9b8d3615ae72d8c79ac4c557f43a6ce7980b7e190d6f4d"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB23832D607607",
       "checksum": "d285f1f0a6688c446049dce02ca612794ea4ad0bcbc865d8aa6cad59e843576d"
     },
     "aarch64_macos": {
+      "etag": "0x8DB23832D40E4C4",
       "checksum": "49f814ef2899c3684564a3fa46c17453850c3105aff1f3a88ff3babaadc054bd"
     }
   },
   "0.35.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB235DDDEED9A9",
       "checksum": "0e472818121e092a41c36cfcedee1021f8e4133465d97b85572448b35e322d6b"
     },
     "x86_64_macos": {
+      "etag": "0x8DB235DDDED053B",
       "checksum": "f8e19f55f37dc43cc9394ccf5ef2968f525e11d68f5cd8025653c3c20caeb6f6"
     },
     "x86_64_windows": {
+      "etag": "0x8DB235DDDBDE5E5",
       "checksum": "023561f7af69f27a0185a58d6a5aecf5d402430bfc865db95d80b83f364ab7ec"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB235DDE0DF5D0",
       "checksum": "9c584fd4a55e6d8ae5edc5cf26bf87388eee2634f98af5f4653e3136ebbc619f"
     },
     "aarch64_macos": {
+      "etag": "0x8DB235DDE36FB84",
       "checksum": "4b597e335aaaeebb62df1a1cb395fe10a53d0877e3fcbb872cb67e033b92a6a8"
     }
   },
   "0.35.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB21FC5B713028",
       "checksum": "e5bf6ea8fb9a9b236c8b03415a33e524e6721414a94786853be84e8d6a17351a"
     },
     "x86_64_macos": {
+      "etag": "0x8DB21FC5B621737",
       "checksum": "8b42979146ee9b9f064ba1fe6062fe33f5d9e776ff2e96710747fe7dd9a727e7"
     },
     "x86_64_windows": {
+      "etag": "0x8DB21FC5B3B0D03",
       "checksum": "454e10f765a5e5d3c8de29f0ddc5f74f33f9127d70fc8d7a41cd0c7b1bbd14ee"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB21FC5B676D9B",
       "checksum": "1fcba163e11d34bbca766385612e593b4c69ff23826ae18c8720dd09e05b23ac"
     },
     "aarch64_macos": {
+      "etag": "0x8DB21FC5B31BF91",
       "checksum": "28bef4e5b980e78b311bb8d25ee0c6f807d6d40736782438682c6308b2be9010"
     }
   },
@@ -629,86 +794,111 @@
   },
   "0.34.5": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB0D4B4203CBB7",
       "checksum": "ad0296a8f4614a57e107df57e4f1f0f25ac32aeebdc201396160b5d046c26f55"
     },
     "x86_64_macos": {
+      "etag": "0x8DB0D4B41FF5F8E",
       "checksum": "1b23e31fe318115bfcecc4b8025b8146d2c1e160092629c930feeffd02d7e802"
     },
     "x86_64_windows": {
+      "etag": "0x8DB0D4B41E9B7E0",
       "checksum": "c98ecc413a40fd275d3d0aaaa245169926cdab27de17d732a9709dad9491fb3c"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB0D4B42246E58",
       "checksum": "21dd3aa277e35184fb6c4ebca899b7c4ddbb2a25035edee75d0c927443d5f7e3"
     },
     "aarch64_macos": {
+      "etag": "0x8DB0D4B41E7BC5B",
       "checksum": "42bd63c2436bbcd058d7fb38bb540a4cdc576e109ce90f607103159dc5bbe1bf"
     }
   },
   "0.34.4": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAF8925A3F25D2",
       "checksum": "088d41a1b13b4623148119af9a3c2f618794170484294c210d5acd64f94a5cc6"
     },
     "x86_64_macos": {
+      "etag": "0x8DAF8925A09298F",
       "checksum": "74a1751e335ffde8385fb415365290b81d26f3509007a0cead1f62f8bb6d0e37"
     },
     "x86_64_windows": {
+      "etag": "0x8DAF89259FC0C19",
       "checksum": "209e751b693f1c076fbd3d204af01bcb5c10be3f9dd99106bd14145e98de01fc"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DAF8925A56A217",
       "checksum": "80607da90a920448d4361ad4993f7c5e770f3e8b6062d492ac00dd2eb558f256"
     },
     "aarch64_macos": {
+      "etag": "0x8DAF8925A02C1DC",
       "checksum": "bb052fa8f0cc995c09563adb07fb554a5386c2ed1152ba97a76734ed6ac55c4e"
     }
   },
   "0.34.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAF887EB1D0464",
       "checksum": "aee0a7ee92e67b9cc3d8d215dce4e0985c1239a1e674fbb987ac9e719f969ac8"
     },
     "x86_64_macos": {
+      "etag": "0x8DAF887EA640890",
       "checksum": "5127902352952d5d913aafa16b65a52d3dd7b10f2f0f8c984b2d177f427f6c73"
     },
     "x86_64_windows": {
+      "etag": "0x8DAF887EAFC13B2",
       "checksum": "fdcb3c85e11b90ad18f2a967af6a259c881adbd895582a675ab5fd87798d05b4"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DAF887EA94123C",
       "checksum": "507541fb2580113e2933ea34c5afe28bfb82cfb61650fa05827dd8c9981242da"
     },
     "aarch64_macos": {
+      "etag": "0x8DAF887EA64A4B9",
       "checksum": "038f0d391fdcf33214f0cd2793377c5673a39ebf8ff3a19225afd320efb0f8a2"
     }
   },
   "0.34.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAE2ED7A3AB863",
       "checksum": "dd5833178a7986acaeea8abbac687754f3ee7ce39371ac55c3e17113938027c9"
     },
     "x86_64_macos": {
+      "etag": "0x8DAE2ED79D9E27B",
       "checksum": "b7d1a456d34cffcf010820e3986b3ebd5d22614556a532dc57f4a25ed8bab6a1"
     },
     "x86_64_windows": {
+      "etag": "0x8DAE2ED79B8F203",
       "checksum": "a3a06a8d1a6a2801db11c605b603401c0e5ba8dbc0e65a55c666bdd89fbecddc"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DAE2ED7AF8BB43",
       "checksum": "105c982071ae43c1e207231cd1516f714d29efd79d050f4415e3707d3baecd54"
     },
     "aarch64_macos": {
+      "etag": "0x8DAE2ED79CC28F2",
       "checksum": "1aae5c10fcdf4e554b8e75a0e2992eac731e15b8de0d9a2f6ed77d26524e5d5f"
     }
   },
   "0.34.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAE16006ABE0D5",
       "checksum": "227572fbcb761310dd21c2286fdc56a033f408919706895f7bf3913f241cf63a"
     },
     "x86_64_macos": {
+      "etag": "0x8DAE16006A13413",
       "checksum": "e9907275ab476897a72f99e279f137df0cea81b63a78da9367d3027ff072b18e"
     },
     "x86_64_windows": {
+      "etag": "0x8DAE160068091BF",
       "checksum": "29da4f68d07cab10d0d90fdcf671c3ccdda15503ac5aa5c23c72534064b0e0b4"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DAE16006AA0C5C",
       "checksum": "ef75ba1e02064a1f22184aab1888d0040e795e996c27c5339694e45cbad0500e"
     },
     "aarch64_macos": {
+      "etag": "0x8DAE160067FF58F",
       "checksum": "21a43b89adc42fc563371b6807642c8eb8669e75471a57bef67de99bd1bb7b75"
     }
   },
@@ -717,18 +907,23 @@
   },
   "0.33.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DACB519939971F",
       "checksum": "77c52e21df129e96a7860163029e267f38e705bc7be014b79668ad15f6e0c8e2"
     },
     "x86_64_macos": {
+      "etag": "0x8DACB51994359B5",
       "checksum": "d4b502bb00bd4e3e19657092648883e8d8270de32f61a0ff78af7709dc70b9b2"
     },
     "x86_64_windows": {
+      "etag": "0x8DACB519922B71A",
       "checksum": "98d3e6616e23cb9b2a969975b9c34b4b571e40725b0348d19cebedcb9c584be5"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DACB51992B6867",
       "checksum": "9762ae7b175d68d853daed32a17580b0662a3a46402053d1770ee6e7f355b2e5"
     },
     "aarch64_macos": {
+      "etag": "0x8DACB51995B7208",
       "checksum": "df3a99c68d7229125040e720990d70fcec0e16b64e7ccba266f5771e2e9e7edd"
     }
   },
@@ -737,52 +932,67 @@
   },
   "0.32.2": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DAB5CB2548138F",
       "checksum": "8e8d0f32e5522a61f6251fb3b9c6be106584ccdfdb13008b276c1ee8bfdc6ffa"
     },
     "x86_64_macos": {
+      "etag": "0x8DAB5CB25D54A5A",
       "checksum": "5abcc7e2f99b98a629b73ded47ca84bc851b4f6ec35ff6df496c2eefd569c55c"
     },
     "x86_64_windows": {
+      "etag": "0x8DAB5CB24F9FF32",
       "checksum": "e4c0916438a11b18b1d6a3ce7c4e23f18998648d39247fa0b617c9863dea6d11"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DAB5CB25FAF52B",
       "checksum": "ddff520568958b6dfeac83105a913db7247188035a0e1af12d4100d0c0d631e4"
     },
     "aarch64_macos": {
+      "etag": "0x8DAB5CB252304E4",
       "checksum": "ec909acfc179b064e7d19e130c1aa1bdf0350d929b9a04dc6f6b5ce84432eb69"
     }
   },
   "0.32.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA9396CBBFC1B7",
       "checksum": "def34c9b2846a4a3675f324eee97b82d1834e522bfd42476ae91a036d2d1ded9"
     },
     "x86_64_macos": {
+      "etag": "0x8DA9396CBC872EC",
       "checksum": "b5ddd3a179c974b3b6c01187281daa40235f07d2dc5c8525de042430c3ff7ed6"
     },
     "x86_64_windows": {
+      "etag": "0x8DA9396CBAC8AD0",
       "checksum": "9532ec060da2d4415d417064e84bb97dbf066f163b1252cc0b322c6b9692d74f"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DA9396CBD4F41B",
       "checksum": "78d5eb14fb337d6a026240aa999d31ed7ee94b0e77a5d7aa0ae6a8de7d38183d"
     },
     "aarch64_macos": {
+      "etag": "0x8DA9396CBDEB690",
       "checksum": "ea7d0595027c425751749e293bf31bccc343a8e270b23868d94f7f32d604a267"
     }
   },
   "0.32.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA9375F023F40A",
       "checksum": "c339d67de7b2b119590629440b9809deb4f220b38c2f9bfd4c41af330731b901"
     },
     "x86_64_macos": {
+      "etag": "0x8DA9375F0BEE367",
       "checksum": "6447c2bbcb61aca4d32bba3b677b5a741d7d0b36f001ec0d12c71982ff5c51ad"
     },
     "x86_64_windows": {
+      "etag": "0x8DA9375F001081C",
       "checksum": "910c047191d1d2ff6177713dd3b199b02c76ac5e9f202128b52f2a015057488e"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DA9375F019BC6B",
       "checksum": "2e164b3d1481df5b87bfab3c3dc91cbc34127fade224ba3b90e747090a81b2fc"
     },
     "aarch64_macos": {
+      "etag": "0x8DA9375F01C7B19",
       "checksum": "11596c9edb64ecec199268477c6938960ae2c7e5b0a6776d4c97bd2f453fd479"
     }
   },
@@ -791,35 +1001,45 @@
   },
   "0.31.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA89C31FEA3EF4",
       "checksum": "50ac53a230b44ac4c6f1259dc7223fdfa142bb0b8f15626008b2b770e7ee8e6b"
     },
     "x86_64_macos": {
+      "etag": "0x8DA89C32008E616",
       "checksum": "dbdd120419cbba2219c27eca188400f02a025671c827148292708ecd3555a46c"
     },
     "x86_64_windows": {
+      "etag": "0x8DA89C31FAC2D64",
       "checksum": "e39935a409d58c985de3d9b6c17d60f308d36b149da2665ae771d490b0c4f65d"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DA89C31FF2C93D",
       "checksum": "de1ec7294ddbaabea485ea1f40801d48888d86b6d260ecf4af92467b9d97d5a5"
     },
     "aarch64_macos": {
+      "etag": "0x8DA89C31FC493ED",
       "checksum": "6d03dbe17dc0ceaecaba3a0a1779d64381044c93f9bf48b2f45841f81d8dca6c"
     }
   },
   "0.31.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA8898CC645B1B",
       "checksum": "7e7b8617b357c6925534f35f3c8f9b76b19884e665d7c3c30792395e8334fa86"
     },
     "x86_64_macos": {
+      "etag": "0x8DA8898D744D7C9",
       "checksum": "cb8eadc09f4a6a6172a6724e71e4484e04233cb59e020160bce1874018d6f3a1"
     },
     "x86_64_windows": {
+      "etag": "0x8DA8898CC756F97",
       "checksum": "b46e46d1b2dbc8d838787f0e8e1567da9ee676e683a907c5257917a3b8ca6f25"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DA8898CC696373",
       "checksum": "62785d92dc11d17b164f9da67f6997c2ec694a5f9345b041d95856efbf3d2e2e"
     },
     "aarch64_macos": {
+      "etag": "0x8DA8898CC82B40E",
       "checksum": "f89c577c39a201e47eba4143c39edad4e55943a07057e3663cabd2b18275a36f"
     }
   },
@@ -828,66 +1048,85 @@
   },
   "0.30.3": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA5E871B3177CE",
       "checksum": "cefdc43953d9e20ec136219a33f9b866d67620e11975135a57562c3beb5b4842"
     },
     "x86_64_macos": {
+      "etag": "0x8DA5E871B26CB04",
       "checksum": "a4e27daea3d28052f2ea9585ed962b238af214d7367abb59c14c711e39de737d"
     },
     "x86_64_windows": {
+      "etag": "0x8DA5E871C6C61FE",
       "checksum": "1d9fa9b6ec8b3afe102a6f9c818114d3f96644261c7dfc4df93dd293d44b2fc1"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DA5E871B2EE025",
       "checksum": "98303e7e7a401423605a30df4d403ad7b250e707b94f150b7e04636979bb9ded"
     },
     "aarch64_macos": {
+      "etag": "0x8DA5E871B2EB917",
       "checksum": "2cdde2accc7fe8f6890ad8632be930987e0e925d8f5e21af0aa2b730b0164c84"
     }
   },
   "0.30.2": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA5BE0A8B371B3",
       "checksum": "c2a2c8dbc7b8f2e5e3ad2d3f7640f11df4e4745a54b5ba066b3bd6288265f6f4"
     },
     "x86_64_macos": {
+      "etag": "0x8DA5BE0A89D06C7",
       "checksum": "48341fd22590234380cd870abf7a4e707875ed04ccedcedf682a7d3afbc88f70"
     },
     "x86_64_windows": {
+      "etag": "0x8DA5BE0A8827DC2",
       "checksum": "0dff7eb4e64d144cd3ce34c34a12bbaa479af3b4835a2d661166bec2072e6b83"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DA5BE0A8ABF8BD",
       "checksum": "62a73b78c98d266e67e98871e596d788bd531a909ce6f56cbe0115714bdb3ef6"
     },
     "aarch64_macos": {
+      "etag": "0x8DA5BE0A896780C",
       "checksum": "2a00262de9becf2d3446d6bec0d3545be27e196fcb550966cee6f100ba972be7"
     }
   },
   "0.30.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA5BD79F7CB980",
       "checksum": "c8b45ca831b742c3555060e4895e4adcd03894a2ad017f0fb9919adb99060197"
     },
     "x86_64_macos": {
+      "etag": "0x8DA5BD79F8C6E9D",
       "checksum": "a6ead43b4533c06c57d6c1222c6098d885cebfa8d1a47af08593f55d8c612d63"
     },
     "x86_64_windows": {
+      "etag": "0x8DA5BD79F525446",
       "checksum": "1139681d31837ae2d73f4ddada4e2a921e73c2f61a881ac46d84c26ff80a9178"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DA5BD79F79107F",
       "checksum": "69875e044b831ba34df72fbc9009f269909cf72d18485d876690ee9f51a5dfd5"
     },
     "aarch64_macos": {
+      "etag": "0x8DA5BD79F4EF962",
       "checksum": "d7635304fef67261a1abb5d864aa963a2958b3f4d0c2653f18e8ee70892654c3"
     }
   },
   "0.30.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA5A3406FE765E",
       "checksum": "8ca8c0d834f8e7c6f7be10c32e1c54fd99067997b0a15f22f598ad492029abb9"
     },
     "x86_64_macos": {
+      "etag": "0x8DA5A3407066462",
       "checksum": "6b1d425284c6b0d162b0c13b02f3183aff4f923662bbc37181b1697582f0c59c"
     },
     "x86_64_windows": {
+      "etag": "0x8DA5A3406CE460F",
       "checksum": "d1faf9884094b476af6a37b121b76d7714c44704a9b2d8b468d60f63b6b59efd"
     },
     "aarch64_macos": {
+      "etag": "0x8DA5A3406EE7346",
       "checksum": "63736a49a7b1bb07a10e653cdb936511f7b5fe30863f6691d0786f5fbe3c2fe0"
     }
   },
@@ -896,29 +1135,37 @@
   },
   "0.29.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA3C2CE5D3FA61",
       "checksum": "be43c8ab4f3c4dc82490d33662307935a0665318e4f0609452cbe9d5f9a2f6b4"
     },
     "x86_64_macos": {
+      "etag": "0x8DA3C2CE5B0E724",
       "checksum": "40429fd1aedc5a7917f2174b37ba67772975bcec26e6d83f53d0c3a3d944d656"
     },
     "x86_64_windows": {
+      "etag": "0x8DA3C2CE5CB701B",
       "checksum": "ff29940506de655e2abf554f707e02a02b2b15219086d29a3d81fe51f32d5ea2"
     },
     "aarch64_macos": {
+      "etag": "0x8DA3C2CE5DCABA2",
       "checksum": "fe82ecd5497e9df8f7304986b16c3e799e4dc81ae237bc9ef4c0c8ccabaa2ef3"
     }
   },
   "0.29.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA3B47A4E247A8",
       "checksum": "b355e3b023dc3d659bba2828bcd1bc3fa976d5cc1512a64df6e606800585e56f"
     },
     "x86_64_macos": {
+      "etag": "0x8DA3B47A4BC9CC1",
       "checksum": "7aa8622987c0374d7027ce56dcf58f9247971131c32d0ad8e50df99a2d0c7d8b"
     },
     "x86_64_windows": {
+      "etag": "0x8DA3B47A4A595C1",
       "checksum": "3188f7d85cf0d0920f1eb955e10ba34033a309ce3de4af67cd89be54dc787d7e"
     },
     "aarch64_macos": {
+      "etag": "0x8DA3B47A4C32B87",
       "checksum": "c6c4bd6817d3fbb8dbb183165ef719d0635f83dc2feab67ffb23d12ddfa831d8"
     }
   },
@@ -927,15 +1174,19 @@
   },
   "0.28.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA33A5A014FFCD",
       "checksum": "c53ff412c826749a3ff7a1c13265bd2012e03130600868656bb3d43c23e9768c"
     },
     "x86_64_macos": {
+      "etag": "0x8DA33A59FF40F21",
       "checksum": "ecabf3729a31f8d8c64d14e8ce841c1638f0b6a60bdc28c147a8462b6b9f1aad"
     },
     "x86_64_windows": {
+      "etag": "0x8DA33A59FE4F62C",
       "checksum": "7a9ebfdd87e31b67432315364430a4b07792bc1aa2ce21ef53b1eb92fcbf060a"
     },
     "aarch64_macos": {
+      "etag": "0x8DA33A59FEBD2F1",
       "checksum": "3d05c3825cdaa3b091c7a768c06b432159f4eba56d6c0ddcf2632198c74afd7b"
     }
   },
@@ -944,29 +1195,37 @@
   },
   "0.27.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA2ADCB827DB28",
       "checksum": "588f4f904fa3f7346d7bea008d9b4f8905a0d9df2da45c93d1f250b5fdaad6f2"
     },
     "x86_64_macos": {
+      "etag": "0x8DA2ADCBA490BB4",
       "checksum": "8099142fd2d78c4122c53c0763b8b0175b00348849f81686a8ce88fe09907019"
     },
     "x86_64_windows": {
+      "etag": "0x8DA2ADCB80C40EB",
       "checksum": "1b61a89716fd9bd4b528fb09bbad832254133a37d27048c49892652d1b260c13"
     },
     "aarch64_macos": {
+      "etag": "0x8DA2ADCB83630EF",
       "checksum": "f6cedbbf00665a917f1746d7ec2b64b42fa07814b3683527ffb5c8d30c7c55a2"
     }
   },
   "0.27.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA25875FC4903C",
       "checksum": "0bb1dd7a4c688bb89d4a70d5b76881f9766bd6e02b32dcb8e7311b7d3a581fe3"
     },
     "x86_64_macos": {
+      "etag": "0x8DA25875FAA7C5E",
       "checksum": "69365653860490b27bd54277218f679426b2365bc12c96b4304cc6dfc0157b4b"
     },
     "x86_64_windows": {
+      "etag": "0x8DA25875FA32A78",
       "checksum": "17b2a984c3fc86265b89bfe3b92af3e4caba710eeb8e365558b63baad067a0c0"
     },
     "aarch64_macos": {
+      "etag": "0x8DA25875FB3F0DB",
       "checksum": "43d78a685f2a5047a35b28a9a666cdc3f127e4ef03f769bcd10c128972bf4b51"
     }
   },
@@ -975,15 +1234,19 @@
   },
   "0.26.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA226E990E35CD",
       "checksum": "d192142a310044178be97064f858f5a9327d73e6ee0ed6bc6b5a90378bf0f606"
     },
     "x86_64_macos": {
+      "etag": "0x8DA226E98E7EF02",
       "checksum": "b7c2acc90f4cb5647e1c8130420d72253797793f3decca16153fef3f17eef2e3"
     },
     "x86_64_windows": {
+      "etag": "0x8DA226E98E7A0EC",
       "checksum": "40a128d102db1e74d65c33d497eaa4d85963b2ea21245dd29d6ade06bb93bbda"
     },
     "aarch64_macos": {
+      "etag": "0x8DA226E98E382D7",
       "checksum": "fec96023e3be1646d44f890b0458e99b4caced6e3d79e185c62f012100f987af"
     }
   },
@@ -992,29 +1255,37 @@
   },
   "0.25.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA2082A32611FC",
       "checksum": "5d9fd5a46f230ebcc19323a718d59f69871a647efddd9ec1c3579ef809c7222a"
     },
     "x86_64_macos": {
+      "etag": "0x8DA2082A3160ECD",
       "checksum": "6496c932b093867f20af035ef2486eee0c4a403bca72718484940353cb3a6840"
     },
     "x86_64_windows": {
+      "etag": "0x8DA2082A3071CE2",
       "checksum": "f980c4b7df17a57f0de3b2db2c86c2cd4becbedd246929253fb36e0190419b14"
     },
     "aarch64_macos": {
+      "etag": "0x8DA2082A312B3EB",
       "checksum": "688f813870d05675a0385b3dd0dbf33396584c9ba3a18e695fd293e56b852238"
     }
   },
   "0.25.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA1FC4F4336414",
       "checksum": "7dcb818e7a626504762685b8f77f49caffdcea4830bc4eaaeed8f3f5ceecb0ea"
     },
     "x86_64_macos": {
+      "etag": "0x8DA1FC4F419773C",
       "checksum": "ec38f0b1ff8c45b31c2b0a8e7bb78dea0767800372b772033a0b6a3bef147ef2"
     },
     "x86_64_windows": {
+      "etag": "0x8DA1FC4F41F42C5",
       "checksum": "9fc64de459d4e790eb00c5a0f0219c4f1f21d2ba1efe2f590012be31300098c3"
     },
     "aarch64_macos": {
+      "etag": "0x8DA1FC4F41BC0D6",
       "checksum": "aad1d3c11403abc1014184df3f848671cc6e68e58a73c9d29c7651bbda4474a8"
     }
   },
@@ -1023,71 +1294,91 @@
   },
   "0.24.4": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA18F1CB49761D",
       "checksum": "1abbc9940b998793d3269f9f40d86d69aa78a7c62664f2889a1c3aba560049dc"
     },
     "x86_64_macos": {
+      "etag": "0x8DA18F1C65D5812",
       "checksum": "186d51b5096a5d5e9f5ba29c780e0d9ef705ec876f1934ee2ffeace6f5f7b1b4"
     },
     "x86_64_windows": {
+      "etag": "0x8DA18F1C64C4392",
       "checksum": "d119be13c2a8d155e28115e95c9d15727fe00c8593ae5ddc6a3ecebbe7f47ee7"
     },
     "aarch64_macos": {
+      "etag": "0x8DA18F1C64E3F18",
       "checksum": "50ba9494cd7179291b9b1580ee1314c5242c604e749915966e8c69c288accf45"
     }
   },
   "0.24.3": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA13F2725B84B1",
       "checksum": "f735d07f51f9d655d0710efcf0288fb9cdb76cc7b1e0f9a58ef79b6a3c6a57e4"
     },
     "x86_64_macos": {
+      "etag": "0x8DA13F2726F57BE",
       "checksum": "c4277c6a9a68e29212ebc4527d46453469f933d78016cb56de0e117c02fe8469"
     },
     "x86_64_windows": {
+      "etag": "0x8DA13F27224C5BB",
       "checksum": "a1cbe8a730de4799462bf755ce2a4ac373609bd05d8a20b620cb9d1318f7598d"
     },
     "aarch64_macos": {
+      "etag": "0x8DA13F2724CE0EB",
       "checksum": "0a72012a150157658b5b1bcae67c4a63575e65e56b2fe6cbc7518c55209db943"
     }
   },
   "0.24.2": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA13215FFD03FC",
       "checksum": "5388a8f82b9c073ee9b854ee67603216ee42fbc92a4d97b45f16a67893a25d6a"
     },
     "x86_64_macos": {
+      "etag": "0x8DA132160084CDF",
       "checksum": "94ac9695cd35c4bb50d57666b09c2b49e975337b1a5f3ddf22970a12a27755e6"
     },
     "x86_64_windows": {
+      "etag": "0x8DA132161CFF51C",
       "checksum": "c1ac6230388ac85ae2117726e7c74cc63cde2cb8ddce4868434aa947eeabb666"
     },
     "aarch64_macos": {
+      "etag": "0x8DA1321602C711A",
       "checksum": "caaf7cdffb3ab22e7936c3b98232cf2bf775d4025a667ff9b5c4da819f07c0ae"
     }
   },
   "0.24.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA10576503B41C",
       "checksum": "3b1b80921f2996b4989e904f90a5cbda77dd510e74c7b94ea7fc46477b310a39"
     },
     "x86_64_macos": {
+      "etag": "0x8DA1057650D9D90",
       "checksum": "6bbcec508d2979596dfe9221ab512efbf39021511a37e1391456708e2cb056d7"
     },
     "x86_64_windows": {
+      "etag": "0x8DA105764E49826",
       "checksum": "78c6b1f511a1be1479901833e7bf7a55da38086d0659c1809f283aa474c81b53"
     },
     "aarch64_macos": {
+      "etag": "0x8DA105764F42629",
       "checksum": "c8cb1cb6da39cfad5ff403f58b58f3a947917d4d1e17a24fd91fc5d5930ee303"
     }
   },
   "0.24.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA0F83DAF1DBE3",
       "checksum": "02de50aacbf9d3cc5fad45b503faba8cdd72626b7baedc7de430dc6db7b63e8a"
     },
     "x86_64_macos": {
+      "etag": "0x8DA0F83DAB85E50",
       "checksum": "12821c811af93ef01e2af304607d2ac5e55b2036a7857779b2c7827df10cd914"
     },
     "x86_64_windows": {
+      "etag": "0x8DA0F83DA92B3C3",
       "checksum": "b87fe1b623a28940ecf059d0fcd828b5adf6a53e956e7889a04135ca2373810d"
     },
     "aarch64_macos": {
+      "etag": "0x8DA0F83DAB8D36E",
       "checksum": "e08348d333cfe135a0eda6e932de01bc08ffd2cd24fc042f02756c079d1b6378"
     }
   },
@@ -1096,29 +1387,37 @@
   },
   "0.23.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA05CCB0E38ACF",
       "checksum": "c57923a76ce8b5b134371f337db437a59b4ea5a86875c55339d366ad409bfd2a"
     },
     "x86_64_macos": {
+      "etag": "0x8DA05CCBA3089D7",
       "checksum": "f8403a2643e23d384c9fc74c23793cf8d556fc1edd0367f56e5c006d61259380"
     },
     "x86_64_windows": {
+      "etag": "0x8DA05CCB0C83E9A",
       "checksum": "ddcaa082a48ced91bf1728ba027bf6ee53750e03c9c21d6846d94e63aa7015df"
     },
     "aarch64_macos": {
+      "etag": "0x8DA05CCBAC2544C",
       "checksum": "abea1615d6926a4f71d6877c0e7fb93e56604bf3085855df8e68a29f9221f6c0"
     }
   },
   "0.23.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9F7F7FAF0D2F8",
       "checksum": "488b0e78e5e607b5ad18ca02cadc55b23ee8ecde214c72881501097ba9b8d17b"
     },
     "x86_64_macos": {
+      "etag": "0x8D9F7F7FAE3DCA4",
       "checksum": "4ed52ac8fe4012bb7932ab0a607b985ea553da50b0095fc974c921879b7c6c37"
     },
     "x86_64_windows": {
+      "etag": "0x8D9F7F7FACDC000",
       "checksum": "bc080beee7d5446e5d5cb972d26bc550e556af0de68f56035ab5cde6a51d0b2a"
     },
     "aarch64_macos": {
+      "etag": "0x8D9F7F7FAAB2220",
       "checksum": "abb901262a597f330f4f8b34a960d04f619ba4bffc30cd66d479df09b46bdbe0"
     }
   },
@@ -1127,37 +1426,47 @@
   },
   "0.22.2": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9EE6341DDFE2B",
       "checksum": "e57168da7a15efd980bc433afba2815697f51c4708313526fe95a25c83a5ba85"
     },
     "x86_64_macos": {
+      "etag": "0x8D9EE6341CAC736",
       "checksum": "ab087ad3c89c11f8dbd60b810012a6d3944acef91cfc3eec028607c137868ac8"
     },
     "x86_64_windows": {
+      "etag": "0x8D9EE6341DC29BD",
       "checksum": "a8740fa8e131fdc163725f712a9d4d5ef426294c9c5d0b672251e950e9e2b2e5"
     },
     "aarch64_macos": {
+      "etag": "0x8D9EE6341C9DD05",
       "checksum": "c93be255a084b552314b011469c8549cdcbf548b147256eb392199cf7e31a611"
     }
   },
   "0.22.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9EDC29A2141D9",
       "checksum": "20178b34672777805960ca56643e74e0dbf07cdca648c923b4292d70131db7b5"
     },
     "x86_64_macos": {
+      "etag": "0x8D9EDC2A020D73D",
       "checksum": "d52e4399a81576181fb9cdaf7f2c12de94b53c88394bed287f07a891020bb634"
     },
     "x86_64_windows": {
+      "etag": "0x8D9EDC29A031068",
       "checksum": "b622edf5318057aa54f278696904cb8ef030cc04ec662ee4bc75f1e849f6f0d1"
     }
   },
   "0.22.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9E5A1F62C79DE",
       "checksum": "cf0f87fca34c6f1727da7737b1d8accdb705e8660023d031a35eced91a87aa9f"
     },
     "x86_64_macos": {
+      "etag": "0x8D9E5A1F60A50E5",
       "checksum": "a37079fdc21fb662e47a62c46e0f53823ebe69025c514ca575a4ac52f3e619f7"
     },
     "x86_64_windows": {
+      "etag": "0x8D9E5A1F5EE688F",
       "checksum": "39fcf2672d551f3c783e5deb3ed0fb79dca5131006c5a56ff86f6b1ecea42732"
     }
   },
@@ -1166,12 +1475,15 @@
   },
   "0.21.2": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9E0D55B93C37D",
       "checksum": "5af30a5668d7ed285b5ac541822055b5dadc728e152af2ae966dfbc5f3be3466"
     },
     "x86_64_macos": {
+      "etag": "0x8D9E0D51859E7E4",
       "checksum": "994b8c219cd8e14fa34ad9acaa988a30b9e6d3ee75b3cfd5e602be5a61c16a69"
     },
     "x86_64_windows": {
+      "etag": "0x8D9E0D71AA44C2D",
       "checksum": "552abd0869c767a26dd6c2e3382b7de8285bcdb72cf11e6601b863458becd705"
     }
   },
@@ -1180,12 +1492,15 @@
   },
   "0.20.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9D953032A10D7",
       "checksum": "5bb80558cba2f2f530e26e3acef2688523ffe826f40794f7bfffd954bd181992"
     },
     "x86_64_macos": {
+      "etag": "0x8D9D953031B45F1",
       "checksum": "f979bde6d728c89d35de1d7b0518a71969fb554ea4220213511b3300f61b670f"
     },
     "x86_64_windows": {
+      "etag": "0x8D9D9530350CD08",
       "checksum": "fb31b4fba385e01dbd6870aa5fdc70e13822b0eb027ef6e61fc23c131661ea41"
     }
   },
@@ -1194,34 +1509,43 @@
   },
   "0.19.2": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9C26CC1F6B0B9",
       "checksum": "2c481ffe7b20c905ec8288281738f080a1bf650875c6c00a8728ca23d6fa8aed"
     },
     "x86_64_macos": {
+      "etag": "0x8D9C26CC1E54E0D",
       "checksum": "0e6db7b5fb20598930f9c920369063bca9ef54714eb5091ca32fa24fc76494a4"
     },
     "x86_64_windows": {
+      "etag": "0x8D9C26CC1CF3133",
       "checksum": "1014c23b7377ab5f7f59b64e76f7cdc46a3bddf2c4ffe540de0c3570fb35e18b"
     }
   },
   "0.19.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B94186A7D484",
       "checksum": "97450b4830e2ea518b9b7d10c0e9cdd84e2f3a146a3b8d62ac6a323b8435dcd0"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B94189C7154C",
       "checksum": "bbaa1862a373095b785ede0d84c8932738611e2fb727747d37329d1a17dbbbe9"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B94179ED352F",
       "checksum": "f468fb9ffdf6d4e0b5cc99ab01137ad644398cc7536406ce5cf81b3562862721"
     }
   },
   "0.19.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B94180722B3F",
       "checksum": "6f3ddfc5eaec246e225c1fd7f6644e537936296673da4699a314af0738108f3d"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9418A6A9032",
       "checksum": "1614ccb04fccf391d57e6fe33bfa5aa390f611b1e41a4a1e03755753d5823777"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9417634FF43",
       "checksum": "8d89467672d75b2ca54564c0491ccd1fc3ec0961a10312dd15c00898b0e4350e"
     }
   },
@@ -1230,34 +1554,43 @@
   },
   "0.18.2": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B941832BB458",
       "checksum": "aa7ec5bec46142c8d851845ee50032c2f2928960669712cb3b45bfc0d000a3c8"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9417563C456",
       "checksum": "34a84bc9f40b5325df5bd797b4bcee7da8485b995117bb46d0dce08b855f1e64"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9418E100433",
       "checksum": "be21c2365600701f240f7bb65a363d5313900ee19f3bc90d4f1b4b8f3ec4e395"
     }
   },
   "0.18.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B94181D61AAD",
       "checksum": "955723c75429c58d5b513d85424421f8a1fb01bac5027f00efa968fcb232fc3f"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B941825EE594",
       "checksum": "5ea30428d69b1e17bf9c4b7090e65d0456750ca17c1a75d97b6b1ba6b3e51068"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B941899CB02C",
       "checksum": "8b50eb23b9931f11874eac96d204250aede11d3d65ef25de7c6b3faeb7d592aa"
     }
   },
   "0.18.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B94181EE330C",
       "checksum": "6f0b460e81ad26cfdb325e8eea01e972d6575ed3a563ffe7fe58f504eacc07b6"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B94180DFF816",
       "checksum": "ee5913f242f176f6097269499d42a359a5f47be3ad9a4ec2136c335b9de6d6c9"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9418D03C4CB",
       "checksum": "cf35c8fad60a08ab282b27b7cd7d33241c81f24b58c4f480774fe3371a72d649"
     }
   },
@@ -1266,45 +1599,57 @@
   },
   "0.17.3": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B9417BFCB4A8",
       "checksum": "dc8ee039ecdcadd2b5abe5c1b96e220ffc04aeb43a6b1461db5fc3940f18884d"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B94187E77865",
       "checksum": "7630e976f9100898100f47ca6399885049be5c1efbdba2e5b9aec798b1c84531"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9418CF9B427",
       "checksum": "9c98092ec4af5bdbaccbb12d2532e4506d21dbfb0704fd64bc4488a37f4f1695"
     }
   },
   "0.17.2": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B94173E106E0",
       "checksum": "4c40db2ea98c8c950568a4883054ce950ee523346936ed9e200e3b2ae86b0e3b"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9418D466949",
       "checksum": "1dbc3c47243d4a55db719a7bc67218eabf8693d14b3e54dbf7eab6c9efed6493"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9418E760A07",
       "checksum": "322af517b437ab2719f66993f6b1dde6fbfc885cb541846b8a311f022f5e0519"
     }
   },
   "0.17.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B941732C296D",
       "checksum": "2cb7a12d5d66bbaccbe544036feaefe3e0844ea93144b416bef3bcde072c1c89"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9417BFD77DC",
       "checksum": "f7521a86cdf708c8cdd8404cbb184945b78e338cbfccabc14659dbc199e02c2f"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9417D995EF6",
       "checksum": "cfbdfefcdc1955cb563b9a09631bb42273f78c43417c4ae9f960da2f609e944d"
     }
   },
   "0.17.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B94181673C95",
       "checksum": "0369bf22e6bcff3da8ae72b15f7b3b7d44fb9bea91cb989a29c95eb47fe42086"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9418156010D",
       "checksum": "46a503f99ba936d0c346d793d64db74b0cb762843dcaf2ff0a6ec21c81a95158"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9417F3B1197",
       "checksum": "7b8d6457421310f673e6f09da6428de4f7bb5431ee06cd7a9d3a2ff42c7eb94a"
     }
   },
@@ -1313,34 +1658,43 @@
   },
   "0.16.3": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B9418AEC0930",
       "checksum": "89e68f2ceaaeec4713c01177452789bf27189665beac40fe61bd819f549fc748"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9418D272619",
       "checksum": "f2d9a05a8b110ef62891d5de3c5e4d6b564199a41c7523176ae19e0d3b4bd8c5"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B941891C968B",
       "checksum": "3fd4ae51efcef46d9ee039ea1d2f0e2bb2e45e2d6ed5be6f5eb81034c03f99cc"
     }
   },
   "0.16.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B94178A888FC",
       "checksum": "a8c6033e3efd0a7bfabe577b3de33a716e73aeff70d485f13e537ced143dde76"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B94182C53971",
       "checksum": "6461ceec32865a7c5b237536c0ac97af6a23c0a15c8fffd1b0d960db543727a1"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9418AAFA556",
       "checksum": "0b17c5f0419ed3cc16f661fc981338649cf754fa092022043316ab2ce353153a"
     }
   },
   "0.16.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B94187DD67C3",
       "checksum": "65b8580d046a92cffa2f3b6a39d16e470a8af61caf45953d80fdd257c13995fa"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9418506E512",
       "checksum": "965cad05a308765009cec2489d60f53f981923a3ff6504f81667dba408de20c2"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9417A920F77",
       "checksum": "52a7cb13346cb85a9c47cc96a27033c97eb124920d24f2a93a52d875a297c09b"
     }
   },
@@ -1349,23 +1703,29 @@
   },
   "0.15.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B94188B9C49B",
       "checksum": "12bc594c74e8a1e73da2927bca082acbc6ae7b04b84f212a15c9df400ffd35f7"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B941807E857F",
       "checksum": "58dd524e22a390b9fb852c0c9f62d96d7804ef0b95744f4ad82f47696e21780f"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9417B338ED9",
       "checksum": "484e9677ee711402213ff496f3674cde7f746ec100fa498c3fb98256bb151090"
     }
   },
   "0.15.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B9418BA66417",
       "checksum": "3ab70ddb0d1218eec1facfcabacf2d9732e070b04f324f837eed8463ea10703d"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9417A5ED204",
       "checksum": "18f43b2a861b5a9e3d27f4ff911449c15cfbf518f2a43e51b8d61d36fa787f7a"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B94182922309",
       "checksum": "60e900f82de60940baaeb010cc571f2ec24929a61bc29be65c81e64a7818ac19"
     }
   },
@@ -1374,23 +1734,29 @@
   },
   "0.14.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B94185197FF3",
       "checksum": "0946e3fae7212e80379241ea555d3570f297423f227b1b9e568552fc4a9b8a3f"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B94181BFAFCD",
       "checksum": "62cfcc0d3414908de9b05a9d3d18f9ccd3a68b7e3dc4a3b25aa5ea3c9f3c3d21"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B94187418CD8",
       "checksum": "6d2094abeb6b78faec9688d24ffad34e89a9bfce91939567fa52af89e99822d3"
     }
   },
   "0.14.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B9418032457C",
       "checksum": "18be4651601822e425de7f536e56f5095b257ffc0fdc019759bd967d8f888e1f"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B941794B19A7",
       "checksum": "bda9f9da62e9e1cc1e297ef5f3b8890bfb00420eed87d30af514528a5ad7873e"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9418CE34946",
       "checksum": "d57a6cf154294b23190d7354e3b2b1cc2bed67539b5f8c1fffb896a9d81e4fd3"
     }
   },
@@ -1399,23 +1765,29 @@
   },
   "0.13.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B94174D41CA6",
       "checksum": "219443b85b843b820f97e8d590a6bda750ad7fcefb62ab07030992583eaa410d"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B941761805A9",
       "checksum": "0b3eef74ba6488ded3a86ebbbeb456aac1a2f892ed3fb3666b04bab3dc565e43"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9417D9D7D0F",
       "checksum": "56db20b7ffcc160e7aa6790eaa7196e064afa43376468e41528456150a98a29e"
     }
   },
   "0.13.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B94174E753AA",
       "checksum": "632a12524ff5b312582b3ec651d810bcad3610b0b8efddcb6f8cfc7890d56f63"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9417C78D745",
       "checksum": "1ee3a23ae7cec968d517417a1189a4248dcb7506ed6e5792a7f69998ecf8896a"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B941884C93F2",
       "checksum": "26e5923deaad1ac1b5068f2461ca52ce2cc550bdb2dae5a061349981acaea750"
     }
   },
@@ -1424,12 +1796,15 @@
   },
   "0.12.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B9417ED8DBD8",
       "checksum": "ff8934e44b5a42601a14d3a60c29259e8b3a1ebb132e1d6db5741857a86b3384"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B94178EB2D79",
       "checksum": "25adadee882b3ada134229562673a2b5d0147ca165ca029390985701223a5e15"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9417D26FEF3",
       "checksum": "f39cbb93196cd56ff7e0124baad4cd8a9950cd373dd24fbc1e6a5845943f7fc4"
     }
   },
@@ -1438,23 +1813,29 @@
   },
   "0.11.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B941745C6639",
       "checksum": "842ac6cf2d15062a9c5be2918f028a58d00740db0c2b9d3a25672f07d98a23c8"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B94177ABB09C",
       "checksum": "8b1ef2a93feb9f4c39cea5a2b4afa0ab85b475222ebf0e725fc9416a3b9a1224"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9417501407E",
       "checksum": "044091ef7a114674d90eeb472307ffcb9170141486b0b21e67aa33370f1dc078"
     }
   },
   "0.11.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B941856BD990",
       "checksum": "f396e88900c848f55507fbca63207d84c1485dce11fe8b77f4e51e44b284cb4f"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B94178BDBB8E",
       "checksum": "42e3d244663027691d36856862cec86876236ae2dc1a2b19f8307082584117a3"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B941867DBD72",
       "checksum": "f3db441a7c4e5390b89aa87d7de76052e2aabe1fdfcc0edbe95c1188daa6658d"
     }
   },
@@ -1463,12 +1844,15 @@
   },
   "0.10.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B9417FDE3E6B",
       "checksum": "d459ace41a816314d6cdc90c7eba44c40079d35520f10393d4d87c28248f9b64"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9417977C864",
       "checksum": "85805951f5828930c2b93b381a3f468f82bc82c4b339e429388aa74b9aa5fbd1"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B941793A052A",
       "checksum": "580514a27ae1ef1c880e0f84124ff63419ae115e05ffdd7723f28d2b8d4bb00e"
     }
   },
@@ -1477,23 +1861,29 @@
   },
   "0.9.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B9418FB6BF27",
       "checksum": "d8f8490f56661633ce7c569b14e1c551c5d2a72879f6b6107d877586643977ca"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9417CE5B9D6",
       "checksum": "f0b8f1b2854ea193b9e5e9d1c093b5a3e7cc3a7e4d9fc9d86c45d9666136e256"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9418ED4E4E3",
       "checksum": "38c4930ddfc746954686373f3470b4e61d46ef8cc2a73a4c0f6643b7b9cc4fe4"
     }
   },
   "0.9.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B9417B728A63",
       "checksum": "0abd4b359bd8d87ef58bdb803770a9e4ab4f9f68f3377acf036624a50df56650"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B941819E7110",
       "checksum": "384d3203f0956731d66156490731038895b339dc3dfc1a3dfdd32a2877ad430b"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B94175295C04",
       "checksum": "9e00c4e5716e652948c21a00d79fa7cebb1c6402f11caf200652461869c779be"
     }
   },
@@ -1502,12 +1892,15 @@
   },
   "0.8.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B9418BE5ADB6",
       "checksum": "294c6d8296206be52032c63c3f28ceb412fe92ad6dee468f02b93316f18a3be1"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9418E4DC76E",
       "checksum": "a61fad876d79493174ca82ae5eaa48233ec7e6227bb883fe541bcb8f4fbe36dc"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9417B4F9E39",
       "checksum": "5d65fbe48f3bdd0e0e90b317b421f843457b33d040a9188211a291bd5c0cd573"
     }
   },
@@ -1516,56 +1909,71 @@
   },
   "0.7.4": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B94185F8266A",
       "checksum": "50e42237094c59229227c0ab8bf1edb93aa54d968ee56d4e9ddcdbcf38dedb0c"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9417A4FB90E",
       "checksum": "82f7e751c9022720421c0a4abb9cafe381f53914fb67c544f5d360611fa947eb"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B941817C210D",
       "checksum": "b32e601c59c39d1969087f97b705b70e4fc62f03e0c4fc43b1ceb9be0abf3cbd"
     }
   },
   "0.7.3": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B941750BED5C",
       "checksum": "ec6b32a8bb742d9735bb217091431f0c12e35bbfc288238ecd575f3937c41ca9"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B94175598CA9",
       "checksum": "46e4612ecec1082efe776065a3907d78242eaa1d83a2d547adbf607180d9de45"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B94189B7D547",
       "checksum": "55e460aa7eac5d994d1c8220ae622ef1d57f0d18baad6bc0f778481a7bdb7ae2"
     }
   },
   "0.7.2": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B9417F9F69F1",
       "checksum": "39a07c31b7305240eb43aa3ef2f542e17d4535aa64c1f1042795dd5b56b75400"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B941814206CE",
       "checksum": "cb13d54c8306f29a1bceb681cbeaf0d65c61328dc235ab6f3ccdcd760e37fc17"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9418A8A488B",
       "checksum": "691018ca617e82a19f4a51aab98943dfcba2273161913de4dc6a3a162cbf6be7"
     }
   },
   "0.7.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B94180577B40",
       "checksum": "640e4bb8e63658fd35bd4a10eedef1f7e690bff32cd2337087d620608b981934"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B94186D5466F",
       "checksum": "f56566a30726536c640a2875f17b16429ad039e3971a7f7b672693e417e432d7"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9417F6C0572",
       "checksum": "96a8c376af1fb441b63275bc12536bcf34cb2eed53ccef8c8e91e2ca1a430192"
     }
   },
   "0.7.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B9418554D283",
       "checksum": "b1f559d28e3f0bc2385d17b2d28102487e231228fe0a40ae69e772065375ade1"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9417F234759",
       "checksum": "1cadbaed4a98ee4e43fe44f738a6cfc297c9c2d1bf8aa4b645fd7d74ef0891c3"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9417F827055",
       "checksum": "0bc70c5f6cc5352992500da972b679bfe5bb5d879ef952a619005f3bb1e7fc9a"
     }
   },
@@ -1574,45 +1982,57 @@
   },
   "0.6.3": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B9418A0FFA75",
       "checksum": "dbeb29cd5877d52e603265e85f6fd26d0a122ab4c8de66a93cb24e09d5da23bf"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B94186978337",
       "checksum": "8349d972336612ca0ff6ec2b0661a0c20c13058e2e73062a732c607310b3638b"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9417E9F84C6",
       "checksum": "1d575a2fb8d04a5ba97b10126eadd677f626c78c698a6cd2050cd065333a5c84"
     }
   },
   "0.6.2": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B9417BAFB173",
       "checksum": "dfab688f5a2306e7ca1d0f58bf245954cb6805bfb3d87b90d3d75991e501dd7d"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B94177DE9FF7",
       "checksum": "ee108f30f596328b57f759d9a2b22914925649e9eb9a6bb4710a86e558aa9b0f"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B94185B07993",
       "checksum": "cc4e493e64a775f358b68c63309f52cd15ae8a936a5aa59433298fab703a6d85"
     }
   },
   "0.6.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B941755EBC0B",
       "checksum": "36b6719ffbc608c7a9c2fec6be99f76e88e8ff81a89d45e010e694cf610048f8"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B941839785A6",
       "checksum": "f81875512f36502121206bca934d3d7077ef69e134969d0e5e7b3ae72bb0e04c"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9418D2B1D1F",
       "checksum": "b63e086bc843e5cfe3b783f9fc3e8c268bfc349108c8e4ffd9723016dd3840c2"
     }
   },
   "0.6.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B94183F0E31F",
       "checksum": "1cd56f16b3f9c27f3c40fcb00b38363a3955c0c182108ee943c5e6fa13a7ea9a"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9417CBBF0D8",
       "checksum": "97d242531da2eb7e028ec4e11e4473cdcc4c104424c600c4f4fe2a438d18368d"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9418DC41244",
       "checksum": "11edf871da3166822bd5a393f02370d6d7b8a3614e0f5b35863fb3308c0ca253"
     }
   },
@@ -1621,100 +2041,127 @@
   },
   "0.5.8": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B9417DDACB2C",
       "checksum": "b7ded26218ca3e7b1a80675e025e34442dd5d0315fbe8c11b9095b7b9a8d814b"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B94181A108BE",
       "checksum": "ca5c77573d2c544e4bb1e587de8412183eb1c3cc0bf1dde4ee704cc17e35239e"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9418AD57744",
       "checksum": "bd933781b7fbf3c3ded040a46dee86620f24a526a5e3021da0544879d52f7e3f"
     }
   },
   "0.5.7": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B94181E951BB",
       "checksum": "a82061612937efb631d8747f457ac109f5cb2d8772c1d66c8659bc12f29c11f9"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B94185DA428F",
       "checksum": "4ecce05eae076826f7d07a69a10052d616597d9fad6074c498eb3ab0758279d3"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B941813278C3",
       "checksum": "d695d210d4d71a08549b17f5ec72fc772e748503518af34cc9f5d1ec8a470b2c"
     }
   },
   "0.5.6": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B9418C84BC75",
       "checksum": "8d31183001ae3bf9f151f93b91dc374adc0fb286d8575cfd71ff01e287dc8016"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9418D6389F0",
       "checksum": "20564fd3ec4a133b740b0836d5fe4956e6e91f39811b8e22a4d8cf81edbe100d"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B94177F6DF59",
       "checksum": "4a65c42aae195eceb6fcbab13cf81a6659e7e48dae331ebc96ff008e34755da6"
     }
   },
   "0.5.5": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B94184D888E5",
       "checksum": "7f4be451f682b7992f4db4c127054f9aa9ec898ceabcfc8f175ca977d087bb4c"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9417DA9D748",
       "checksum": "1a7c632ff1ce1db195b665d0101855fa484f01444b6090b0d5b60c27e04f36d7"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9418DCE22EB",
       "checksum": "9a6caaecde718d30bd27fa5faae33032852fbb6841af4e6067cc76e41767baff"
     }
   },
   "0.5.4": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B9417C7B20D8",
       "checksum": "f1640b238846294b07018b668e8767f538636ea87edc5f337c7614118db9387b"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B941828CCCBB",
       "checksum": "ac5831987da30eeca49708897b355b532f552e392e8ed80fc5c858fbb9e56f55"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B94179F2648F",
       "checksum": "e77b44ef859ebab46134c60242dd8f7ac2b2ae6bddf5d295714762ca756e9095"
     }
   },
   "0.5.3": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B941829111C1",
       "checksum": "5a87236acf7dd142209a2c64f2d4716515502643cc6b1e4a4fa0e9570fc23b4c"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B94174102635",
       "checksum": "6d81cacbc118cc3b31ad834346ddebf455a7c91a852c1d9e4e99d41a63664628"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9417629412D",
       "checksum": "a2cd2bad9d6e04ffa204573701526f646463e55208792d1d1a46e1b9bd2d2818"
     }
   },
   "0.5.2": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B94180DE4AA4",
       "checksum": "0896aed3e0de22abaa38466d25db00af8898d980dd8fa3818b0ba92a10ec3f47"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B941812A8AAC",
       "checksum": "e8cc4823b008a67ba9b5259a51a344cbb303da747d44be084d91689c25c3772c"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B94186949D73",
       "checksum": "a08eb51b8bba3e7426bedcdba468772e4628d6a6b3a25f88228abd9248122802"
     }
   },
   "0.5.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B9417F337196",
       "checksum": "7eba6068def0b5e9e647a02e1521a6d1c9e20d761c110bbb3f6badc8e41f0925"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B94186FF5D79",
       "checksum": "1ce1b0d31c6fa1f61ca90d82271d05dc25f4962da31b7a95b728121ccf3f8b89"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9417F565DC7",
       "checksum": "9d2bb5e1860355717ea94f95f244aef34062dfc06f6ce0ff55368fcff8bc1efa"
     }
   },
   "0.5.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B941889133F8",
       "checksum": "51870e9586d1e98ddac92cc4334ddb628c2af0743ede0ccbe389d761f07cffc5"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9417BD53546",
       "checksum": "683035b9b5f16acb20d2e103f46d22017620d6f1c6615f3cee8088836204f3d3"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B94189E91737",
       "checksum": "b7386738a41620b8389c61808f1f5b814360d4f4bd6c4acb2108295ea44befa3"
     }
   },
@@ -1723,67 +2170,85 @@
   },
   "0.4.5": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B9417527FCA9",
       "checksum": "47ebdd71ba513fb18cfb0f19b95a6cecf27fecc8da9c17b7cf75bd608f5022f8"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9418953A400",
       "checksum": "24acd6779c997573ba614d89bb11a53094340f6038bf25bd4c48c139bc76ea43"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9417D4E092F",
       "checksum": "2a5be2768156ce4942f30b730881b1f892356098d61ef8711e723f0326e3609a"
     }
   },
   "0.4.4": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B9418D6B50F9",
       "checksum": "0ef7044896f80504e1bceec17ee22657226227092a0ee6cdb063757956affcea"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9417481C308",
       "checksum": "987a0a7b4e2d703bb51735455d577790a23b6847877a2d9b2c17117e888ce061"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9418A252CFB",
       "checksum": "2ee76ccc05fcd725d01a700a1131c4f7fcecf24ed66af3ea51f48389ae778b62"
     }
   },
   "0.4.3": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B9418591AB7E",
       "checksum": "b377462db6778f77bee112221298b88c2d1fb541304af92657de58f9eef27e93"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9418A9B0EEF",
       "checksum": "a4a9904b4b95ab8133b5cb358645041d9430b12c7b7295a227c1e3a5915a4739"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B94184747EA5",
       "checksum": "50edf5c0cdab46e773fc2e035f2db75cb319f32d605136994e1c0c96e6d89627"
     }
   },
   "0.4.2": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B941824E463A",
       "checksum": "191d5666593022917b0c51da568da5ddfe6e5d964289c49a1b67408ea6b82229"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B94183ACB835",
       "checksum": "0f773b0d775fa2da5f6188992e614fa7befbd52a673ab605a8e73bccc62b410a"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9417A07490D",
       "checksum": "023aa3c0fe6b3b6902bbc3c551bb9f9e43299dbba8fda70521fdb096aaac45aa"
     }
   },
   "0.4.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B941739DC62F",
       "checksum": "6d3cd69790b871d479169b0d1688bbbf9b3bc6fa40a39a6f8b3769e5dbcfabf2"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9417D4160DD",
       "checksum": "bd60676867e471408af6f0026f61252dff781c47e832fa0e8934c5c5d513de15"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B94182938267",
       "checksum": "1f74eb93069e0fa75f7aca3b3aba74605bcdf9d720428f062cd74056b168e857"
     }
   },
   "0.4.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B94186C19A43",
       "checksum": "2fe30f09a2f517476a957f67936580b388389b9d569f4d9e71ee8e979d44c71e"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B941832B3F3C",
       "checksum": "c979afea954822f40390cbcf76ae048fdf4165bfedad7ffdb48f59429a27cc49"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9418321559C",
       "checksum": "a4251a400afe347e60647e1e1585a532328550f14c03badc09cdef27b0d5f535"
     }
   }

--- a/manifests/earthly.json
+++ b/manifests/earthly.json
@@ -26,35 +26,45 @@
   },
   "0.8.14": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DC898036907B4D",
       "checksum": "9c184536faccf2e16e92ad06d2a2579e4b3ff6aaf6bf4c2f72b21228a6903bc2"
     },
     "x86_64_macos": {
+      "etag": "0x8DC897FFC054806",
       "checksum": "09d749a4f5b9d71acb803ba229086b28f447ac2080492106f6f51536a64a0760"
     },
     "x86_64_windows": {
+      "etag": "0x8DC89807141A969",
       "checksum": "3244284dc9648d7cd3af350ab4a8bfd4c63b0e0e16e656c3e249fc1d58fe7e5f"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DC8980535E3770",
       "checksum": "a88786778964eb74b6b5db44734a4630dcedab49c4ed21fe432e9e6d08ff116c"
     },
     "aarch64_macos": {
+      "etag": "0x8DC89801984C346",
       "checksum": "0a0154bb94ef4c8692737156a74534d369947be1a4558e81603be3d2b4328d7b"
     }
   },
   "0.8.13": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DC7F5FF4E42C3C",
       "checksum": "5e1d7a41cd7a5c22f7c5c71f08e99cab3964eb604ca223b36312c755fbbce4f8"
     },
     "x86_64_macos": {
+      "etag": "0x8DC7F5FBA6D141D",
       "checksum": "8d50d07d24794fa284ae78a699c45df540e85347ea108374b86df45a7800ff55"
     },
     "x86_64_windows": {
+      "etag": "0x8DC7F603050FEFF",
       "checksum": "8201bcdd20272e4e68c56ce3b070fd488e410aef6be1e75b3b1992b4cdd0caaa"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DC7F6012229473",
       "checksum": "6b33bb767f34a94c49fc5db668b3f5936daa01777f3083a217f73b8aefdd7859"
     },
     "aarch64_macos": {
+      "etag": "0x8DC7F5FD78F1F62",
       "checksum": "8d4e2055a761b07f77b11deb2f75914fe20a7bc033eb1115d9b74731df0d3593"
     }
   }

--- a/manifests/editorconfig-checker.json
+++ b/manifests/editorconfig-checker.json
@@ -38,41 +38,53 @@
   },
   "3.0.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DC54967F3BEFBA",
       "checksum": "debda88bcf5048280101b743b3104732650c8b49a2a017ed815481c817cfe13f"
     },
     "x86_64_macos": {
+      "etag": "0x8DC549663BF24F5",
       "checksum": "9e4b4e1340e905bfe0b993fe1343e95e0714eb8b715e35608018a8420866a60e"
     },
     "x86_64_windows": {
+      "etag": "0x8DC5496CCD13EDB",
       "checksum": "902556a8558108f910834f3e116f778e4a6710dbc74f79a065039ea52abe4d25"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DC549684C470C1",
       "checksum": "59de9965c7b2629112b158bedff3f132115bd53fd14e3b477cc3a5fc77233e6b"
     },
     "aarch64_macos": {
+      "etag": "0x8DC54966905DDEE",
       "checksum": "d7f0d4fbc05cee0afcb7debc130f2dd133fbd2a03ba80efa0d21fd19d774bf1b"
     },
     "aarch64_windows": {
+      "etag": "0x8DC5496CEA80BFE",
       "checksum": "b845ef4cd75fe76233f5537111bf24f9aeb3fc69f0aa90a4ebf306ad8028aa08"
     }
   },
   "3.0.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DC3C3FCCBF9621",
       "checksum": "8e2f3c5fa4891542535185a4859c5f92832bc11821eb03a081bc6bd87af5a829"
     },
     "x86_64_macos": {
+      "etag": "0x8DC3C3FC9D55B3A",
       "checksum": "d331806227c1a1ed96ddd34eceac51bd1cef0121f78bdb09d509771f6e5aec79"
     },
     "x86_64_windows": {
+      "etag": "0x8DC3C3FD475C8CB",
       "checksum": "ff171ef63361bbd783622ba778a83e6fe5d6615e8b9e9e9c2f2c177e89dba499"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DC3C3FD0E61D19",
       "checksum": "edf1d12ba1e6ff70090f063e7937081b49ba6007cd02e45f8329bbf965ed609e"
     },
     "aarch64_macos": {
+      "etag": "0x8DC3C3FC9B59AE9",
       "checksum": "35324d5914d147cb51859e49c48909cef22ae448fca407b9d39f95dcc77be109"
     },
     "aarch64_windows": {
+      "etag": "0x8DC3C3FD4E1CCA2",
       "checksum": "40b382a225a345e28f575010b637a372eb004ba3f1544341df0fbc265d183ff6"
     }
   }

--- a/manifests/espup.json
+++ b/manifests/espup.json
@@ -26,18 +26,23 @@
   },
   "0.12.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DC8AED2BE0D3B8",
       "checksum": "2c89370a2cf2eaf2d300439d5f15fa89ae71d635b027965b1325effc8d84b383"
     },
     "x86_64_macos": {
+      "etag": "0x8DC8AECD493C43E",
       "checksum": "00867da14720005dc0ef174e93164ca2934126840be7ddb7a9eaa2c17e940555"
     },
     "x86_64_windows": {
+      "etag": "0x8DC8AED2FC37463",
       "checksum": "a7d128180d30e1d351c63a02436de8a75a8b90479fb49ce23b4eaadf03e637d1"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DC8AED040AE074",
       "checksum": "b7259c225ad713f94b73e4f86f7daf37e7c02ba959b00a3f2f8327fbab639247"
     },
     "aarch64_macos": {
+      "etag": "0x8DC8AECE15DA083",
       "checksum": "a91717477c816bc10b75a250a3d415ee1eea329dcc9a8bddb70d73bc4ebc521e"
     }
   },
@@ -46,18 +51,23 @@
   },
   "0.11.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DC23DA2E311E04",
       "checksum": "c5e61c9a680ecb68f2b35ee17709c08cce7806b8a5ea0c37ac0979a71fa4f549"
     },
     "x86_64_macos": {
+      "etag": "0x8DC23DAAD52B3CF",
       "checksum": "c2bcb7d6203728ba11fc5b3e0a5a0596257f575f33a2b07b312b7adc7ca2b0b0"
     },
     "x86_64_windows": {
+      "etag": "0x8DC23DA483C7216",
       "checksum": "f760eb7111d38d6044caf831cf64512b311a565b225f6fc24d867afd7826179b"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DC23DA111B0B2D",
       "checksum": "72dd9d2b6505b014283746f5e9aa477ceab067670a3d119e04fd97d7b7300c4e"
     },
     "aarch64_macos": {
+      "etag": "0x8DC23DA2E956279",
       "checksum": "6bdfc6d8787c23b03e3b3b4112c354621c93123c56ab4b53ffa869f2b9d1df9b"
     }
   },
@@ -66,18 +76,23 @@
   },
   "0.10.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DBF582FB237D43",
       "checksum": "ca70fa0e2b491fcc9a4d6b96d7a80866c01de4d55ce3c5725d1890735f264aea"
     },
     "x86_64_macos": {
+      "etag": "0x8DBF58356F6EE40",
       "checksum": "8aac2148dd41f717a968395486b4c903c1efcc1533aba581a678bfe662ecb8f5"
     },
     "x86_64_windows": {
+      "etag": "0x8DBF583093D8EE3",
       "checksum": "1cb2a856c5604eb4bba0be5c8dfdb395fe2ecad97037142069bce7d6ed8d3b06"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBF582E0990759",
       "checksum": "3ca7f300faab743191cab7f037e1341f88c0503265decb3408ba9173c9b96a4c"
     },
     "aarch64_macos": {
+      "etag": "0x8DBF582F2BAC95C",
       "checksum": "9eaa530208633d686840e647c613ea8ff6a69fb400b3ebd9a09d13428db36811"
     }
   },
@@ -86,18 +101,23 @@
   },
   "0.9.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DBE1D55D8C2FE4",
       "checksum": "a07e4759519b5ec216fb7f8ae8f078f632ba570bbfb218729f5d6e7e57752601"
     },
     "x86_64_macos": {
+      "etag": "0x8DBE1D57B346BEC",
       "checksum": "fadeeb8e570f52737d738797e29a13f5a92e56095c60eb1b623a17170a49cc48"
     },
     "x86_64_windows": {
+      "etag": "0x8DBE1D5BEF9C415",
       "checksum": "259f58c87fc13de5d008579274e060b06c4beba66c9e3cf95f1fa6fb31230534"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBE1D5C43602E1",
       "checksum": "75ee11f57c6aaa51dd3f0e5925355a3ab6686922721fb1608fd5c34fab3fde65"
     },
     "aarch64_macos": {
+      "etag": "0x8DBE1D58E6F6902",
       "checksum": "c60aeca657dbf31a90ef1f76dc99d197cd9ca2201dd1b5812bd1f2c6f553a53f"
     }
   },
@@ -106,18 +126,23 @@
   },
   "0.8.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DBDF8621745174",
       "checksum": "b1edd222e9ba62c689dc020e7871a762140f68e83da72a3d27b7e78baa226359"
     },
     "x86_64_macos": {
+      "etag": "0x8DBDF8554F10E7A",
       "checksum": "c28fdaaffddf50a74bf13d75546284c328dfdc6e56494b92d6ade845fe0218ec"
     },
     "x86_64_windows": {
+      "etag": "0x8DBDF8549714CC7",
       "checksum": "ee27fcc80f950fecd84fb87611227f9e264b87991824d497ce9147afd3e2dfa0"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBDF85C1DD60D9",
       "checksum": "0479c7b05d6d9e484b68732977f5366619cb4302b0d454be1496242cfcb47af0"
     },
     "aarch64_macos": {
+      "etag": "0x8DBDF8561C4A871",
       "checksum": "c3fa06787c2445889881fbe6dbd3fb14a8f2289729683d4999c32471b639d57f"
     }
   },
@@ -126,18 +151,23 @@
   },
   "0.7.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DBCFD830FC86E7",
       "checksum": "7b471314d7d61b5f6d4029c51dab9fb778cd6a16d997890c9ace05046af95011"
     },
     "x86_64_macos": {
+      "etag": "0x8DBCFD771BAC8BF",
       "checksum": "c22afb7e46ae384e3a331db8c566d962065c8edc4a898dfa6ec214250325f62b"
     },
     "x86_64_windows": {
+      "etag": "0x8DBCFD7DC41F92D",
       "checksum": "e7e63cdaa805225af94d02d8f58c25c189d345c14d74fa81cba40bb35c4b7d77"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBCFD7FF0D5B4A",
       "checksum": "ae270f69f631d595faad2721adb278581ed0b2e427ad021448832d29b5eeb4c9"
     },
     "aarch64_macos": {
+      "etag": "0x8DBCFD8096B66E7",
       "checksum": "8ec65c9a2bb7b0f94edb4585cfff020eef3e56827c5466b5d56bcc67401469bf"
     }
   },
@@ -146,35 +176,45 @@
   },
   "0.6.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DBC4BDC55B689D",
       "checksum": "3c158f242397dc94a99bb2582653961f311093d3f67c0015a2913b2b5633bb63"
     },
     "x86_64_macos": {
+      "etag": "0x8DBC4BD492352AE",
       "checksum": "0a04c56f10289d54f0eb9a0c06097b6243f7e76ba78450659f9b35557653c368"
     },
     "x86_64_windows": {
+      "etag": "0x8DBC4BDAB49FAC3",
       "checksum": "cf7285401183292a2f35d84ae09533f3190ebe9eda1bfd3004d8c1c5fcf9c510"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBC4BD23833C01",
       "checksum": "b331abd7166950e1035e5d88c51d2e0e3d1d5a853490967877c61c5fc6ddc184"
     },
     "aarch64_macos": {
+      "etag": "0x8DBC4BD2A37F0CB",
       "checksum": "731a638a05d5349dc32bf6c5e81cf34eddbd7287b992059c3993c6776aca6efc"
     }
   },
   "0.6.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DBC34B72470A35",
       "checksum": "c495a00a5bd88879b2319d1443cbd038048dba6edb208e91c5cf76418dff86c8"
     },
     "x86_64_macos": {
+      "etag": "0x8DBC34BE9FB0318",
       "checksum": "45da5140fe9cf72b0e4e3a8d4e829f2d37a9e7ef8267094565dd47fb4e3fb38c"
     },
     "x86_64_windows": {
+      "etag": "0x8DBC34C09C3251B",
       "checksum": "00859fcb5c0cee75212422c9279867d369177337a4b1194eac3142a112476b7c"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBC34BF9566D04",
       "checksum": "a28ea03a356071aa9a333ae81a8145683f1ba0408f11be614ebbac1066740657"
     },
     "aarch64_macos": {
+      "etag": "0x8DBC34BD99B345C",
       "checksum": "4fe3d8ba0dcaacef4dd76826c6398a8a0d3297f50226fa307e3ee1524ce1b6cb"
     }
   },
@@ -183,18 +223,23 @@
   },
   "0.5.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DB9A556BA37393",
       "checksum": "383e71da20eacec51499bd3c0470abe3ec246172ff034c0384d0a5413dd8d315"
     },
     "x86_64_macos": {
+      "etag": "0x8DB9A55CC79806D",
       "checksum": "748438256097bd82ac6bb528a909c58b2906ff9e1c6c38380cdff8e08bf546e9"
     },
     "x86_64_windows": {
+      "etag": "0x8DB9A55CA988661",
       "checksum": "9ce029d643db3dfdd4d21a99e910632e530b4594d307031dcf2602e307472e32"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB9A55D563F00F",
       "checksum": "3eea3ae14c58dd2321ae885f9f09fbaa71920b56e728237823bf884928f80f3a"
     },
     "aarch64_macos": {
+      "etag": "0x8DB9A55D833BB41",
       "checksum": "ec36f876c9b6f3025d49dcda16e9765e26922b124e4bac8b13d6af5a7519182d"
     }
   },
@@ -203,35 +248,45 @@
   },
   "0.4.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DB57823829B569",
       "checksum": "685da2e7c923ff0ce4a80a4691b2f1fb4661bfb86ac710ba8fb66ee4f1904842"
     },
     "x86_64_macos": {
+      "etag": "0x8DB57860C4A3401",
       "checksum": "71b8264ce5bc6f42ef53d284bfdb3540ff08e79441fb286a502630cc96726438"
     },
     "x86_64_windows": {
+      "etag": "0x8DB5855637C9C6F",
       "checksum": "567e325aa4934be2ee4be2f1d24d1801fc4db78aa7ed09653de18502b851d56f"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB57823E85D4A8",
       "checksum": "c98a7b0fbd45453e9c91bb35791506f9fae2ed768601d1187866546f5349c868"
     },
     "aarch64_macos": {
+      "etag": "0x8DB578248021CED",
       "checksum": "81c5fd62d8fcbd3a0df2ad0b6803863da9a9eac4a717c44e327bad3c13e00e48"
     }
   },
   "0.4.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DB44A49836657D",
       "checksum": "942ad537212676c52bbb8370695cea056148f9577cae54a0721fb596b4f1b6b8"
     },
     "x86_64_macos": {
+      "etag": "0x8DB44A4FB715BED",
       "checksum": "98dfe0a6c64b06baa4565a10ae1af124daceb0b2aa15d606b28284271d8eba32"
     },
     "x86_64_windows": {
+      "etag": "0x8DB44A58ACBCC97",
       "checksum": "1063e2dd3e434246e962a5ec8de355785cd830aa9515f522b0732257e44db878"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB44A4C09CE0CE",
       "checksum": "8ea5e89c2dbf850a5122683c6a9207a38d6855297fe9571277b340b206f3e9e0"
     },
     "aarch64_macos": {
+      "etag": "0x8DB44A4F64F6980",
       "checksum": "ff371b56e16dc331fcdd38e8ef9b354fbe75e916b8cc627bb91870362513ad81"
     }
   },
@@ -240,52 +295,67 @@
   },
   "0.3.2": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DB239C9714527E",
       "checksum": "89d415976f1b97ac5168565915667e325cacf95cf1122a6c0ab287c0f3187ecf"
     },
     "x86_64_macos": {
+      "etag": "0x8DB239D43A9DDE9",
       "checksum": "11ea5b9096b77646319613efaa3e92825253e9b324f1472f7a0902fa9b2e9403"
     },
     "x86_64_windows": {
+      "etag": "0x8DB239F6AA278B0",
       "checksum": "18fed4294e0f6a30f3873bc84d31acdce67561c565e8e44a73f14918eb6c7131"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB239D033F0209",
       "checksum": "952abade1330b9f785b2cbfcd044c58dd9d3243966fba1894d10a031cf78ab87"
     },
     "aarch64_macos": {
+      "etag": "0x8DB239D25A5DAC6",
       "checksum": "670948c4cf2140a0448e702cb77366c52d492c0b7f7763425e75097ba5a45da9"
     }
   },
   "0.3.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DB1E22431B307E",
       "checksum": "b72fce4f9769212bf852631b8d953802324e8d59b064a182726bdd9df4a44a3d"
     },
     "x86_64_macos": {
+      "etag": "0x8DB1E232A65E5CA",
       "checksum": "96aedbc89b35be65acfd536c40384b1dd2231b228a1d160ecb54481c0fd65e14"
     },
     "x86_64_windows": {
+      "etag": "0x8DB1E2A6E83E2D1",
       "checksum": "c98238614b4385fc6e6bd86c26270ddc5f9c71b3ba22e6f45795ba2f18993522"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB1E2278A6B86A",
       "checksum": "9afa1528ac6d4b341f06c3b829f1bff17d1052ba76b4f794d4776905b74a5ea9"
     },
     "aarch64_macos": {
+      "etag": "0x8DB1E22EB58745F",
       "checksum": "705ff26eb909a81e5fce6830a38b4e7dbc833380aa539041bca5c160ed8f278d"
     }
   },
   "0.3.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DB1414E3DC19CA",
       "checksum": "d255da4791a6ddf94f213b2a1e5929143e7fbf19e6e019ff8aab11498a604ffb"
     },
     "x86_64_macos": {
+      "etag": "0x8DB141505345C1F",
       "checksum": "648b8af89d58d75cf5c7becd9b0bf3bfcfd56b83ccc0f139896df0f798bb5d5a"
     },
     "x86_64_windows": {
+      "etag": "0x8DB141583D76400",
       "checksum": "12eb1cdedd4591b26eca904fb7c7e921c919bdad82039dac772f90aaa14bc299"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB14157626E922",
       "checksum": "c02aea392ce6413c7951df2cb7e936f5545c4fe5ed864b7a11252ca469af2ab5"
     },
     "aarch64_macos": {
+      "etag": "0x8DB14157717B5C7",
       "checksum": "540eb8a78ca14dd69189461934a615c3d68510522c4e8744d7c2c1db7ad603bf"
     }
   },
@@ -294,171 +364,221 @@
   },
   "0.2.9": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DB0EC5B2A3D3BE",
       "checksum": "896d36d739ddd246b4d1ab8f3145f8bc32417dcbd75ccd49223d50950be1e78f"
     },
     "x86_64_macos": {
+      "etag": "0x8DB0EC6E52E38B7",
       "checksum": "79bed7ae7a78ad81d6cd190e397d7b312b3f0cea37e3b0bccb99ea8330d9867b"
     },
     "x86_64_windows": {
+      "etag": "0x8DB0EC675720668",
       "checksum": "1eff5fdb51923329dab361132a8a00469864a9f2a12530400d981a59d8e6dfe2"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB0EC5DA2CF9FE",
       "checksum": "108345e27257b3413e15227ba8fdd24326df1c5a56a6774f242863955fc15d07"
     },
     "aarch64_macos": {
+      "etag": "0x8DB0EC71B8D8147",
       "checksum": "199dc49126772dc50692c1688955abe5f3725176e63b454d065e7c401a73d9c8"
     }
   },
   "0.2.8": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DB05F262E2CDA9",
       "checksum": "a3b533e601aa67e3202f4fc007c84927c0b6f1f1864031edf186c62b3a5c4062"
     },
     "x86_64_macos": {
+      "etag": "0x8DB05F309E45C6B",
       "checksum": "9bd4a709f59ab3d95bc25d054fba433724440981313863b8b274109a2aa60796"
     },
     "x86_64_windows": {
+      "etag": "0x8DB05F54479EF43",
       "checksum": "9bfdeeb71cb0215e5af1c83ec89ed662186b096e8d2189205b3f0f7eabb9829b"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB05F25EED50F0",
       "checksum": "721ec39e4bd7cb550e1f296b8441f27b6c4c7e67695b15da2587d53c7d80d80a"
     },
     "aarch64_macos": {
+      "etag": "0x8DB05F2DA01ECF0",
       "checksum": "d3b200071dae4fa03ea0c7a7be357e5d804e313673981bd556b7305d0e8a3603"
     }
   },
   "0.2.7": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DB05DFA65271D5",
       "checksum": "4e7a3aee73826d14d0289b9e93f6e81f3a3de90e192a30b4d5c1664bad3965c1"
     },
     "x86_64_macos": {
+      "etag": "0x8DB05E082B8AD1F",
       "checksum": "d843c37e558446d235ff0d84d6d91f99609fd2d79c8085752885a79673caa9c2"
     },
     "x86_64_windows": {
+      "etag": "0x8DB05E13CE3F0E1",
       "checksum": "4b14ee55d6cb70b9a50963ab1d076c97e71763833bd2a4cf74b2809a232a00f0"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB05DFE8D261A6",
       "checksum": "eaf437be7a7d3a4aba042488bdec31a6e17cd2962efe395a06a5e8bbbd556d30"
     },
     "aarch64_macos": {
+      "etag": "0x8DB05DFEE88F9D5",
       "checksum": "83febbb3b6eb94c4a0aa51e1b3f7a2c7a0c8e7249aaeb1d05f5092bbe3e2a6ed"
     }
   },
   "0.2.6": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DAF57A0B6EAA32",
       "checksum": "cbaf6b8f7849e23366714b2a2319cc1b620519b7398e10413457a4b2447f7d9d"
     },
     "x86_64_macos": {
+      "etag": "0x8DAF57A68E09BBA",
       "checksum": "c45b1876b89960792675d394050456fec504e16f78241a5263f1b77d8758a4be"
     },
     "x86_64_windows": {
+      "etag": "0x8DAF57B1B5011F9",
       "checksum": "2147253593048e7fa0ffebe8a80aa1d6b6e36cad96f0fb361db9000968ddbe33"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DAF579F6477F18",
       "checksum": "dda535c1842e4cac696b287abb0fc938ce457ca8bdddbeed11da58e3e4d45b3d"
     },
     "aarch64_macos": {
+      "etag": "0x8DAF57A35E98590",
       "checksum": "c5433bb294ba9dedc0801509a903e8a025a07efd3fe55f047323ef9d0d435d09"
     }
   },
   "0.2.5": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DAF3D81216C932",
       "checksum": "a2e6282538ef7272166bc7e188f07a46d8577de754d74108f90dd9e079782448"
     },
     "x86_64_macos": {
+      "etag": "0x8DAF3D88288E3BD",
       "checksum": "bf4163499ced01cb3f99571a213571ce7b2384b24bc0d3f5857f87a683782041"
     },
     "x86_64_windows": {
+      "etag": "0x8DAF3D978E3B683",
       "checksum": "41ed36e66e3a92fdf5ebac343249f1d9326ed3ba6c4d18b72d096d8874abdb7d"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DAF3D848E61D7A",
       "checksum": "0835a9c8dd1157780f05e26cfc0b5b5b130085009012cf1abb3b9682a39ce445"
     },
     "aarch64_macos": {
+      "etag": "0x8DAF3D8B0482547",
       "checksum": "d0cca810afae92c2790dea5021c753baccb0d72eba83089b9f9bc61115c4a14e"
     }
   },
   "0.2.4": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DAE1B333A18F34",
       "checksum": "e0f149892ded57167bac6258bb83aeaf78db763b81b8fa0f6f357fa84e0b8275"
     },
     "x86_64_macos": {
+      "etag": "0x8DADDD2A35FE4FD",
       "checksum": "24bfbb5602ed66eee2af666fbfc52c3965e05454222d9fdcefe478508d52a7a5"
     },
     "x86_64_windows": {
+      "etag": "0x8DADDD9A1840A40",
       "checksum": "ea689fd7a48b9002a22dd56587252b419f2e230f268c2f1eaa0f39a5d460b3b7"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DADDD2E13AF72B",
       "checksum": "1dcaeb3e813921f35bde24b09913a7286e23586b5e35961989ae4fa8b6aee684"
     },
     "aarch64_macos": {
+      "etag": "0x8DADDD2FA43336F",
       "checksum": "daf0fd4a3eaa5b338fbbd5d49c117a17fe45cae6600eec992fe7100458926e26"
     }
   },
   "0.2.3": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DAC8A4B02220AA",
       "checksum": "7b864a48e661fb974375bb984dd8078c53dc049bd63e9d7841bfaa474bfee7d3"
     },
     "x86_64_macos": {
+      "etag": "0x8DAC8A5EB63C525",
       "checksum": "4f3758accf1e5449646a7c0e3ce0f3931d4c2989cb9e3eb59f429949cb593db6"
     },
     "x86_64_windows": {
+      "etag": "0x8DAC8A528C8D280",
       "checksum": "72d7503e84ee6c561edc9bac965424b4e81cb693f85a05be5f9a31e3cc7988b0"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DAC8A4D9B5BFEA",
       "checksum": "5624252f61fad0813b398084d94fddf164af3c7f5944b3e5c6fcd47ed91cfbfc"
     },
     "aarch64_macos": {
+      "etag": "0x8DAC8A65D6B2565",
       "checksum": "c3f88dc363a61a2927437dbc272dc5318a43a1c4dcd4e1b263676bebfc6064cb"
     }
   },
   "0.2.2": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DAC88579A72470",
       "checksum": "5adda795d6e0c89a2af8578fda0f483d62c714ba6de309cd85f7af82f9a66f23"
     },
     "x86_64_macos": {
+      "etag": "0x8DAC8863DB448D6",
       "checksum": "9c037538847171eb49a7ebf487b5dec886a6c75958f51be7a32c975697caaaca"
     },
     "x86_64_windows": {
+      "etag": "0x8DAC88589DE5C13",
       "checksum": "b9af83c899681d4590110d0fb552eb73e711e8ad1ff84620e88f14a3502fed5b"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DAC885D187693E",
       "checksum": "ecbaf29288776317591b85ce7114153122351d17ee73a6b6f1a50d7af037f8de"
     },
     "aarch64_macos": {
+      "etag": "0x8DAC8858F1706E8",
       "checksum": "bcb35cdb27cd9658b82e479edd74e7f5245a79e59e60def3bdebb4993f9e58d8"
     }
   },
   "0.2.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DABE57A7E19702",
       "checksum": "ac61ef0e0118650c8cbb9c9288cabf3546bb80a799d6c6bad238003b4de3df49"
     },
     "x86_64_macos": {
+      "etag": "0x8DABE57D9347FE0",
       "checksum": "260d6ac607006127d599b36c7d32f94a3d22b31c9ad191f9f65ccaa09672da12"
     },
     "x86_64_windows": {
+      "etag": "0x8DAC0937BF51D8B",
       "checksum": "f0a05cbccae03154822bf4f7de7bf2a953be6c97d46a61aef3a51fecf2755a7d"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DABE583407CE81",
       "checksum": "cce579d9d222ac01b3944187bb7684538580a875f8fb59d397793039603a4784"
     },
     "aarch64_macos": {
+      "etag": "0x8DABE584142D8CD",
       "checksum": "b6f79fcfc03adffbb4e8fd4ffe6d00a40953d9889b6ffe5e99a5ddbc6c121940"
     }
   },
   "0.2.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DABDDDDC603F47",
       "checksum": "5561c5eca9e4670a6aac1adfac694751abdf0d6f03f93949470cf75a38b67fac"
     },
     "x86_64_macos": {
+      "etag": "0x8DABDDE15413D4F",
       "checksum": "039971e043b91fc41387ab8d3fd7b89af7662602a311e46099327aac0c492940"
     },
     "x86_64_windows": {
+      "etag": "0x8DABDDE0CB4B104",
       "checksum": "dfe83f90798dd5f3997b21e5922d1f96ad7914ca4db8cd3b4fd5068b21fd6dba"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DABDDDE4F7519E",
       "checksum": "c92103b51956dea1bacb423a6d3234a3fd10e5b87e4984cb89e3b3bb18b2c448"
     },
     "aarch64_macos": {
+      "etag": "0x8DABDDE8DDA3A04",
       "checksum": "451b224c090cc1a8d04cbf6c63fd2d21e4e0d5dd918c7dd92764d22077e8d1a6"
     }
   },
@@ -467,18 +587,23 @@
   },
   "0.1.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DAA8516D38D180",
       "checksum": "c450fd34ee089e9ad9ef2aef773f49835b2dbeef2783e819604f47194b5f646c"
     },
     "x86_64_macos": {
+      "etag": "0x8DAA851ED215109",
       "checksum": "e9deb64f10a51d37f00ddfe86ad8c73469d250e327ecfd8bdb5a82823adcd64a"
     },
     "x86_64_windows": {
+      "etag": "0x8DAA851AF21CD60",
       "checksum": "5b5de20515fc0dfdeb68abcefccd9abea7525500f52dfca149a3438b6f7c46d6"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DAA8520F4FA776",
       "checksum": "31df56e1460e34acdc3699f14a1b56565ca83472fde58f9760a58e16e67c2ce0"
     },
     "aarch64_macos": {
+      "etag": "0x8DAA8521242D670",
       "checksum": "56b26580269a7c4d7a5591eb0fdaa34d20e55d5ca5c55cb264bd683867954a15"
     }
   }

--- a/manifests/git-cliff.json
+++ b/manifests/git-cliff.json
@@ -38,21 +38,27 @@
   },
   "2.3.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC83BFF653D2DE",
       "checksum": "0371c0c2fd948a711d05198f719a2ec8ccb2a43ae5e4760394916d5cf6b45c6c"
     },
     "x86_64_macos": {
+      "etag": "0x8DC83BFCD2E9952",
       "checksum": "73ce46c671a593fe1acef725e7816c793968e3c315fd72107280e830eaa55820"
     },
     "x86_64_windows": {
+      "etag": "0x8DC83C0C7E1FB1E",
       "checksum": "90bc9c60b5db44a62fae51fb09e9565e2d460e107df3404ac5384a2f0bdd96d1"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC83BFFF78C27F",
       "checksum": "aed0a6fba4d5b309be98ef71db75928c84c57495d46843791e95870582f0d1a6"
     },
     "aarch64_macos": {
+      "etag": "0x8DC83BFCB5E54C6",
       "checksum": "1fd8e277212db52c791a20b6ecdb993ce47884a1aca3ee3d31066fd29acea6bb"
     },
     "aarch64_windows": {
+      "etag": "0x8DC83C0C1757250",
       "checksum": "059a29642ffe16ad720cb383290564df35bddd329fa34f6d1d1a4f633d6dad48"
     }
   },
@@ -61,61 +67,79 @@
   },
   "2.2.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC71F61EBBF260",
       "checksum": "3a199e08786eeb8801e40c6f2e022e236c1a640eb172695898ded679089eb5cf"
     },
     "x86_64_macos": {
+      "etag": "0x8DC71F68F2B7AB6",
       "checksum": "3efc16a26b1e511f285395a241d338991dc89494a1d3b4fc4c67c99a5b8cedce"
     },
     "x86_64_windows": {
+      "etag": "0x8DC71F6C5C22626",
       "checksum": "9e2956b4ec65dbf48ca9b9fa1815012ca9486c721a143b6eb35412f395f2fd7f"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC71F625EE211C",
       "checksum": "a5484af486d8ac20748c681ae205c698415550783d3cf13d0a5e230c0cca5961"
     },
     "aarch64_macos": {
+      "etag": "0x8DC71F65BBDC8A9",
       "checksum": "0f5b598795b6b6f2c6b7f683559ef90b2cbe59393c88c057892a12713e08d20b"
     },
     "aarch64_windows": {
+      "etag": "0x8DC71F6E1F95701",
       "checksum": "919f5b90966dc90c695ab327cedd840ef2fe705270c3a0902d106abde8110c0f"
     }
   },
   "2.2.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC59AEA664BA71",
       "checksum": "3cf00214bb60269a1d4073c10bc468907e9b92570892817083fdecd3133e5da3"
     },
     "x86_64_macos": {
+      "etag": "0x8DC59AEAA68EB4E",
       "checksum": "59f761954d01ffdabb7db83f3cf49891158a303d9be27898d5e62477bf2308fa"
     },
     "x86_64_windows": {
+      "etag": "0x8DC59AF4C88DD53",
       "checksum": "727c92204c1b214204d9be1e7f6efcfcb236f2cc0bd9e51f51d39e25926648e7"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC59AEA495D45E",
       "checksum": "6e8d262c30c15d9b8b5d4029ce92f7576bfcd83c26a9c1a964e219695b236046"
     },
     "aarch64_macos": {
+      "etag": "0x8DC59AEA65E0B36",
       "checksum": "6f1d4b2c93bd35014074aa1b383fb7c4fe552ca0e241514c10e89da5f09434ba"
     },
     "aarch64_windows": {
+      "etag": "0x8DC59AF2125937F",
       "checksum": "ca0d2dd4e3590c6c78bda6ce5c8275e201da4c1f5a47998de4118dccfdbde01b"
     }
   },
   "2.2.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC50BD98BCB2F7",
       "checksum": "5f4c75d60fe2a8160ad5d4f6bd9fa8d7c780272e1cfae0753c83ac20101e898f"
     },
     "x86_64_macos": {
+      "etag": "0x8DC50BDC54F79F7",
       "checksum": "26d1810e470735a551998f727b87728d9de1b993c14666a018e1f7ba7f5c52da"
     },
     "x86_64_windows": {
+      "etag": "0x8DC50BDFDA4AEF6",
       "checksum": "85f55fe0cdcd7de5410d82cb7417051cfe2eb4051ae8b9bb907ee6ce1329efab"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC50BD97B7B2DD",
       "checksum": "66697436c1f6581458c95ef5187d725a34f6a1fd94e2a46306f85c92a27f7f8c"
     },
     "aarch64_macos": {
+      "etag": "0x8DC50BEC46ECDEB",
       "checksum": "395d50f2657a0c5425e5c24672f9c5247ec36c57c08f485d2b0050dc81270b22"
     },
     "aarch64_windows": {
+      "etag": "0x8DC50BE209806FB",
       "checksum": "11ed1767f0384ed2dc7b37b3f8842ff9a5385fe71ca1811a3615f77b92e2f45f"
     }
   },
@@ -124,21 +148,27 @@
   },
   "2.1.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC3BC476436068",
       "checksum": "ff5a7e2927a4f79bb641e69728cca82ec8d6824b98ec464c7d9b722d0ec7c9fd"
     },
     "x86_64_macos": {
+      "etag": "0x8DC3BC5E2E61760",
       "checksum": "9ace8b0ebf94fec73b9262100a411c00bc8c66730802e7e8fbe373bb1363b4d5"
     },
     "x86_64_windows": {
+      "etag": "0x8DC3BC4F7160BEE",
       "checksum": "c91ee40aa05dc630c43ae0a448ef19c22ccf47754be7696ba7cd76d8d2aa2c0b"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC3BC47C374B71",
       "checksum": "adc0d71795e2a3d3ded03044f80dbfbdf68b094b3e111698974dfe9aa4b92143"
     },
     "aarch64_macos": {
+      "etag": "0x8DC3BC4C50D9A26",
       "checksum": "bcdbbc66327060ef7584bc497adce342ef8f815b1dc46cc183b649b7d0b8a020"
     },
     "aarch64_windows": {
+      "etag": "0x8DC3BC510B2CC0D",
       "checksum": "9abf430ad1f9a536eec6107ee7f6d41e70578b6ad15c3cec7bb2d10db47ed698"
     }
   },
@@ -147,61 +177,79 @@
   },
   "2.0.4": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC33E5387083EE",
       "checksum": "c9f85b8e4db814b3bde86d87e90501df5883df2163a19c773ab353c7d144405d"
     },
     "x86_64_macos": {
+      "etag": "0x8DC33E66C5F652B",
       "checksum": "bdc7033a537a72c3d0551b634e0805869d03a540c4c6d7144b650a60f7776660"
     },
     "x86_64_windows": {
+      "etag": "0x8DC33E58E5111C5",
       "checksum": "ea1232ca6585c7292cebbf8a1742d1b51e305b8a6ce84c1c6941130b557a6c48"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC33E535F8133B",
       "checksum": "4d506fddeae5317cc5ecaca36dc9d1d8ad6a89690355beae7bf524c9cb8a293d"
     },
     "aarch64_macos": {
+      "etag": "0x8DC33E5574C04CB",
       "checksum": "29b2c38ce195cee02c38cdbe0de4c51c68428ef21f0956f5420f59f1207ad492"
     },
     "aarch64_windows": {
+      "etag": "0x8DC33E5BC2CC9AC",
       "checksum": "cf56854d2a5ff935bf09dd7d682b52e2bfeb014d20e75aeeed31f39f433ffbb4"
     }
   },
   "2.0.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC32DEFB73AF35",
       "checksum": "4fd0d9cf6a0c19c3e0f37aed13683ad92994b89ed943fbbd73a137ad9cd56815"
     },
     "x86_64_macos": {
+      "etag": "0x8DC32E020E6772D",
       "checksum": "4e71a0646212301829750e2c3943309ab80c1d7a5a46f368116eb4953b73bfe2"
     },
     "x86_64_windows": {
+      "etag": "0x8DC32DF527F87F4",
       "checksum": "797ce004bfabafce1cb9f991937eb43aa52e5e6adc3a7ca8b37cb058f85ff08d"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC32DEFA841B80",
       "checksum": "50adaf8cf0fd17f2a0657233d9aa07f46c5abef63da6c0e1a7024f61f759fe35"
     },
     "aarch64_macos": {
+      "etag": "0x8DC32DFF0A02073",
       "checksum": "36ba70be562e3e6e73b7bf2977d803a69ffa88db4ccd9d97758043221fc7f466"
     },
     "aarch64_windows": {
+      "etag": "0x8DC32DF4D3B65DA",
       "checksum": "c7bb385a49c3efcdbc65d2e46e2db245def0556579ea75004e405f509cca52ff"
     }
   },
   "2.0.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC31496394C6D6",
       "checksum": "17cac2d43f7e9c01f1f4c060162e07f7cca01a5c65019c39fe3f9ec1be4f6bf2"
     },
     "x86_64_macos": {
+      "etag": "0x8DC314A171E84FD",
       "checksum": "05197004bf24b99de95651ee82fdd314ab633b61f4744eaa389e35efef1c9a18"
     },
     "x86_64_windows": {
+      "etag": "0x8DC3149BD9B2022",
       "checksum": "5b6539ca4fc37c51468cd5b21cf547ba3cfb81247b9c4c768c374532b6bc3beb"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC314960BC52A3",
       "checksum": "a22bbf9afdd9f4b267cf015ff4d408842ade546981918d36bf831edc32161f37"
     },
     "aarch64_macos": {
+      "etag": "0x8DC314A054E59A4",
       "checksum": "4ecda8d0c7d3daac903c3ca02e574f6cb8b4de1eb04f7290db72d536b52d407e"
     },
     "aarch64_windows": {
+      "etag": "0x8DC31499BB6B21C",
       "checksum": "3592542d1fe27a89c375720af8016928cfe1fe6ef25e25d0c55660fd70c4ee1a"
     }
   },
@@ -213,21 +261,27 @@
   },
   "1.4.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBD8827EB558A5",
       "checksum": "44664b357397a832874a673076fa65773c081c255986e163f44d4f9c7021a742"
     },
     "x86_64_macos": {
+      "etag": "0x8DBD8823AE5DEEF",
       "checksum": "a120f4b6104cb6e1c9c37230a42d5359847be2230332ac9989a1285213aa1559"
     },
     "x86_64_windows": {
+      "etag": "0x8DBD88357B1C49B",
       "checksum": "5aa4147cb7862438c61c7d73a6651a48b91dc36b545fd0c61a790b6f71ed0c9e"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBD8828D6C883E",
       "checksum": "664ff97641e21954acc01ab190bf88c519b772f4adee4e3189f1f139bd1a3a9f"
     },
     "aarch64_macos": {
+      "etag": "0x8DBD88256A0E0FB",
       "checksum": "e4e0a0023d6669438231abbb121b86758af4cd1dbd6a1ab736d2438714ad4d5c"
     },
     "aarch64_windows": {
+      "etag": "0x8DBD882EEA0F57D",
       "checksum": "09420ffcae595a3a03930da75b7b4de5e0f5de7d654b65e8a7d30d620813bc13"
     }
   },
@@ -236,41 +290,53 @@
   },
   "1.3.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBC1BF8B9E7909",
       "checksum": "0f9fe4bc2057442f98976948638b54527a673f0c196dda8e328ad9e18666bd92"
     },
     "x86_64_macos": {
+      "etag": "0x8DBC1BF9FE15A42",
       "checksum": "2fb6bef4d649fe9fc6723d83ec2b9b78f76301fa4543e47ccbe5675d2ffda758"
     },
     "x86_64_windows": {
+      "etag": "0x8DBC1C09FAA0D7F",
       "checksum": "52222b33aaad007b1848418c5b2f3dd68cb940490d8088a6018a62dffce066e9"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBC1BF787CDE5E",
       "checksum": "778b9e32f2bdac52e36310cfd74f729d272774cf6bc57ce25371d83b8b98b789"
     },
     "aarch64_macos": {
+      "etag": "0x8DBC1BF40135DF3",
       "checksum": "30dd2d93c9fc25cc4a5a59457021da39875bcfdf444a9baa222ea051bf277db3"
     },
     "aarch64_windows": {
+      "etag": "0x8DBC1C0A09F8E5A",
       "checksum": "2e275941f0acdb4ddb09bb0eebd1d28616f1baff015b09dd6a623a0d90f804aa"
     }
   },
   "1.3.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBA9FAB955D41E",
       "checksum": "05835750f46b95140e868ec7640585cf2957c09ec6ca73e9d20deebb27334429"
     },
     "x86_64_macos": {
+      "etag": "0x8DBA9FB040BFD99",
       "checksum": "9ada21878dec7b4bb85c400fd1a20a4900920453b82d4e3b5fae3450f49fdd7e"
     },
     "x86_64_windows": {
+      "etag": "0x8DBA9FB0A240C37",
       "checksum": "710abbad2dabe602eadffe255e73b62c4a664c314c548ac4e95c33043606cddd"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBA9FA98507148",
       "checksum": "83786afe9668d53a3c31762344ec6981e3d5fe2689bf4d40e0ea0f6fc2afd4a1"
     },
     "aarch64_macos": {
+      "etag": "0x8DBA9FB67B39CB1",
       "checksum": "bd5cd6c64bc3cf1040bac6d33ee2e534228252097ae96a3407ff3ae4468b9afa"
     },
     "aarch64_windows": {
+      "etag": "0x8DBA9FB1B6B2C18",
       "checksum": "d8d8f4fa85e4b1eb0c77dfcb4cc60896f15fa1d08b2a03e39ec62fa41230918f"
     }
   },
@@ -279,21 +345,27 @@
   },
   "1.2.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB47ECDE111023",
       "checksum": "b7ea0417a5f4b854b11156c7098351e3bc144ab2aba4361f2f19f3bf09181140"
     },
     "x86_64_macos": {
+      "etag": "0x8DB47EDDFBA4548",
       "checksum": "27623e65b5e916b620fb37eb23abb27f6b36a7325a1d6f782e5b117b6b0a84f9"
     },
     "x86_64_windows": {
+      "etag": "0x8DB47EDA957A1F7",
       "checksum": "8f8412bc3ae7da3a7ee16fa10fe3b0003ac4bfcafd7d1fdceb744df952a97c23"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB47ECD30784CF",
       "checksum": "256dea5e4ce16bcc1ddbc86658178fc3442683bc59eb4b06ed42e71bc95f29c5"
     },
     "aarch64_macos": {
+      "etag": "0x8DB47EE21145F6C",
       "checksum": "35ddb5442a6c81cb98f6be54acc430df898dabd454c53e143b2085b61fa49ccb"
     },
     "aarch64_windows": {
+      "etag": "0x8DB47ED06275A8C",
       "checksum": "953a247cbf18596f4eaccc49e93df2270293323becf682347610bbc9ece653f7"
     }
   },
@@ -302,61 +374,79 @@
   },
   "1.1.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAFAE448E92389",
       "checksum": "5e761958b33c5f2c22825b25747b489a27189cfcb2df8fd5f346e9e5768576e1"
     },
     "x86_64_macos": {
+      "etag": "0x8DAFAE459BC64D7",
       "checksum": "b63a065b4474a7e22351627dc93e55ab7b5cfe7a07dbca186f677499f8428261"
     },
     "x86_64_windows": {
+      "etag": "0x8DAFAE48BCEC24A",
       "checksum": "f5013fb320cd892f2bdf2f4c38bb984f613a3fc41356eeec1685730a6b580c79"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DAFAE3E8804359",
       "checksum": "fb8931cd95bb1e3038b20905cca7f1fdb88bb2fe76a7aad0e24e87e65bc22bd9"
     },
     "aarch64_macos": {
+      "etag": "0x8DAFAE4CD256D6E",
       "checksum": "8958c8151da2dbc0f5afbf2a91b94e4411e6c916b06ccce9c6d95c8389f6180c"
     },
     "aarch64_windows": {
+      "etag": "0x8DAFAE44EAE1DEF",
       "checksum": "9b99eb9b7945f7077bdf6fa4f442ea5b93131dc8776a4e813c0d1e2169eb7d6b"
     }
   },
   "1.1.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAF26DDC871D5D",
       "checksum": "32f55ea92e959fbd6daf9dff4e01d458d4d6cbdce8ff6f483f9a21d282248416"
     },
     "x86_64_macos": {
+      "etag": "0x8DAF26EF8E367FB",
       "checksum": "b3c6deb2cc7353f0c8df136118fbe010f5eace4409f2509fac84d96c3ff411cc"
     },
     "x86_64_windows": {
+      "etag": "0x8DAF26E692AAAAE",
       "checksum": "c3cd060cd191b2a8801067bb7e58c127f80abb15b142d8fc5ebaef42cec4df13"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DAF27075669AAD",
       "checksum": "95fc1cee46859c71bfad7015ab0465c063060bf5ba4e37f76e2abef9f3dc9fcf"
     },
     "aarch64_macos": {
+      "etag": "0x8DAF26E6DEB29DF",
       "checksum": "3c57c58e81bb9e2917bd1d75157ff120380fcf4a9c890c9de55060bc5f746508"
     },
     "aarch64_windows": {
+      "etag": "0x8DAF26E63664F25",
       "checksum": "6c6245c3b22d21a3abb2e108a3cd9c55c18634c3362c7da49c33d1247d63da30"
     }
   },
   "1.1.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAF1B528C3569D",
       "checksum": "58cf2e55a1ba1a2262a97df29ca6811e2d08a959086c83e3b34ba77357f05e4b"
     },
     "x86_64_macos": {
+      "etag": "0x8DAF1B5588093B4",
       "checksum": "0d307f0b0c1ae1b613325ebb1ce65e52ea6a76ecbb218121cfc4a884c5929603"
     },
     "x86_64_windows": {
+      "etag": "0x8DAF1B5890792EA",
       "checksum": "7ab923986e81012105043da18eb3cc1b4b2628d78c67f585d29f4cceb4753733"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DAF1B570143E09",
       "checksum": "0102623e8bc8922bfa616ef52704875fee6f66354ed57b602721d8a1476c1573"
     },
     "aarch64_macos": {
+      "etag": "0x8DAF1B5A30DB61B",
       "checksum": "581bd8eea35221128c72973a26a7163b04a50270a9aee564fbec1fe42d777f07"
     },
     "aarch64_windows": {
+      "etag": "0x8DAF1B5AB17DBBF",
       "checksum": "def514c24e7752911070adc77ebac318c9b9b5484f6350ec0b7be6d75d321ad1"
     }
   },
@@ -365,12 +455,15 @@
   },
   "1.0.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAE6A636F5101A",
       "checksum": "ef855010b9cbeb635bae4b25815fb82795578073c7fabb2368898938001d21b4"
     },
     "x86_64_macos": {
+      "etag": "0x8DAE6A6C2C5D5FE",
       "checksum": "acac1b940186ea8cb45c6a7396e518b7dc747f9f4678e7206242991c6223bab1"
     },
     "x86_64_windows": {
+      "etag": "0x8DAE6A689C8F10C",
       "checksum": "38998de19ff4116d3f6614a26e5aae26f2100fcc38ce5ae0135e6951ef5e6a4c"
     }
   },
@@ -379,12 +472,15 @@
   },
   "0.10.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DACB11776484A6",
       "checksum": "116b07c0989dddbb6535d24ebb5ccfec690cce0edde76eef36c514d1ae8159a0"
     },
     "x86_64_macos": {
+      "etag": "0x8DACB11AB568B70",
       "checksum": "4370aee41f417b61fba7d226556ee02e27ea343b8bec1ef721e919fbc4410ab7"
     },
     "x86_64_windows": {
+      "etag": "0x8DACB11CF6E3BEF",
       "checksum": "da1f1fad0e24f9bfad810317357c2cd42a61b9f17d11eeff822b12afccda9213"
     }
   },
@@ -393,34 +489,43 @@
   },
   "0.9.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA9E66ECEC6248",
       "checksum": "9936ebc62c220cd644566f04810db9a648b4d31b5e67e5cce61ae4b49de9d073"
     },
     "x86_64_macos": {
+      "etag": "0x8DA9E67C51AB464",
       "checksum": "d6be4b10ad5e45885e7cd3c1f5a5cbc13d50052c237d1f1ee82e26e2405e8b1c"
     },
     "x86_64_windows": {
+      "etag": "0x8DA9E678EDD2DC5",
       "checksum": "1fb43d35e9e08fd55c1a49f625c56403a6a6fe7db1147ac7aed4b3fb2046f0c4"
     }
   },
   "0.9.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA9B22D0FF7071",
       "checksum": "570d70bfba95fd9c3ad639fd8f77f0bb4a086adb648cba12e511705b75bab0b6"
     },
     "x86_64_macos": {
+      "etag": "0x8DA9B236C688215",
       "checksum": "f027b31431edb6f3597012c587a7eee9dea07c55593b492553b2ebbadf85b249"
     },
     "x86_64_windows": {
+      "etag": "0x8DA9B237361F127",
       "checksum": "76dc7749b6f9dda978f2e33e83263ffd6fbab995d5640ff85ada77304c49df0a"
     }
   },
   "0.9.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA7FB885D110AD",
       "checksum": "d59854a93b7eabdaa49014a91b41bc63506943542634bfb8ae6537fb4fea8cb2"
     },
     "x86_64_macos": {
+      "etag": "0x8DA7FB8E90400A8",
       "checksum": "36f2b0dd9d5345cf54b47adec288305afb4915221957cacdac6f266780adb5b3"
     },
     "x86_64_windows": {
+      "etag": "0x8DA7FB94AEB9435",
       "checksum": "afb6961b4096825fcf9eadea19b7d88fd53368345076422d55a5cad4fab0f89a"
     }
   },
@@ -429,12 +534,15 @@
   },
   "0.8.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA64246268E755",
       "checksum": "202bfdc6f4e07484c5e45666936ed3cb878f860b91c3c32d4391fdef0f23c831"
     },
     "x86_64_macos": {
+      "etag": "0x8DA6425308D80FD",
       "checksum": "6635348a949a76c24af9a35a1cf082cdab431ff1dc602d303d841bd39e12c992"
     },
     "x86_64_windows": {
+      "etag": "0x8DA6424D0E2ABDB",
       "checksum": "e555c69240f444a51cf49355dccb6d71543962a75b4022c9e8d64b17d786da10"
     }
   },
@@ -443,12 +551,15 @@
   },
   "0.7.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA25EB7DCCAD24",
       "checksum": "0907b95480d15100ccd1cacdd47729258fcde0d67d317a8e34b7402fb152454e"
     },
     "x86_64_macos": {
+      "etag": "0x8DA25EBC7D18FAC",
       "checksum": "695a2178446e775ca0b7e6d4bc9ea3903800f03f6d45985ab015837ecd59cea2"
     },
     "x86_64_windows": {
+      "etag": "0x8DA25EC7FCFE1CF",
       "checksum": "af87514826ae32f8f0db55d580a9b48f59f0e5834d232bbb7dec5bd401c816c0"
     }
   },
@@ -457,23 +568,29 @@
   },
   "0.6.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA04F28EE4CB09",
       "checksum": "dd11951ab6724b040df359e0461ba2cb6a7310a0d6e42eb25aa2b6fde45c1ce9"
     },
     "x86_64_macos": {
+      "etag": "0x8DA04F2A1255E03",
       "checksum": "b29f16ff20f30fe4f12c691572ada100cab6d47c1c7762b2e142d0be84b41b5a"
     },
     "x86_64_windows": {
+      "etag": "0x8DA04F336806F5F",
       "checksum": "bfc47c94f015517dd7de015c11ef2d36c57fec3217ca00b0f5a7cda81cb60109"
     }
   },
   "0.6.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9EE5D26B7DDD5",
       "checksum": "ba978fcf7b03b4f8d578258f54d8dc3cdd3ac42a1daf1fe53ac67e5e597b035b"
     },
     "x86_64_macos": {
+      "etag": "0x8D9EE5D3248AA33",
       "checksum": "ed35196f5beccf2458d8edbf394575ff7d5e98a4fdb21073493229cc04bbf585"
     },
     "x86_64_windows": {
+      "etag": "0x8D9EE5DB9A95597",
       "checksum": "9380518a867eb24c4f660854bc693a3990a9125238fac646ece5ef527c69b102"
     }
   },
@@ -482,12 +599,15 @@
   },
   "0.5.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9C0143DF08148",
       "checksum": "899f6544c6a6249e232d385def6361d90d46137533f736df375a875e21f31be6"
     },
     "x86_64_macos": {
+      "etag": "0x8D9C014799049A7",
       "checksum": "251c848f7c74e91350861390f2b4d2880bc9570ff8ef12b1d0c8421b99d53104"
     },
     "x86_64_windows": {
+      "etag": "0x8D9C0149DB33469",
       "checksum": "b7272791f5e6de04d8581811abea4f901ad7ad34867048545491f8b8a3cbab68"
     }
   },
@@ -496,34 +616,43 @@
   },
   "0.4.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9D656C36443",
       "checksum": "8389ab46f82cfad4692b81730c7a77fff9061ce5f81784c2f33c910e849b6524"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9D66EBB457A",
       "checksum": "bfa10850ab67bfa1fbc786a5633e824539c9d7040797bfb70f37687ab662e88b"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9D63A48C638",
       "checksum": "e40278d9f780c335dffa01d1134a1bb3be5b2bfb6a130d5f77778c8a57a4110f"
     }
   },
   "0.4.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9D65E4228E8",
       "checksum": "a8f63328b3bf18d34c67e952561e42493c555c672bfcee74a510fb3959751244"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9D67647C3C6",
       "checksum": "37d87460b938b0afeafed0737493b6452cfecff6d73eafc67eac8ae5a159fc60"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9D67841C35F",
       "checksum": "3d3506230d007d1fce40fa007730e9d7e17c2619c5cbc131b6870c1dc22e448e"
     }
   },
   "0.4.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9D670624F2B",
       "checksum": "d3e2f96f98500dd37bf216ce8af616b1fd0bb6f6ab0870e8abccdc0c1c5f5967"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9D6737D4C20",
       "checksum": "3bca497a0b09083f729401285aa0ef519d9d146f55edb90ed0530a8270b8bd46"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9D66D191D0E",
       "checksum": "8c98d2ac3e4a52ec4a875d210b9c6d7ea6504716d66aa62417a5b504aad6ebea"
     }
   },
@@ -532,12 +661,15 @@
   },
   "0.3.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9D67D05C586",
       "checksum": "48df1a40ec5bd4372c966596dfdfb1f38d7bd200890570994729cd61879ae8d2"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9D66FEEDDAE",
       "checksum": "eaa751d4f671f1015d01e09b9f6bd6d81f014b435f67c1d1a341007e2c6a79c6"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9D67069A118",
       "checksum": "361c0a9651e2a0e89294a07d4433977dccf9c6c058ddf2b63ef762deb9866e01"
     }
   },
@@ -546,78 +678,99 @@
   },
   "0.2.6": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9D676C0649B",
       "checksum": "4c692aada1bed60ddbf55dfbc07346e0f821fd94ca93c7a74612ace6dcb9a7f8"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9D677747F2E",
       "checksum": "f2a932feecbb93635d2a55451f058f2a8012527828ad223c04a0ac08d11f49bb"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9D66CD67873",
       "checksum": "d9171c4380307d4a9dc5dc97ac158798234ce35a0939be9a70297193d36b082c"
     }
   },
   "0.2.5": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9D66E36E688",
       "checksum": "3d9484eebdc9af0396569e49804c9aed3ea9a206c00a5dd2ec7aa08550a5498b"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9D673602B6A",
       "checksum": "910b9db46e62a808b9e5b27b13cd76ee60dc965c7bbdc2b8b0ae23065162a8a5"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9D6756F0F90",
       "checksum": "e69b25444520c8a5958762bd17c706182db7786b4ac238f486ba988cb76be490"
     }
   },
   "0.2.4": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9D66E5A47DB",
       "checksum": "8f813425978ca6a4e054f0276917cb2acd1a45efae7503709ba2438bfc433624"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9D639DEC921",
       "checksum": "19adab2ed658792dda0648cae0572897a0ce75dea703df31292eccf3d0f1364e"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9D67D2A5F30",
       "checksum": "de54ac99d7abdff890afdff4f59179d94289ada3556f2dd3227d0f691195b162"
     }
   },
   "0.2.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9D64564EB21",
       "checksum": "59d4ef9c9a1a48e9850b35317ca271366fdcee21630011d5241aacd34b35e001"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9D64A6C2E0C",
       "checksum": "195b95c853c58a677923b5534df887b30de831c99cc977f48adec49345a1a219"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9D67C5442AB",
       "checksum": "50a0bcb7e7600defed3e12511290d79161c2db89d25b5a9a290fe5c313c29b23"
     }
   },
   "0.2.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9D63FF1AFB8",
       "checksum": "3c3def4f6fdaceffe33a7c7007c0a5eaa0992228c3a832b1f9a109c7c7c6386d"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9D67459342A",
       "checksum": "0cc6e3c682d547309fef7ea677695608638f7d51cf43e121cce428001811f590"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9D671E22787",
       "checksum": "3963391f541b7ee9c66d86cffeaa2ce13b5b97bf337038317df14f12a0e21a7f"
     }
   },
   "0.2.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9D6492DC1F5",
       "checksum": "554b4abe0fe55258ef47e24b6fe5032c68b62c690f77216ea6a649d1f29c9a23"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9D6714D503A",
       "checksum": "85017458dcbc33558a7e829f1232e5ad23da3245d880b5a9fadd327449f2e145"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9D65525CF09",
       "checksum": "69a3afee646fe1833f8b8555290096b21aaeacef6108864da9f7d11017791c51"
     }
   },
   "0.2.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9D6508750CD",
       "checksum": "9cdb59382faa8e3fa1562ef1788fd55c092c1fd2e0a7a83ac7926da4d7668a29"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9D654B98875",
       "checksum": "e4845a07bddd6e8e59c2a5e7a1d3ef92b5e10bf2c82926b6ff4a6fe344698e5d"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9D6766C5D6D",
       "checksum": "e512cfdfa4a5246a3381a39a7395e302258ab3ae5110d82da74204779fcc504b"
     }
   },
@@ -626,23 +779,29 @@
   },
   "0.1.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9D678A7A243",
       "checksum": "5a518008ddf3bf8b043a211c4a493eea9ab1faa7f25c49c3c9fd97708782bafc"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9D6722E8EB2",
       "checksum": "8811ef747f77526b0f4ccb9553019b5f7781d9da1c5e2d20d7f0e933c3a80046"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9D6777A98CC",
       "checksum": "58cad1b7758aa9d426ddf85c843f77e9cfa210bdf8323941ee2fd0f70cf136f7"
     }
   },
   "0.1.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9D674D04E9F",
       "checksum": "bb956271fde5aeeed83f72b46f717b7c606289d073cfa0f56bb233c9db32e3ce"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9D67CD37237",
       "checksum": "589d6a7248824a4be55c03bfc2378577bac23ad67e083f2d4e1c9b0ff87b887b"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9D6783ABF87",
       "checksum": "48de883ccc656ce3f9f86b85f63e3974a48d93f73ba0c38726f1f2546a8f84d8"
     }
   }

--- a/manifests/grcov.json
+++ b/manifests/grcov.json
@@ -26,188 +26,243 @@
   },
   "0.8.19": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB81934DB2F6E8",
       "checksum": "1d64e1ec2b46122e605a739e05f6df42ec0d7c20feb632dfdc6beab9e29158f5"
     },
     "x86_64_macos": {
+      "etag": "0x8DB81934C536C65",
       "checksum": "8c4a46740c09ec071ad20eaf916175b8cf7322eacb7c37e905f3d2925690c44a"
     },
     "x86_64_windows": {
+      "etag": "0x8DB81934CC75676",
       "checksum": "33c28588407cc89d1923cc1771ac9bcc625a2b111dbc45395be163a1988e7fcf"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB81934BE26543",
       "checksum": "426bd9e8b0c05c9e804da81416c1f99d3d4bf2b4e903d50db3332cb17f126330"
     },
     "aarch64_macos": {
+      "etag": "0x8DB81934A9F1C83",
       "checksum": "1651b6640142d4feddf6c900af11b8e815f979c53f01d08717465e939eaa7589"
     }
   },
   "0.8.18": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB3B820A0B7BF2",
       "checksum": "43b1b44a79b2fec04a4057ccaf199a1b015e02200d44c8c1a4eff4f2b2edfa87"
     },
     "x86_64_macos": {
+      "etag": "0x8DB3B82083E8F53",
       "checksum": "b5fccffcde800c1bbaec94229b80fc678ad10420d9769b25a447f1c7c5bec573"
     },
     "x86_64_windows": {
+      "etag": "0x8DB3B8208EA8870",
       "checksum": "1ae5759da07ffef41e5b2f9930a70e312c5e4bf8a64fe3a67b05c095601ad879"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB3B8207C33382",
       "checksum": "272a869894d321554b8959ea8d9f90277dee8fe79ebc6da5349d047fccf86b36"
     },
     "aarch64_macos": {
+      "etag": "0x8DB3B8206307653",
       "checksum": "a4b21dc5cc6ecd0ae0cf8016787b1d1b3e59a37d81d685bde45025f98a9a0ca2"
     }
   },
   "0.8.16": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB335C597E90ED",
       "checksum": "c414d6c72c693c103a99ac33eb759fe870c2ebc90486853ce2d72e94f0392853"
     },
     "x86_64_macos": {
+      "etag": "0x8DB335C57CE178E",
       "checksum": "9b6725d2087a0f3e6b65395c2ce5e189e4d54b26b9d28a6a01ad878df56bd29a"
     },
     "x86_64_windows": {
+      "etag": "0x8DB335C5842E71A",
       "checksum": "e4e77816f6ce8c6a09b03f7bf853fd788a084e868ae23cd1e297831b388ce84c"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB335C57334F71",
       "checksum": "4f219438e490665c117d49f23ddd41990bbb423e89e03b59c0e3356df2a47196"
     },
     "aarch64_macos": {
+      "etag": "0x8DB335C5530A447",
       "checksum": "5323fafa4714753eefcbed052971914dcc58cd9f3a4dfc53e5756518acba47ff"
     }
   },
   "0.8.15": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB2CB60143FDC5",
       "checksum": "b4e369090a105aa264c287c1ced52d7cc04ec964179bd8affe05bcb762e75ea4"
     },
     "x86_64_macos": {
+      "etag": "0x8DB2CB60019B363",
       "checksum": "5f4dded36e2a7258f938fa9e6fdde9c887bbde9ba226dca46701a1bcfca1ab83"
     },
     "x86_64_windows": {
+      "etag": "0x8DB2CB6006D1E4F",
       "checksum": "35d9add293fe2a573023dfc1a7c6fe8005ab52dea3f96805f80696851a299e7f"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB2CB5FFA83D90",
       "checksum": "6dca525df8411f456833cfe244eb657c523960140b745fa046aa22909da5d462"
     },
     "aarch64_macos": {
+      "etag": "0x8DB2CB5FE73E288",
       "checksum": "0ef477a66f7f74ce5810327923a1c6b73d9924d5dfb6dc2ba8c927cd2ceb039d"
     }
   },
   "0.8.13": {
     "x86_64_linux_musl": {
+      "etag": "0x8DABB2BDE24F39C",
       "checksum": "e6c9108459ce028bc0ae257f73060f54e30f07e22d003b4c84dd74080a0cc5ce"
     },
     "x86_64_macos": {
+      "etag": "0x8DABB2BDCD3EEEE",
       "checksum": "714c8950635c87270f79cee8f9dd1d0ac9e1ad8ba5722ad9492402c3827a273f"
     },
     "x86_64_windows": {
+      "etag": "0x8DABB2BDFFE9B6A",
       "checksum": "d899981481a0a11cabdb926b61133697aa9691f0dcb164a9c2442cc0d168286d"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DABB2BDC411424",
       "checksum": "f18add0f0e29dcac89dbf1c9f7becd9d490c67fd04780b3d2b4aae5fb5599ac0"
     },
     "aarch64_macos": {
+      "etag": "0x8DABB2BDB28A308",
       "checksum": "faaaa4280a8ef5d8b47f03db7e8bf885847186e8f1135658b3ad763c0e993edd"
     }
   },
   "0.8.12": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA93F1F2F4FF8D",
       "checksum": "e1e270550337ce9b9bf190615fdfc09ba0d7d50b6f62b342ae438665edeaaa52"
     },
     "x86_64_macos": {
+      "etag": "0x8DA93F1EF4D437F",
       "checksum": "9305358569d12aa8a60ebb62a1a704bf86dce0c1beb676ea51c04f0fec761834"
     },
     "x86_64_windows": {
+      "etag": "0x8DA93F1EFD63539",
       "checksum": "1e8b8ff52593294b5676ea56c65547bec04edad94b549bfee03a5ab2133cb599"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DA93F1EEDA9597",
       "checksum": "bb0f521acbecd3f8c30b67cc948de40c65297a34080485815ffa071a43332048"
     },
     "aarch64_macos": {
+      "etag": "0x8DA93F1ED95E9EC",
       "checksum": "fbb9ea6d6ec5017ae3927a7f190083e375ac7d9c2d4e8ebaba1282aa27c23ce2"
     }
   },
   "0.8.11": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA5FF1CEFE1520",
       "checksum": "054641c3e8cbdf78ec5643a903e6fc0560287343e03435e3adfbbb809f282b53"
     },
     "x86_64_macos": {
+      "etag": "0x8DA5FF1CDC28ECF",
       "checksum": "2ad2921873c27d6bc7445731cefe44950bed5e5582eb0668342b3a41705ed592"
     },
     "x86_64_windows": {
+      "etag": "0x8DA5FF1CE2DC41C",
       "checksum": "16a958f907bf4b67b9c6d748dbffa34261b149c3becb8edb3217fe327dfe9e91"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DA5FF1CD500793",
       "checksum": "b18cb035b9d2b13977ce530b282784529cd0bbbe22ac2f4676c95a063e77d989"
     },
     "aarch64_macos": {
+      "etag": "0x8DA5FF1CC0F03D3",
       "checksum": "3288d4b4cd65b8205d8d6dd8ec4696df4cb7d9a66338f29c843926f03f7d3d5a"
     }
   },
   "0.8.10": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA4C4EF265DBE0",
       "checksum": "8afc04b10914fd7ebaad061b5c1d31be0e42b5c1efc65caab21522f517e8023e"
     },
     "x86_64_macos": {
+      "etag": "0x8DA4C4EF11A2AC2",
       "checksum": "c85220cc39ad8ec500fbdda630a819a15353ec836dfa7c59aac3cb90373234fa"
     },
     "x86_64_windows": {
+      "etag": "0x8DA4C4EF18B04BA",
       "checksum": "f5027c2575f39b6494e3a1a14a018c23a32598edf988df9423b880567756a1ca"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DA4C4EF0B8B7DB",
       "checksum": "55710fc9ec4d7e15554992b21407155c99c5647efc7396a80d28a7be158d7943"
     },
     "aarch64_macos": {
+      "etag": "0x8DA4C4EEF676239",
       "checksum": "174d1abf444cf8f513e88d7fe2d07d5e79950d4abd92f7910a4ed173a27f30c6"
     }
   },
   "0.8.9": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA143287D7E806",
       "checksum": "a511886708da766c6441771edb7bb413a02a519f316f1ae51a0df8e5cc71d62f"
     },
     "x86_64_macos": {
+      "etag": "0x8DA1432864885A7",
       "checksum": "8cb9a59e3777784ee8f21300abbd3c9553c9d48b323a77bb3de0a28c81927e2b"
     },
     "x86_64_windows": {
+      "etag": "0x8DA143286EAC6D7",
       "checksum": "47cc04bab3e3955c3a1413ddd8ae969d3e151f6b69946813d663eb0baa6a6718"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DA143285B0F134",
       "checksum": "042d53bf4a00981b0c907072011d862cd2f5b3f23d67e93aa942c2a41724c9b0"
     },
     "aarch64_macos": {
+      "etag": "0x8DA1432842FBD79",
       "checksum": "0e24bff04ca23862a7cdd1fac0d7a70eab6f6ab9f89881b588c26b9cd537e2f3"
     }
   },
   "0.8.8": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA06D79744965C",
       "checksum": "a05051eee645073fcccedcfda0d488f5cf7d80e0374b9b1b7faacde3c966d8ed"
     },
     "x86_64_macos": {
+      "etag": "0x8DA06D795E8BC53",
       "checksum": "7f20d3f1c6a6688fd59d2944ffdcf6d1df8efda768823f163c0313ecc3140060"
     },
     "x86_64_windows": {
+      "etag": "0x8DA06D7964AA3F5",
       "checksum": "94b38042164d7215ae1c09f70652e84548b2bd52fdfa2cf8afb4b77c2e35bb34"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DA06D79550637C",
       "checksum": "6eca03d060097203fc87021de409d8a52c89343937e2fb1103e58b442143ce4c"
     },
     "aarch64_macos": {
+      "etag": "0x8DA06D793BDA31A",
       "checksum": "65ab65121602d1f6afc76c26e91b5db94d0fd3a6e1735cdb547e311687774997"
     }
   },
   "0.8.7": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9ED4ADF9884C4",
       "checksum": "21be5741d96fdf2c6ef8db175c4761e49aa43258de720960c1502cf956df07af"
     },
     "x86_64_macos": {
+      "etag": "0x8D9ED4ADCC00686",
       "checksum": "abf754e22d7f2dfe4506c1bff6c4876b0374d6c3f014e56311b80805bedcc28d"
     },
     "x86_64_windows": {
+      "etag": "0x8D9ED4ADD8E82B8",
       "checksum": "d2758870bc3724e55982c1795aca2b36da3c312dc62e7f8cd322de8fe97eb9a3"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8D9ED4ADBBAA3EA",
       "checksum": "2a07b50f91bcc389b563ef6e101a141323d8117bfa18e6cbcf2329e30137b6f8"
     },
     "aarch64_macos": {
+      "etag": "0x8D9ED4AD880B31A",
       "checksum": "5c6de41fc0c14bc69eae2df82cb5d04eaa265b247b80762c0efb00c7191b4a40"
     }
   }

--- a/manifests/hyperfine.json
+++ b/manifests/hyperfine.json
@@ -30,15 +30,19 @@
   },
   "1.18.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBC57A9695ACA8",
       "checksum": "ef3855ad6a1bf97055a90dc3dfc5d4a48494cb80344027db932a96341d415193"
     },
     "x86_64_macos": {
+      "etag": "0x8DBC57A8EC8142A",
       "checksum": "f421263f160f4b4967d0a1420b06a48cb60e429c610096f99bb433dd719685c6"
     },
     "x86_64_windows": {
+      "etag": "0x8DBC57ABD53EBF6",
       "checksum": "b43c22a9eb5f3b6e85bcf480e6adb986b2b0c27f52db762f017893bb1ad52794"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBC57AAEB40186",
       "checksum": "1174db3a55247a89d8f6161101e15455a2ebdca6948d42e9bc50b78c1d771e4a"
     }
   },
@@ -47,15 +51,19 @@
   },
   "1.17.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB64C48A3837A0",
       "checksum": "563de47d843810de501e3e6bfcb4571a4ff957eab811c2af87be23d1c599ae47"
     },
     "x86_64_macos": {
+      "etag": "0x8DB64C48F4707A6",
       "checksum": "5dfc0b1f2791d4b0b18a0629d0ed85717539bdc3a13dfb1bd2a293f203a92d21"
     },
     "x86_64_windows": {
+      "etag": "0x8DB64C489E1789D",
       "checksum": "496a4ebad0f461e81aafd38bedc339442a1c569c7256ad43cecbff1617cafaa4"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB64C46DE1E47A",
       "checksum": "0c3f3c8f572ae6817a6f95f1983cd285ec3065e4f1b39d7cfc3dae9f43fc1fd2"
     }
   },
@@ -64,29 +72,37 @@
   },
   "1.16.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB2A481E827E1A",
       "checksum": "f5d26e69fd17200f6b32debe0603b0ff8b1c0cdf2f25463be6da9311f6910613"
     },
     "x86_64_macos": {
+      "etag": "0x8DB2A4802A36F6C",
       "checksum": "f19d22147b5307138524eed5eff2265a116e5ecbaab886bbe0eb02e57cbb3f2c"
     },
     "x86_64_windows": {
+      "etag": "0x8DB2A48600465FC",
       "checksum": "12f5ddcc4fd587e3c1084e729a5d198bf6eacef5614a4cdfd557475ef5ef9e66"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB2A47F44C48D7",
       "checksum": "1f441fb7ea2b2f9f38230e56840f801d1b55e38b1f1c164ed24101b4cea740bf"
     }
   },
   "1.16.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB2536651F5CFC",
       "checksum": "99e92dce7faded2e0e931e360c26ac50ec945d7d9bd7a679c341660e8201f71b"
     },
     "x86_64_macos": {
+      "etag": "0x8DB253626132375",
       "checksum": "b4964645b56c2b99bc13318038ff1907260523b4131d5b44c83e73dc3dc23150"
     },
     "x86_64_windows": {
+      "etag": "0x8DB2536872ED303",
       "checksum": "299b68922f2ddaf8ff8d9a3006fb56d42ce978c71d188bf2b7f2bc690346c3eb"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB253613C301F5",
       "checksum": "a3237ed292edd867fdba4284ad86df619147ca1efabf9e16a2ddfc1bb244555d"
     }
   },
@@ -95,15 +111,19 @@
   },
   "1.15.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA90A36B8DA8C1",
       "checksum": "38859f8b7cb61f2d76de888eae36c78fbfcbf791fb0ef878ed2dab2a5e91bfb0"
     },
     "x86_64_macos": {
+      "etag": "0x8DA90A353CD2694",
       "checksum": "a79b6b00c4740d62fe4b2c1eed082db1f4eea07102a7c731135d34815f6d924d"
     },
     "x86_64_windows": {
+      "etag": "0x8DA90A388C92C9B",
       "checksum": "ebfefb5ad2bb183152e0b0e929ec8002e18e31e557d40264fa4f0488afecc992"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DA90A3933F3D47",
       "checksum": "cdab3eea4da4108694855b95cd24fa45a4978eba7b009863c18b4c5d026f6793"
     }
   },
@@ -112,15 +132,19 @@
   },
   "1.14.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA38486D0455AF",
       "checksum": "9d3c53e7da84b41896d4208b722765742af1169a4dab9788321f8597ea159010"
     },
     "x86_64_macos": {
+      "etag": "0x8DA38487BDE959F",
       "checksum": "b6aee0b7c13c21b72a04aef6ca9f5cba9186d8114cae3dbd2f0d1fcb4dca0af7"
     },
     "x86_64_windows": {
+      "etag": "0x8DA38488FEF3379",
       "checksum": "0e38512f7c731044629b5bb9f78f3d348a5906be43548c65b3c459333964dc0a"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DA38486C170C06",
       "checksum": "2f7b88181370e8e6d6039fa549ac32ec8c62fa790db38ad99f4964f3d3e1dee4"
     }
   },
@@ -129,15 +153,19 @@
   },
   "1.13.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9FE9FF70663DA",
       "checksum": "d22bc7a845195e7f53268b43bb91455e6cb0a7e6a3fc7f89cd307f7261bfc985"
     },
     "x86_64_macos": {
+      "etag": "0x8D9FE9FE07C8CD6",
       "checksum": "7050e26f77794b3a283f90ba3a47a340a57decf90b4ebf8fab1d7fde1b4d0e51"
     },
     "x86_64_windows": {
+      "etag": "0x8D9FEA01D1A4217",
       "checksum": "555af098497afe86e8284da95cec50768f865c83b8a26ab204c61088ff8898fe"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8D9FEA0191B4FF0",
       "checksum": "942b4eb9bea5b3a223870337c46d759d7945e6db12c803abfcfc20255ba99bee"
     }
   },
@@ -146,15 +174,19 @@
   },
   "1.12.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B8F4731F71BC",
       "checksum": "b66e7a55fc1b7fd1f6443861f65bde87a4794c4721dee5e11dc0294f27116efc"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8F4609B9532",
       "checksum": "fa1c2a80ac1325682c300a772ac80b6374b1e0c2266a6edaa7fd7363be4a8180"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B8F46704A36B",
       "checksum": "ae92a684d0f72c209eab8fe320cfea877383605a7ed18d72e3096b938c28be4b"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8D9B8F46413E5A0",
       "checksum": "791f92fbf7c94efea520901ce8219e3dc63beb9b54aa07664a72ffbe317c1b35"
     }
   },
@@ -163,12 +195,15 @@
   },
   "1.11.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B8F45B546E21",
       "checksum": "0e7a109e99fe34e9dde0f86597fe0a59bc756cb280d0e191d30acdd1226f70c1"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8F46CB7C2DC",
       "checksum": "28dcab2a94507d36870a5bc2173f609b1a9eb002ee06a45a47eb45be1c5f6a55"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B8F45B93B7C5",
       "checksum": "ebaed320d664d0a496d9f2b4953c80cff708c1571d0aa1170e0211b1ed4a7999"
     }
   },
@@ -177,12 +212,15 @@
   },
   "1.10.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B8F465CAF1FE",
       "checksum": "0010d9cae3a321fc1bd4400d1cb6a5098974ec5f8c808c88a2d996afbc4de0e4"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8F46E524ABB",
       "checksum": "8054528f1556143790debbf96171f5c74d82ca4b759bb9cbcbc5ebfb74b7c571"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B8F46D42FE79",
       "checksum": "2f2d930ae41ce75034d0a988d44f125f58110f77decacea4a0bbb93d26c6f60e"
     }
   },
@@ -191,12 +229,15 @@
   },
   "1.9.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B8F46206AF9C",
       "checksum": "9912746d62d63b224f8c4086c0ba41d15013b013256a4e7706a33030850b7f4b"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8F46D16EBDB",
       "checksum": "d59dc8f59d52ba80b5c7f420e09af13311c9aa1f28b7b3f0c02732f490d69b1e"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B8F467772A85",
       "checksum": "30fcf48a55f680a0157e1f8be7698f028ed28bbd7fdd58ec725562c6d8885b60"
     }
   },
@@ -205,12 +246,15 @@
   },
   "1.8.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B8F45FBB8F50",
       "checksum": "c60cb1de2921abdf4da5da70a89e690a2944f13362176288c20806fa199b3cea"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8F45FACC46D",
       "checksum": "429d51e3d1b42acd838d091bfe6f26179627ae976655224683b664f7551cbd8d"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B8F45C218B09",
       "checksum": "ebfdecd67fbd1a827bf4d5af016b9e40623df6d38524809567a1cb426de986cc"
     }
   },
@@ -219,12 +263,15 @@
   },
   "1.7.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B8F46B8A92B0",
       "checksum": "94102b0776cf61b39439efeb9685e8504451b8adafadaf03b0738a616b23d84c"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8F463420E79",
       "checksum": "ec5ada45adc21066404ea7bd9247ef693ef107362d76ba8c69c0bfde98ce6005"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B8F468CF5BF6",
       "checksum": "49344878a094e0998fb3e0ab808eec7754e02d4e11fac4f64b911ac2bb31026d"
     }
   },
@@ -233,12 +280,15 @@
   },
   "1.6.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B8F45ED12ABB",
       "checksum": "023834d68a1572156282d6354e348d2074f9abb5ace975d91cc845ced2a75d7f"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8F47037653B",
       "checksum": "757d6b59f7862f0fba0b8e8d0cddbd076bc39ce0a0f735c85f414cb9cb7f7bc6"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B8F47275DD2C",
       "checksum": "bad7db58bdaa5b520a79617931ebb29555bd81dca93864b9761197c88de38faf"
     }
   },
@@ -247,12 +297,15 @@
   },
   "1.5.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B8F46DA9C77A",
       "checksum": "38d1e1efa4dfd636a9808a580b111a7baf5c60f3b160d2ce22c719c42a0bdb9c"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8F473358E8C",
       "checksum": "ab638d511cde9e394cd41145191a2caefb105962635babed8e9cb3d18d465151"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B8F46A1DF1E5",
       "checksum": "8e34992ef9ad8ccd12a2212982bc54b918083607d3018a19246f024d0d6bc690"
     }
   },
@@ -261,12 +314,15 @@
   },
   "1.4.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B8F45FEC0E15",
       "checksum": "8ff7cf913d7d85cbcafdb443b815f296ec57a50f9944d41b9788deb69616dccf"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8F471700563",
       "checksum": "d5de1465b4121723715ce0c0e05972ede42dd55ce6f3c07763a60e4a35391212"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B8F463796A05",
       "checksum": "5d993dc621f71ea3d13d0d9f48bc083d3b1cb3325e87f248aa0f58f58b0d19b4"
     }
   },
@@ -275,12 +331,15 @@
   },
   "1.3.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B8F4718EFA7F",
       "checksum": "6f4c3103f7d512a985c925e44ab1509c3d5c5ce02595f6f63690c3b0bfa40e5c"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8F471AFC421",
       "checksum": "2145bc8f3c67492feef7be4344e2390c58af163c6fd0e3624cb7ae64e7528b0d"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B8F45B0B3AE7",
       "checksum": "9821346df3c85433e87052518cd91887137480e5070fa0fb5e160ece54d69c84"
     }
   },
@@ -289,9 +348,11 @@
   },
   "1.2.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B8F46EA9FAC5",
       "checksum": "a8048e3b43b2353ccd654c8362231abc94f213770ce3e527fbbc094d8ddd9798"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8F469C3350C",
       "checksum": "c3af3b89b7da9d7d3ff8dec7bf47e62194f07eba0684be385fc74961f4b2a299"
     }
   },
@@ -300,9 +361,11 @@
   },
   "1.1.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B8F4700BC7BE",
       "checksum": "82d89913bae4a88fd70391cfaa9ce3a21473966ecb4ccb8c44bd5d75b449ca05"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8F471BCBA8A",
       "checksum": "e92906bd910ca4038dbdd4c39d649ce8b777d7367ee00f1139681090860f6e18"
     }
   },
@@ -311,9 +374,11 @@
   },
   "1.0.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B8F46BC2D87B",
       "checksum": "6899615cab465476e6f988e8a3511e364f436e013efa1d3069e80d3c19857041"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8F462A2D8A7",
       "checksum": "c9c1891479f2784349645fe82403158d7284713bfcc1669823bfb4b271f37ef9"
     }
   }

--- a/manifests/jaq.json
+++ b/manifests/jaq.json
@@ -29,18 +29,23 @@
   },
   "1.4.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC7B460BA5B41F",
       "checksum": "fce247e4b9693ff260293bdb7d4ef564f765ed6fe889c42cebfd5d2e36b591bf"
     },
     "x86_64_macos": {
+      "etag": "0x8DC7B4609EE5957",
       "checksum": "f12c87eed86258b226c747ccbef55db95e78e6925eee55fe96e8a5eee4fe69f3"
     },
     "x86_64_windows": {
+      "etag": "0x8DC7B463C8CB19C",
       "checksum": "bb8189ee62b3b467f82e06484a7ab7478f8ddc1cc67ec95b7d2ebc2da38dd14d"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DC7B460011203B",
       "checksum": "2e6449091baf52bcb982e75685459464444ea8f29c7316d246f0bd407670c568"
     },
     "aarch64_macos": {
+      "etag": "0x8DC7B4609E258E3",
       "checksum": "545e26ecd01b44468a894cd6576290cc8f787d0f06dd0ef8cc0b02bfe4c95c55"
     }
   }

--- a/manifests/just.json
+++ b/manifests/just.json
@@ -29,35 +29,45 @@
   },
   "1.29.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC8CAABDCD86D9",
       "checksum": "42c47bd34b511c43a4d51a13c425c0e0f51e59e20b9f390fbd8838b85ee8db1b"
     },
     "x86_64_macos": {
+      "etag": "0x8DC8CAAB93EEF32",
       "checksum": "5415dfcf2640b10823c2157c3f5a634d93f0a4a7005f4955bdcc3f009b406727"
     },
     "x86_64_windows": {
+      "etag": "0x8DC8CAB25E7C577",
       "checksum": "194c49878a502d9b756367e8164e1abf00955cf45af0f1e699ea9c9a45a92ba8"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC8CAAC39CF93C",
       "checksum": "53f43c93497a1ae4045f09fa1b528dd800ce5046ad945f4d3cd92a4fc99da353"
     },
     "aarch64_macos": {
+      "etag": "0x8DC8CAAB287A857",
       "checksum": "075ddcc42de6e90dc46a942c8b1914142563dff49f6e8dd2785da3c263e6663e"
     }
   },
   "1.29.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC8C1E006921AD",
       "checksum": "34a059a0cde8a801ae518a7ca7271fc65709110eebbe23ba768760bf0a0eb66a"
     },
     "x86_64_macos": {
+      "etag": "0x8DC8C1DF9742E8D",
       "checksum": "64991d2b9476d89c936404d5149ceedd8fb19c66b0390aa1e959548d376e0acc"
     },
     "x86_64_windows": {
+      "etag": "0x8DC8C1E53626982",
       "checksum": "5ad04990eb4299ad7e802fe86f85a5c116cb9af13deae87c08ed7dbf49c930d6"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC8C1E01BE30B8",
       "checksum": "2072dc38e37e1bd6331d7f38a8a607f81b899e3f6f2685e858482f9650f762d3"
     },
     "aarch64_macos": {
+      "etag": "0x8DC8C1DEE08F385",
       "checksum": "1c7146005f0e1e8d60c8de38b2c75d86a1b5c199705f645d34b5396fac897599"
     }
   },
@@ -66,18 +76,23 @@
   },
   "1.28.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC8596F5E9B7CF",
       "checksum": "a99cc9115c274af56355f87b979c0ac109eb250b0c8cf24375231c4e679f735f"
     },
     "x86_64_macos": {
+      "etag": "0x8DC8596E5DAC16A",
       "checksum": "7c8c59950541dfbd0a08456d90785c660556898df1e2ac46ab09335ca763f6f9"
     },
     "x86_64_windows": {
+      "etag": "0x8DC859753D74FE3",
       "checksum": "e5599c94a48247d8d8088d25ee142df99c63a317d1a786e4be41207fe7822cc1"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC8596F45A0413",
       "checksum": "e6639a4355e7728c63d35c52eb8115c30398a35eece492a5c689c561b8f314fb"
     },
     "aarch64_macos": {
+      "etag": "0x8DC8596E9980167",
       "checksum": "d11f9a23fe8263139acbca65cf6d023d8a8f7e76cb52ed7523c8f683b61f647f"
     }
   },
@@ -86,18 +101,23 @@
   },
   "1.27.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC7C9E9277EDB9",
       "checksum": "6cc91651c4dd5e287df8ea7b3087c44120ba95a32ee50497bb071695846ab086"
     },
     "x86_64_macos": {
+      "etag": "0x8DC7C9E8B570F09",
       "checksum": "ae5dae799d3dafeaf4d53e221e1efdeec88980a38375b0d6dbc9c9bb16eec273"
     },
     "x86_64_windows": {
+      "etag": "0x8DC7C9EBD7B46EF",
       "checksum": "08dca5c6e30258cbb24ec30eb8ea1e3ba5b2beb5349eaabee450230ce45ef585"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC7C9E964D7CC0",
       "checksum": "f049d134d311b3d2190d30a936e0a4257df156082cab37d4eb2ace1b760154ca"
     },
     "aarch64_macos": {
+      "etag": "0x8DC7C9E8D902739",
       "checksum": "5d6b05ab581dca9346114df7c9f7285f54d4b80d8082e2c8fce51a42b3dbdb9c"
     }
   },
@@ -106,18 +126,23 @@
   },
   "1.26.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC73C8EC1A6361",
       "checksum": "be7233b3ebfd5bdda8cae6537c21c839d3d24ecf075f1494a2e67f93539b1e12"
     },
     "x86_64_macos": {
+      "etag": "0x8DC73C8E433904A",
       "checksum": "aa9ad8d097c4d3744c9d06520e28837c5e3fa50519a4cd657e0f2f7a226897af"
     },
     "x86_64_windows": {
+      "etag": "0x8DC73C9443B2CBB",
       "checksum": "e326f8552ac7119b643fed1b8af8fe392593280c185c44beadc313e0291f412a"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC73C9024403D5",
       "checksum": "56352027a18e64bc58aa77d4c020bd79163f10cecc859595b0474b5a442369d3"
     },
     "aarch64_macos": {
+      "etag": "0x8DC73C8E27B72FE",
       "checksum": "1b8b12f348eea603ba935d0799e03b87adb9b15779ff21cd67b3ddb1e6ab21d2"
     }
   },
@@ -126,40 +151,51 @@
   },
   "1.25.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC41616F2E2CBB",
       "checksum": "ad56bf1a804243b51ef2c2eec4b3a8177f970ccc414cbbee219c2e5c06f7bcc9"
     },
     "x86_64_macos": {
+      "etag": "0x8DC41617A875C6C",
       "checksum": "f34de579d82b09d58e9a55759166d7d5642bc34893e0b3d53d2ca3f7e841d1cb"
     },
     "x86_64_windows": {
+      "etag": "0x8DC4161AA0EDBD7",
       "checksum": "9108b612b674381b6baf667a06b1c8f870b2d6ac4fcb9c4eef53c0866a6ce8f4"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC41615FDFD344",
       "checksum": "049d624255d150f18b0f3a1257a163366b0dc22e16526214773903125145e515"
     },
     "aarch64_macos": {
+      "etag": "0x8DC416171015505",
       "checksum": "71d3538b0ebcb21fba84c278a86fc6718dc5d01c38162ffd8bed2e66ead4daac"
     }
   },
   "1.25.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC408A6453C8FE",
       "checksum": "84c638108f84144c82507a83e4611afa1a86f55b51e14a7a9056235640c56013"
     }
   },
   "1.25.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC3FA7939FFB13",
       "checksum": "1eeda5d8b319ce7868ee43748687f849e5a9ec2d03f64e0ebeda05af08f67af4"
     },
     "x86_64_macos": {
+      "etag": "0x8DC3FA7AD804DD1",
       "checksum": "fbf2ef5ab53470c9fbce7f76b87008145addea90671148850e01ac204e3b461b"
     },
     "x86_64_windows": {
+      "etag": "0x8DC3FA7FC8E7D6B",
       "checksum": "76a99c45395ccae0c2e8d95886c7059fde8f2f6cb25c697f55fd9252fe4930ea"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC3FA79D97EF26",
       "checksum": "c73a41acce0f0913405e33009d60645824576a1177039bed9c7575f4c153eb0f"
     },
     "aarch64_macos": {
+      "etag": "0x8DC3FA805BEF8F1",
       "checksum": "cbea371d2e15e94b33f3097eaf0ec97906c7b41ed81cf2d7d3ca972f1774f3ea"
     }
   },
@@ -168,18 +204,23 @@
   },
   "1.24.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC2B3ADB283848",
       "checksum": "2dec2a689872f7baf2b0a59c663463a33ac866272758d7d7c8c2b62ab5b32238"
     },
     "x86_64_macos": {
+      "etag": "0x8DC2B3B071AB225",
       "checksum": "cf35f104d834e9c3331f6b1b00bec6b2f0a99c129fdd27230fccb96b2c2063f1"
     },
     "x86_64_windows": {
+      "etag": "0x8DC2B3B252A8879",
       "checksum": "325ed382221ac9189ec9beedcf4b97e6fc229b4e49ede7ca36e47a5b651bb09c"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC2B3AE7DC620B",
       "checksum": "3cf0913a14f369dd6e927a7ba9d6c483a4d05df2cc353ed6aed593c6a50c667c"
     },
     "aarch64_macos": {
+      "etag": "0x8DC2B3AF1A408A3",
       "checksum": "90a00ed4ec8b229aa82cc7c62143f09c468998909f0f673c04580b0eebce37a6"
     }
   },
@@ -188,18 +229,23 @@
   },
   "1.23.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC13E33F994B6B",
       "checksum": "8d8bce1af9c9dd618369302755c66cc940999ff42c3a3e66692cf56c235dd9e2"
     },
     "x86_64_macos": {
+      "etag": "0x8DC13E37EAE6F8C",
       "checksum": "08447ef729ed651d1317c4bcdcd20eb21e2e59cf5d1a8138ea98f82a5c3d8431"
     },
     "x86_64_windows": {
+      "etag": "0x8DC13E38F2F2697",
       "checksum": "7fe14ff1a8a87ac76c610ba871ce621897eee2dd783569040194e4ca295538e8"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC13E348B8233F",
       "checksum": "04e36a418874d90b754ddaef16415c55148b114e31c9b1af2ba86da9e6fc2b17"
     },
     "aarch64_macos": {
+      "etag": "0x8DC13E38E83A25E",
       "checksum": "f2cad733beae1ac5256c419aaa5f4af79b06c5891eb4a0355abda4e0b281be95"
     }
   },
@@ -208,35 +254,45 @@
   },
   "1.22.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC1091FA712A7E",
       "checksum": "0453edb7fcd7314f54c06ad332cd2a2c6196c9652e856919ff4c3fe6bef931c5"
     },
     "x86_64_macos": {
+      "etag": "0x8DC10921C186C51",
       "checksum": "b6d2ea6086938f2e08d3163a2038fdc31a5e9cc7065079134ef47e53d37d5a95"
     },
     "x86_64_windows": {
+      "etag": "0x8DC10923615C636",
       "checksum": "5e98f799c3f11bd1cecdbfcfbdd2cf565aa8e8a04a5e98581d9e0c0ed557c398"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC109205310DDC",
       "checksum": "19ee9561c00a1e9292be60edc5b99495a8284bc70f73f94b3e0552ce4016a999"
     },
     "aarch64_macos": {
+      "etag": "0x8DC1092324892A2",
       "checksum": "09b4a2585a00e63d22e86b4f1104e229ac47f0bacaa78fb64cbaf08765c28cf8"
     }
   },
   "1.22.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC0D81A99AA87F",
       "checksum": "01331c3c9c190af5686384d8775fc1bf483c0e4699f84f728fbdfc28c660e2ef"
     },
     "x86_64_macos": {
+      "etag": "0x8DC0D81D0AE7D71",
       "checksum": "29524fcb347dac2832a18fe4ec229e1bc82d66b403efdaa2a334d2aef7992ee4"
     },
     "x86_64_windows": {
+      "etag": "0x8DC0D81EF507CFB",
       "checksum": "464f8232f3c9bcf09799ad8af5b4817b2c9192da6407f2348b60b76c660b08d8"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC0D81AF5BD58C",
       "checksum": "5a281fa22e8d7107f2d299dd7662cfce48b85c3aba1b5206676e81da8c3c4bc1"
     },
     "aarch64_macos": {
+      "etag": "0x8DC0D81ED55D51C",
       "checksum": "218bf5f27443e8b484c29a4d55f5ab7f7ecb15af95d32d63d231d71e73309d9c"
     }
   },
@@ -245,18 +301,23 @@
   },
   "1.21.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC08B882E82145",
       "checksum": "3292fd257f2e2dfd4cb0d5650aa5e47d2c99cee1233446378eb45a7b045f3b30"
     },
     "x86_64_macos": {
+      "etag": "0x8DC08B8A9B3E1E4",
       "checksum": "f547f5d256782b946b22fa73e0d7fdd4e7d733c637480d4c4d6fd2feca046a59"
     },
     "x86_64_windows": {
+      "etag": "0x8DC08B8B609D678",
       "checksum": "54fc05c55b84ea1a7a80acf8450d13ba06472ecdd4ca341817ba45a6780c8f4a"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC08B887CA202F",
       "checksum": "2224bd7232f86db42a41411493c7806ae5938ad5ef3cfd37af064ed90d6688d2"
     },
     "aarch64_macos": {
+      "etag": "0x8DC08B8C7F203C9",
       "checksum": "adab0bb1707df8d4995c103a87451e00b37936550fbf1586f00a38328eb6ef48"
     }
   },
@@ -265,18 +326,23 @@
   },
   "1.20.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC0815D348F875",
       "checksum": "fa0eb3681050021ea33df7e6c1159fd3029253193d339c8011dd88fcba833ced"
     },
     "x86_64_macos": {
+      "etag": "0x8DC0815EF504A0F",
       "checksum": "ac23f84aa7fb77b46fc37088f843289d42ae9e96bd4a8f9e728e23d35a3d7ef1"
     },
     "x86_64_windows": {
+      "etag": "0x8DC0816170B4FE7",
       "checksum": "a2a179c32ee8112df66b9adf792deb83c76c6449dddd26ca9ca7a19c3dddd361"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC0815D6630E0B",
       "checksum": "acb16bd3f2fe508d18997216a7c26f292f4cd1dad379368b978c8795dcff7c2b"
     },
     "aarch64_macos": {
+      "etag": "0x8DC08160B78B9F9",
       "checksum": "be998cf887c717730ffd5963cb027d63c39956bf0a1d4674aa95d4f3b8109cea"
     }
   },
@@ -285,18 +351,23 @@
   },
   "1.19.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC075E3ACDA228",
       "checksum": "79b25aedf7c47a1e6669faa65fbe1ee24d019df31a8c0fb5c058514eb085b386"
     },
     "x86_64_macos": {
+      "etag": "0x8DC075E5A804A88",
       "checksum": "9c2295ddbde5dfbc98c93bf584bc6bb0c64a83fd83c53ad905178a5064ae82aa"
     },
     "x86_64_windows": {
+      "etag": "0x8DC075E80BDDDFF",
       "checksum": "4ddd1372cecc9d5c830130beed50db8aff17bd022ff87f15f94a2ab6ad288f12"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC075E5B4A3161",
       "checksum": "c619997d9e1a2528bbce0b360c80c3fa26ab226d7237dfef493560e56d29bd6f"
     },
     "aarch64_macos": {
+      "etag": "0x8DC075E464B1C20",
       "checksum": "649120e1b435684367dfa18b0e822540edb96afc77a0aa8d0dc118dffe76c430"
     }
   },
@@ -305,35 +376,45 @@
   },
   "1.18.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC04A4AA3197D8",
       "checksum": "3dccee333c6ec14a533c53748e8944da58a91877ec6f9d20579744b76c7d4096"
     },
     "x86_64_macos": {
+      "etag": "0x8DC04A4DDA1CFDC",
       "checksum": "d83b17fcb087f8622dac99293b770b585318c0fbee32b36aecc4b811ec094318"
     },
     "x86_64_windows": {
+      "etag": "0x8DC04A4F4768535",
       "checksum": "790ed04a64d2191e1c3a3c4dcf935d8d0a4704624023e7cd09fc627ab413b5f4"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC04A4AEC0CBD4",
       "checksum": "93ef250e5e043dfccf93cfcf62b8e1dc81b9bc7498e9b9d394d86a9f099c8fe3"
     },
     "aarch64_macos": {
+      "etag": "0x8DC04A4BDB422A8",
       "checksum": "0834c029624ba3a04228be9a2b784b7f75d459a07ebf29105186f9b634c8678b"
     }
   },
   "1.18.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC049E7D8FDD90",
       "checksum": "c5c4dd7692250fec357725295b4265617c4c6687df1a74e5f2c65cd70a20052d"
     },
     "x86_64_macos": {
+      "etag": "0x8DC049E8EB742FF",
       "checksum": "ef0e343d5c14234a707e70b3e27a1606bfaedae3005863a16a74919a9364f8bf"
     },
     "x86_64_windows": {
+      "etag": "0x8DC049EC674A1AD",
       "checksum": "308658be85d7a0b7a702b1b011cd2f766c756d105c1fd215e0ca1cc18e456be6"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC049E80BC554A",
       "checksum": "b23013b5aaadbf1ee687b789ed901aec82b79761b9ae20e5b90c7e48109858af"
     },
     "aarch64_macos": {
+      "etag": "0x8DC049E8E7CECAA",
       "checksum": "0c43173e2fc676091279025f55b4af00ec8444e219e89ab835c770e57717d288"
     }
   },
@@ -342,18 +423,23 @@
   },
   "1.17.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC010467FD4BD9",
       "checksum": "dac0ae3850b6a68c927930b956be5bc17250f01853be4338bd3277c3f57df743"
     },
     "x86_64_macos": {
+      "etag": "0x8DC0105448845B0",
       "checksum": "3dd5b14275b940f26b0a6223d9f4cb41a93acfe22282d7ff3fd4bb3e1e742e84"
     },
     "x86_64_windows": {
+      "etag": "0x8DC0104B20F81B4",
       "checksum": "7e2fd34d9be9247a8f962954e1d47aede2774bbd3aa1619015fa822150943ef3"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC010547DD26CA",
       "checksum": "11c5822d0826034b129ee80af687a3934622fcf6127920b814567202d0000e93"
     },
     "aarch64_macos": {
+      "etag": "0x8DC0104A278DEA9",
       "checksum": "1e04d68431762b8898e73f5c9a34e1541132789b719d95063cbf2ac259dffb27"
     }
   },
@@ -362,18 +448,23 @@
   },
   "1.16.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBE0A435C84C7B",
       "checksum": "06bdaeb64cf9077cef7b5ec664b6614850a1271747c10fbc3068b7dca3296ff9"
     },
     "x86_64_macos": {
+      "etag": "0x8DBE0A45843EEDC",
       "checksum": "d4939075bfed22a1a0043e5dd9d755b7d096b19150cee9b2cd9666db1b69ed1c"
     },
     "x86_64_windows": {
+      "etag": "0x8DBE0A471CEE270",
       "checksum": "a15996ae91b51e779181ce20623719857d47ea1564bf235fa5ab3de9cd4c450c"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBE0A41AC74FDF",
       "checksum": "294ddfe0475491b5466ce7fc1a4acda56f91005ef36d224f2d22cf490920f994"
     },
     "aarch64_macos": {
+      "etag": "0x8DBE0A43430B256",
       "checksum": "badc6cb59bcb492d06d8df92c02091f1b093be8e8e67bd35aac7e66826c2405c"
     }
   },
@@ -382,18 +473,23 @@
   },
   "1.15.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBCB4C8D36D61A",
       "checksum": "1e4bed6f63f5f3e99a081336b233a795119e514addcabf8332373efc1b9b3b6f"
     },
     "x86_64_macos": {
+      "etag": "0x8DBCB4CAA22AA98",
       "checksum": "d61a87d3c65462ed77ec7fc14b42b6117529504c28b202a028fdd8b6f69e7e23"
     },
     "x86_64_windows": {
+      "etag": "0x8DBCB4CC8FD9ABA",
       "checksum": "552a629af3636b43e02c6ad5b0366ad59e750b1f9d3d8fce941f9f04500bed39"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBCB4C9E73A96E",
       "checksum": "12ce2fea454b73016f4536274f95cc0ac3c8d30c279cb36b7d8eb6a9331fcf89"
     },
     "aarch64_macos": {
+      "etag": "0x8DBCB4CB46E7B41",
       "checksum": "b153f93b777589fa02a2159d781ae77fc06e6f678ad7ff4cb4310c4821f79868"
     }
   },
@@ -402,18 +498,23 @@
   },
   "1.14.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB63B58375503A",
       "checksum": "19848d0282e95f30188305b1bbd5a087793e5c6f27f5ac98207ab256027183df"
     },
     "x86_64_macos": {
+      "etag": "0x8DB63B5ABB4D086",
       "checksum": "ca4a787f353678d46645f060d96dc4cf8777c16d2a7f064f1aac6e284b92a64e"
     },
     "x86_64_windows": {
+      "etag": "0x8DB63B5C3BCCD70",
       "checksum": "f718211c83e73fe2535c924e8179e9c2f70cb8d23f8039ace746670d38e3c898"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB63B590961527",
       "checksum": "b3d306e5978dd239bbd7803a697006aca5c7fa1d61efccaefae134f792b9e1cb"
     },
     "aarch64_macos": {
+      "etag": "0x8DB63B5F5980717",
       "checksum": "a77944cab60285ea0cf05ee5a3ad9ff4bea313a512a4a36fa5238e77cc760bc2"
     }
   },
@@ -422,18 +523,23 @@
   },
   "1.13.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAFE9764CFF2A3",
       "checksum": "f76fce93a71686f6aa6b2db1a39184e736f9ac8248c0489e003c617b49eb2676"
     },
     "x86_64_macos": {
+      "etag": "0x8DAFE97F25A5C53",
       "checksum": "fb14ec72f0900789b3452ec6bd90becef6de1420c8bb4abc0686e7e0efa99d83"
     },
     "x86_64_windows": {
+      "etag": "0x8DAFE97C37526FE",
       "checksum": "cbb956c59b3b2d48011630fed626f13340b5692aba45833301bdf696dccb51c8"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DAFE97880C3B36",
       "checksum": "1afff4cc864a31c0e167c8b4ea5f68c4f358c6d3a19d764276cbdaa2c1575a52"
     },
     "aarch64_macos": {
+      "etag": "0x8DAFE97DB8A51D9",
       "checksum": "b6c7489f103e154f1ec99e648b70323aff7173e16f18ea2e22d3d21e52283851"
     }
   },
@@ -442,18 +548,23 @@
   },
   "1.12.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAFA4D355C9068",
       "checksum": "a8e1278f3a2c81384f9a146e74fc40b5204f00776cccfb4da4d36e45716546d4"
     },
     "x86_64_macos": {
+      "etag": "0x8DAFA4D22D048CF",
       "checksum": "22eeed0bcff05f5cd280345b611a9950b81c3a5b4cabb925cf5c0c77475b2dfd"
     },
     "x86_64_windows": {
+      "etag": "0x8DAFA4D4EC22644",
       "checksum": "a19d34d8b08e08a2d5b6839db6ece5bfd05faefa45b8924ecbe93f07d3e86e76"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DAFA4D1DE8BDC7",
       "checksum": "a8f990336308179103c7776b463f89d751d7c910b757765dd47713b4a32b93a1"
     },
     "aarch64_macos": {
+      "etag": "0x8DAFA4D39A8402B",
       "checksum": "d08bcc10a690fed8db84e7a64c8665e69d56ad601a85fa970f0a82bee23ec204"
     }
   },
@@ -462,18 +573,23 @@
   },
   "1.11.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAEE1F1D185E64",
       "checksum": "c8068fcd03b800492ad0e5da84761034cb412542d6ded0a234da2a9fc578d540"
     },
     "x86_64_macos": {
+      "etag": "0x8DAEE1F2E1926D3",
       "checksum": "e6e6b32115ce5ebf4f4d9ee7c8f5501c6a684eb874b7b3d68f7209cf40132b4e"
     },
     "x86_64_windows": {
+      "etag": "0x8DAEE1F300C2102",
       "checksum": "43fdee33348907a3771341d5949ec78283bacc711c7aa7336a80fc938627ce68"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DAEE1F14A52B0F",
       "checksum": "b8558bf44588bd21f144e179b4ca8d2afa6059227afbd03582c0715d54229deb"
     },
     "aarch64_macos": {
+      "etag": "0x8DAEE1F2FFC6BE4",
       "checksum": "10344c6001955ed866e24e673c3781b2f1c06efc1d8cf629415b7a27c3781bff"
     }
   },
@@ -482,18 +598,23 @@
   },
   "1.10.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAEC649099EB57",
       "checksum": "388fef161a2d178cc4165fb2d096aafb87248742edbd35cc8cc0de431d4c0a95"
     },
     "x86_64_macos": {
+      "etag": "0x8DAEC650E0B0BC3",
       "checksum": "61196ebfda45f6cfc0297c7b294259122624a3c4318defb867be44ab67cb3707"
     },
     "x86_64_windows": {
+      "etag": "0x8DAEC64C513DFB9",
       "checksum": "b7606ba851714a6e229ca3f94501b7833379226cf2ab7b8fb6c9f785313ca784"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DAEC6497CABC93",
       "checksum": "8fa3117c6b8bf2e957e66c7fbc83b3d419602914bc1ae0d5b18e40abf09c8b2a"
     },
     "aarch64_macos": {
+      "etag": "0x8DAEC64A6C8AEA5",
       "checksum": "e2a2eebac94a6b1d615af292054cac700a83b52b4cc1cc17c668ab69d4ce470e"
     }
   },
@@ -502,18 +623,23 @@
   },
   "1.9.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DACF354A32CE96",
       "checksum": "a7e2349a2d9e0a04466c71924cd7d0744ceedb0a56817322aae6b8ccda889be3"
     },
     "x86_64_macos": {
+      "etag": "0x8DACF354AE90BAC",
       "checksum": "ad8b6eb3395894ff257df425ff6993843c7392cad62e4a4c804cc7c7c5c777c7"
     },
     "x86_64_windows": {
+      "etag": "0x8DACF355D1F9A84",
       "checksum": "1183a5e4c53f115fe6c5dbf5a387068ffe6c18454d05858950ab3232db7ab94d"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DACF352B0ADCF0",
       "checksum": "b1e47d4a930d74be84725e9cb923a49a492468414a263054444129859c2c7e46"
     },
     "aarch64_macos": {
+      "etag": "0x8DACF3554FA9D06",
       "checksum": "95c3d77492012dbb9ebc2addbc3312088fa0a53d93aeea035fa1d1d9ac67f90f"
     }
   },
@@ -522,18 +648,23 @@
   },
   "1.8.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DABD2E8DBCBF00",
       "checksum": "140986a33c901656375068727da33329f7ffb2b555338cc001c245b68131c349"
     },
     "x86_64_macos": {
+      "etag": "0x8DABD2ECFB5B49C",
       "checksum": "f3edecd9c033185277a83bf623dde3e6b2cf2d6e755972f71709f93c00147cfa"
     },
     "x86_64_windows": {
+      "etag": "0x8DABD2ED6F72FD9",
       "checksum": "0cb9030767ae462145d87ab83e1f27fee84823d04c8eec79faca0ade659da6c5"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DABD2E749DC1D2",
       "checksum": "8495ce7179f68d6edd28bed9015710c2aabdd4183e700125db2bab186e0eadb1"
     },
     "aarch64_macos": {
+      "etag": "0x8DABD2EB70AE45D",
       "checksum": "466e8a10dda1d812f8583207e96a176dcb099d67144eb1ee83f1ed98986065ae"
     }
   },
@@ -542,18 +673,23 @@
   },
   "1.7.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAB7E1FD504BE0",
       "checksum": "f474bbc5cc73af368fc7bb33c538874786cc3305211f5ab30e2384309ef3f2f0"
     },
     "x86_64_macos": {
+      "etag": "0x8DAB7E23BAAD5DD",
       "checksum": "66df1ed0f459411a1059f0df9553b586f4cbc55cf33951ed025567a6f2724b31"
     },
     "x86_64_windows": {
+      "etag": "0x8DAB7E231C710F8",
       "checksum": "a514ed220c4a320cfe04b6bec97e32e0282dc0a70462b0562c8b79d4c8d58ebc"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DAB7E233A1CABA",
       "checksum": "22466223886698f3b8ed1033217e47a49eb748079af01e2c21a322021aa886ff"
     },
     "aarch64_macos": {
+      "etag": "0x8DAB7E28D4564A0",
       "checksum": "d906759354f14f259bbdc3d7fb67a31de06c591091476aef26fb7eb53cacc88a"
     }
   },
@@ -562,18 +698,23 @@
   },
   "1.6.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAB24244D20D1F",
       "checksum": "c9e1112fddcb022eb34bcdef4500c603139400d9ac86b9b858ba5fe7e2831281"
     },
     "x86_64_macos": {
+      "etag": "0x8DAB242A74F7502",
       "checksum": "cac7123bad85019a3d4dc9f6c4d775520858b908b31955c45d55b6c025ffd9ba"
     },
     "x86_64_windows": {
+      "etag": "0x8DAB24299329019",
       "checksum": "dd49b2fa34ce008a47f2179c392e6c113e4e2ff196cb5d119a97979f3272b862"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DAB2428C899E10",
       "checksum": "eba0c67cb94e5f866e9253e86564154a7bd389ddf3b90ec5eaa68500982778a4"
     },
     "aarch64_macos": {
+      "etag": "0x8DAB2427DA7D814",
       "checksum": "cef00af72489aa411b30d16e2412b96aae34b2f151b1fd7b45f0c45c6baac10b"
     }
   },
@@ -582,18 +723,23 @@
   },
   "1.5.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA946139828CDC",
       "checksum": "414147908f10a7e9e82b0148de79280ca9c48a70f7cd7bab1ce2d77959446fac"
     },
     "x86_64_macos": {
+      "etag": "0x8DA9461670CDDA3",
       "checksum": "9389930878900ec48b557a509f2b3a81e8dc01689859ca6a388244c8251ee8cd"
     },
     "x86_64_windows": {
+      "etag": "0x8DA9461827D2261",
       "checksum": "106c124c884569869b1a5ccd695de26fb98d0a0967645af1075fedca59d938d2"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DA946141D3B2DB",
       "checksum": "f619b275c7bb21c8adadc6226c40d7825cc2d7a72eaa791008b9364e60c64335"
     },
     "aarch64_macos": {
+      "etag": "0x8DA94615C5D16A0",
       "checksum": "3c466afc4cf860b1555a69d992458f0b966d9077ad17fc6c9ce753c70a6cec43"
     }
   },
@@ -602,18 +748,23 @@
   },
   "1.4.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA79B618C15CDF",
       "checksum": "006a30ceb69f9c93e2dc1d8bac3845395ef5ddb4e6eead762a8cf29e68f6e2a4"
     },
     "x86_64_macos": {
+      "etag": "0x8DA79B63BA4A4EC",
       "checksum": "e7a1917dad906ebf44b75bd5dabda63c25584136039289ca7b4af40a960a7ab9"
     },
     "x86_64_windows": {
+      "etag": "0x8DA79B6A3F792C4",
       "checksum": "daa1b1408b12fcec48301f898612050e97266aef3cbc689f247a3a0db5980ddb"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DA79B622ED17E8",
       "checksum": "5bca3c27768c36fb78737ea1a979f3875bc7a5a58136a86ef0b2299fe39529ed"
     },
     "aarch64_macos": {
+      "etag": "0x8DA79B6FC717B30",
       "checksum": "feba9e66c97b6dbade1154ca44b9cedc062a731dac06f75b81d198512be77c66"
     }
   },
@@ -622,18 +773,23 @@
   },
   "1.3.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA6E13774D8794",
       "checksum": "1c52f337f9e5950829ff990f583d0ddedc11a071d5340980ac7d49dc3095995e"
     },
     "x86_64_macos": {
+      "etag": "0x8DA6E138B106ED6",
       "checksum": "c35d3082e288feaece2d2f77daef00eb9002b9d98fbf377d6c43bcb38292f53a"
     },
     "x86_64_windows": {
+      "etag": "0x8DA6E14464B34B5",
       "checksum": "6d60c646625fe9bb9fad3bcccaeff65c05e7bde58eb3fc1b32c5cb48411aeb71"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DA6E13780CEAFC",
       "checksum": "9f1276717600534a6c60f341b516171c24b9db9973e737d83424f34f0eb3e34e"
     },
     "aarch64_macos": {
+      "etag": "0x8DA6E137E7A8DF8",
       "checksum": "f6b37c0dc76ad88f6b1a9e441d21ebe5109c7f65eeec74b5d3935deff79e3741"
     }
   },
@@ -642,18 +798,23 @@
   },
   "1.2.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA43428E4536E1",
       "checksum": "7102b1ba543745774df500db962dec2e3a01aa2553dd0c3f334e8fdadea41d25"
     },
     "x86_64_macos": {
+      "etag": "0x8DA4342FC7F07A2",
       "checksum": "33275874e88ff4c87b04417258296c20be49cd7c63c457bafd3255f814c15118"
     },
     "x86_64_windows": {
+      "etag": "0x8DA43430FC3077A",
       "checksum": "59c037709cfdb98e1be1e43075ebf3a7c1cd08920dc088df68676a9c3168d57b"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DA4342AC4A4C33",
       "checksum": "73f4f43fcae7b78f707cd1e146b4246e75d6897bdf18fa2b3adaef7e2300d405"
     },
     "aarch64_macos": {
+      "etag": "0x8DA43429D724E03",
       "checksum": "9792a345dadec8346241e38d4c0df8580980c19977f33a1944c4a107e4cb26f8"
     }
   },
@@ -662,66 +823,85 @@
   },
   "1.1.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA2D8E5073FAD1",
       "checksum": "63099f09106d5c5fe5579b3430a3ce4a02c193560842247ae70335575a24318c"
     },
     "x86_64_macos": {
+      "etag": "0x8DA2D8EED077D4A",
       "checksum": "2fe5da96af305ed33841d55653226d97c970485a66e18921e96ca0f6734093ec"
     },
     "x86_64_windows": {
+      "etag": "0x8DA2D8E83AC4BF8",
       "checksum": "00b0f3f158da01bcfc3f712722d917f8084c9bfaa693d71f64f4e67f957fb2cb"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DA2D8E6E8D333D",
       "checksum": "73c034f477b8b6fe5d5d4b1b64d217bc070cbb6bc4f727bd540f53ed432d52db"
     },
     "aarch64_macos": {
+      "etag": "0x8DA2D8EB2BFB7B5",
       "checksum": "e31f75dfb22762e650c5cd1699d67682111e5ec7096a0fca9163b9aebcd6a1e9"
     }
   },
   "1.1.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA12D78A420145",
       "checksum": "7d4d620ea73b58233b170ecc93dd1ef59336eeb9b59f94dc5ca7e06ed520e0cb"
     },
     "x86_64_macos": {
+      "etag": "0x8DA12D7A52CB33F",
       "checksum": "6d5cc5466eb495d2c567d96d29e188311e11b70a52251ea7b9ef551efc9a1e25"
     },
     "x86_64_windows": {
+      "etag": "0x8DA12D7BEA324FA",
       "checksum": "fd961ac0df25306b3b18bb1e7849e3e6e9e61dcb3755105ced617e3838ef5e88"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DA12D797B96950",
       "checksum": "1038be03bcc5554b1daac07354235eaa945eb6aea5100b1013c1624cb8e1dfeb"
     },
     "aarch64_macos": {
+      "etag": "0x8DA12D79D697A4B",
       "checksum": "9c16dc0ad44bdee332af8459489faedd7b215c5fcc61b3b004c4b96b7687524d"
     }
   },
   "1.1.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA0C811885E4A9",
       "checksum": "ee7bf76941e8d7a41bab6716390a293e381a4a32bc46ad4d9d112f540aad34ba"
     },
     "x86_64_macos": {
+      "etag": "0x8DA0C8166923E57",
       "checksum": "afdc9eed21fdc3eedc6e853715232b982cd167d63b741afaf47462e7c61bfd83"
     },
     "x86_64_windows": {
+      "etag": "0x8DA0C813F5B6BB1",
       "checksum": "446e6091b2aa2b40bc57857f1104cfe4153e757379141ae5ded1dec3da59c10b"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DA0C81103374FC",
       "checksum": "c4a136d9c2d040200f950043e01aa0e81e4eef33778d8a25ed051c34ae2b1008"
     },
     "aarch64_macos": {
+      "etag": "0x8DA0C81470557ED",
       "checksum": "9d2a1335c4d62806bd36c5f4d2195c61e4223097b1ca527f90630931fa914ad4"
     }
   },
   "1.1.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA0277D1F330C0",
       "checksum": "2dc78e8470dbdb0569a781ca85d86c01189ca16853d0aa997cb15b2fa1f70423"
     },
     "x86_64_macos": {
+      "etag": "0x8DA0277F948F86C",
       "checksum": "5437256385d2216d723f761fcb3dc6a1d592709839e83281c8a5238062f1b039"
     },
     "x86_64_windows": {
+      "etag": "0x8DA02785DE96628",
       "checksum": "6e132abb88759aab0d704e9a94531d3e14449c1bcee71e4c8c91ea6b4bfa1871"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DA0277EAAB5D0A",
       "checksum": "66de75c1b23bd9f674f0afa6c418d90acb1f87590310bf89235b0bb2b27080f6"
     }
   },
@@ -730,29 +910,37 @@
   },
   "1.0.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9FAA203E3D74B",
       "checksum": "e8695fb60126158f7708dd48e36f51028fbed00ab62d9477b0e86ef1de6cbc73"
     },
     "x86_64_macos": {
+      "etag": "0x8D9FAA245CF9398",
       "checksum": "72e64d529a5ce47de4a65c98bb616d35628d8e27aca8fe24e419e69de035a2df"
     },
     "x86_64_windows": {
+      "etag": "0x8D9FAA24BADB57D",
       "checksum": "a5d83fefb56f9aad15f3ee1752a2d77b3d1dc8753d17a000204bc15171b8030c"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8D9FAA22E7A4632",
       "checksum": "9638a9abffd31920b3d9b7fee8e28db8fb3c998c1d6df4a9395269f247a6340d"
     }
   },
   "1.0.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9F648B1EEC17D",
       "checksum": "342f8582d929b9212ffcbe9f7749e12908053cf215eb8d4a965c47ea2f24b0a4"
     },
     "x86_64_macos": {
+      "etag": "0x8D9F649820A3B99",
       "checksum": "56ebd949683e55416c783741fdc76aeff566bd0ed8fbd28c629b0f2c319b309c"
     },
     "x86_64_windows": {
+      "etag": "0x8D9F648F6B6F537",
       "checksum": "342cbb940da6c04781ee490533adf6a077a16b47dcf92d4a3f2270222bdb04e1"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8D9F648B66F53B1",
       "checksum": "712c95b63faff7a9cc0e4af770adb82206a4ecbfe7d3ddb6a9e3dfafeb97ae32"
     }
   },
@@ -761,29 +949,37 @@
   },
   "0.11.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9F0C8C572B91A",
       "checksum": "5cd03d96518dd67eb691f6783293c62d610fc63ee0a9ba5223f4c1383c2a4661"
     },
     "x86_64_macos": {
+      "etag": "0x8D9F0C8EC89253B",
       "checksum": "51fcea64c8dad9c7bfabcbbc9ae1450e750237e45ddb5c68784585f6820fce1b"
     },
     "x86_64_windows": {
+      "etag": "0x8D9F0C91E719D09",
       "checksum": "8293cc38eab2ba5570a1e1d91699c1d8441dccbacf04ebc5b979d14e917e38ce"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8D9F0C8D3010F52",
       "checksum": "e209a0d8ce139d2f6de1c93ec8c0ce1191bbaf0a40357c6812798098ead75e5f"
     }
   },
   "0.11.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9E779CAF41264",
       "checksum": "7aef288e87d052bb6411ce4938167b5287963a4fa40515c9a2b403ce98342fec"
     },
     "x86_64_macos": {
+      "etag": "0x8D9E77A24E7813E",
       "checksum": "a326cad89510d72f9a7fa253ceba6ef5f34c71ee2caece6269bc2644b742cb98"
     },
     "x86_64_windows": {
+      "etag": "0x8D9E77A1DE4F1B5",
       "checksum": "f0409252f929015c8f50b7a3e9d56113a28b4e1d144dd3afdf53dfe532390c59"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8D9E779B6CCF45A",
       "checksum": "92f6aa18b7789d81ea5dad55cb3da2664faf271b6eea0fd2576643cd4d04823e"
     }
   },
@@ -792,89 +988,113 @@
   },
   "0.10.7": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9E4321AEE8EF6",
       "checksum": "54927f5e261a4965a5f406374b48eb39da6c15f859098626aca24765b6e158c1"
     },
     "x86_64_macos": {
+      "etag": "0x8D9E43267B21B2E",
       "checksum": "be6c3e684bc4a547725ea32507c38c8c47b09e460cb9f736d53e1c7f031c5e37"
     },
     "x86_64_windows": {
+      "etag": "0x8D9E43228727EB0",
       "checksum": "47c353f7925efe6ce989362c249ecd6711ec0d2624b5acde2ff81c260c0c3994"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8D9E4322B967A8C",
       "checksum": "2ae05195bdde56e52dd839797257a947790587870c4855dfae8435272ac783e9"
     }
   },
   "0.10.6": {
     "aarch64_linux_musl": {
+      "etag": "0x8D9E36D6EFDBECA",
       "checksum": "ccc9efd7f33cf7b18136d39540aea5e1d32337a9122cd29755dd54313fed4464"
     }
   },
   "0.10.5": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA0AEEE6C0AE",
       "checksum": "261e6912e3f63a37baa69d2dee5cc9f95f2523eaab38e3b73030ec1a1afde80e"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA0AED45AB26",
       "checksum": "8802f2591734472048d02125215dcebbe6cd2c68e04ee2d791f45b189a24803b"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA0AEFAF49DB",
       "checksum": "ef5421ed3b3663f58a804d1f3d8f865318fc1cb89e87cc78b28b00dfd1f41a6b"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8D9BA0AEA390704",
       "checksum": "c10deb9ad12b55c7a30af3137492fa31953e0b7a3724cc65deed93c1c18c7bd6"
     }
   },
   "0.10.4": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA0AEC53F543",
       "checksum": "4d1f3e3bef97edeee26f1a3760ac404dcb3a1f52930405c8bd3cd3e5b70545d8"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA0AF4A4FE41",
       "checksum": "0fec7608b7b7c95cb02738951428633ac972af4885b0229d720eaffab696f9aa"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA0AEEA41C54",
       "checksum": "4fefce55e95f4c8b061b9a50153aa3c7bdfc0ea937ecf21832eeafff5fac8dec"
     }
   },
   "0.10.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA0AFAB6F497",
       "checksum": "0f43a286dfe67ed94034843cb72cec61a024303118ec19bd618bc4e15a0970ac"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA0AF299C516",
       "checksum": "d7d9c24554abda2c2c5a4adba6b5763be1e1b44f3472f1be152c922ee0c62f84"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA0AF1B5A1BA",
       "checksum": "ffcf9b0a31666419cdedf059966463824347e57692ceac1e2470b48e94d0e494"
     }
   },
   "0.10.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA0AEC90A70B",
       "checksum": "280a6edf58076e90d2002b44d38f93dcd708209c446dbcc38344ed6d21a8aaf7"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA0AFB7064D8",
       "checksum": "49ad6c74eba74870dbf2b245c3748a1d7ce20da48b9be52e883819585cb95d15"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA0AFA07E30F",
       "checksum": "745c0bad2d771c7a471a561b03141f5fe0a4bcb1a9d2fe8026d8306ffb80ce35"
     }
   },
   "0.10.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA0AFDE3ED27",
       "checksum": "5f99ddf0969eb2cfc3eee4b3b296e4ec495015c38eba65e91e89b764ca06f3bc"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA0AEA53B6F3",
       "checksum": "d701fa6cfa8f160bdc722ea57b1481deb4052e464edd65ba278d7af6eadcfae0"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA0AF7BAC8C1",
       "checksum": "a59ca028669393472b76239b4be37e716d2fba217aa94cca9a350865ecc36963"
     }
   },
   "0.10.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA0AF04B4B75",
       "checksum": "661f3ebf1504f99cd96dfcb148f5e1d30e93c9c182680aab855cb881c3e0f13e"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA0AF186F794",
       "checksum": "f7adf6c5e39917f4e6d636085dd9068c12b6be150ffd33a368017ced886a45c0"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA0AFA55F764",
       "checksum": "3f4824e3940e5a2d870510d99e72a2b3ee407120f5c26d2daab15786c8234908"
     }
   },
@@ -883,56 +1103,71 @@
   },
   "0.9.9": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA0AF095DDD8",
       "checksum": "2c21ba77d25e385ebe751d0ced27225313a2c4c849b1b9ce397ca5ef6766afc1"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA0AF1C5A4E8",
       "checksum": "a1226dccd3ded3e8a57e6a6f31b5b7fb01e89c85c8d78af4d89b288c5f341410"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA0AF11533FD",
       "checksum": "e40a21e71bafb33d809418aae3568f4193b8633e9fc865a90b2516c5fa0f2839"
     }
   },
   "0.9.8": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA0AFBEC1205",
       "checksum": "d41db56e50731d7019f998a958c8f640b4d61a887d814175159a4b53cd1fc4fe"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA0AF27E51F5",
       "checksum": "472653e946f520f1fcc178f988ca8142ecd619506c157a00af55d0467f018b8c"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA0AF0A6A43E",
       "checksum": "7a3ec14cf0513ae795c63467291a3816bdb6777124bb8ad0246f849806690342"
     }
   },
   "0.9.7": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA0AF032E52A",
       "checksum": "cc5e50f64732e561043d469ffac99f335023c93978a45c8fbc921eb4e955e688"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA0AF5B2755C",
       "checksum": "6bce036e93dee708fc3f4dc6496b4c571ad8927217bfe860528bf4ea90f1f837"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA0AF6E2B187",
       "checksum": "d235114992691573e55a3d88829cad6935e0899b7ae602b9a2dbbe78fb12e5d8"
     }
   },
   "0.9.6": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA0AECEBB1BA",
       "checksum": "1253ac5b61eca3eaf5c69dd4b7e7ec551dec78821e9308f0b3f2a00020934f0e"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA0AECAA45B3",
       "checksum": "4469e58a5bf4a2c8fcd69da50c15c5ccf7746d019dea904f1f4f062c56ffaf34"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA0AF2B7CFEE",
       "checksum": "7773e06f0bc19810d78083a0aa799955ca759207ebe6c9e3b83abef957fe1cc8"
     }
   },
   "0.9.5": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA0AEAB83621",
       "checksum": "2b6c3bc26f0e8b6a7403e7569a1e4d189e0361c5a5a7cb021b4e3d128cbf9b5b"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA0AF430F10B",
       "checksum": "fc829983ff11891f18798cc69119b8587fed4fdb6a264a7e86229ca3100373ca"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA0AEDF88CAE",
       "checksum": "ff2fb1bbb8dd52f7e944f927676e352e1926a38b236a3aed295c088c30f7a0cd"
     }
   }

--- a/manifests/mdbook-linkcheck.json
+++ b/manifests/mdbook-linkcheck.json
@@ -20,23 +20,29 @@
   },
   "0.7.7": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DAA53F81571FD2",
       "checksum": "18cebca9493804b307b39a44af2664cdfa881e84b8d92a94205d6c51572318ef"
     },
     "x86_64_macos": {
+      "etag": "0x8DAA53F82196925",
       "checksum": "13f83555d63d730ca28e92db2bea4d81f815f26af3db7dadc4f27cab83007947"
     },
     "x86_64_windows": {
+      "etag": "0x8DAA53F8533CA05",
       "checksum": "b19f03e7c4fb38f936e118ae5dca5eb67c26614b202c42b2eec27fb260f625f0"
     }
   },
   "0.7.6": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B8F45642F531",
       "checksum": "2c478d9754e38be2dbd3ee2fcac629179c6d6146f7e0f1749a5a697030e27c4a"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8F4485AAF9E",
       "checksum": "c5abc778194a17fa2417d345a842038c62e7f6733daec9ff6234d21872d0629b"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B8F44EDE94EC",
       "checksum": "1b15fef5856ea186358a41285db29c6e411d15c95818e644cb8a29047b97a7a0"
     }
   }

--- a/manifests/mdbook.json
+++ b/manifests/mdbook.json
@@ -26,495 +26,633 @@
   },
   "0.4.40": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC76132CD10679",
       "checksum": "f7520ad60d1a6fe81c667d0da876a9ddd736f874eb61c01b025eafdc83381227"
     },
     "x86_64_macos": {
+      "etag": "0x8DC76131DA27994",
       "checksum": "5783c09bb60b3e2e904d6839e3a1993a4ace1ca30a336a3c78bedac6e938817c"
     },
     "x86_64_windows": {
+      "etag": "0x8DC76139E120E95",
       "checksum": "1470e5b06614cb2851e8b3c908dfdef2982b90e6cc6045662512ce66d6c7c5d9"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC76133A0BC2F6",
       "checksum": "d5ebfd2e31755726f8c0988a423b1ab5d950bb894fbba170355bb7d1cb852586"
     }
   },
   "0.4.39": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC760D35F84046",
       "checksum": "25d66ee23c67815549a1517c484aad210c5e0f97c68bb990a93a34c03e859d47"
     },
     "x86_64_macos": {
+      "etag": "0x8DC760D016D9F9D",
       "checksum": "dd52578a17c892afa805ec29b15c06f1e7c6e6707791ef840165fc3f1763c6bb"
     },
     "x86_64_windows": {
+      "etag": "0x8DC760D85904527",
       "checksum": "f8efb854df122d6d99189923d7fe61625f8931e0a46d38d8449fd850a67079d1"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC760D1A55ACC1",
       "checksum": "68fc653b401b6d344eef77f9f119d262acadce248e23a4dd1ef2e958eabc2be8"
     }
   },
   "0.4.37": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC279203EA8C38",
       "checksum": "d59f83c4cf9626787336684936c56e01a9511272cc2e541f7cc9455d43fff1c1"
     },
     "x86_64_macos": {
+      "etag": "0x8DC2792904D8C6A",
       "checksum": "4cc0133122a263a50116235c82ebc9d14b36cd7c0d223aeb5805ba7e6fcd788b"
     },
     "x86_64_windows": {
+      "etag": "0x8DC27926C6AC85D",
       "checksum": "99a61a99a2529188854c1a2719b1849d92cce0509e6241d11b408fda9e5ba2d9"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC2791FFCB0198",
       "checksum": "23b198e0538a9e0689c41b41060c1fc299e834a2b8a68b7409b4e3f68be059ec"
     }
   },
   "0.4.36": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBF12F51C8810B",
       "checksum": "cd90951af7b4afc3afb6d8e96abd8f48bcd24249d042d359739883da919352ff"
     },
     "x86_64_macos": {
+      "etag": "0x8DBF12FC58156DC",
       "checksum": "5276f8f3915c6e52f35e5e44c2c199e346f00d519b54028d75241e1fb364a93e"
     },
     "x86_64_windows": {
+      "etag": "0x8DBF12F95B36ED8",
       "checksum": "69a20b3906884769381c33d613d5d6ffdf795f052951681b6ce8a8a30f281bf1"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBF12F4DB041BA",
       "checksum": "dad8195fca7bac42b91cc9f7be12509425153df6c87d947699a4b04f9a84f844"
     }
   },
   "0.4.35": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBC146A2043563",
       "checksum": "574c2a4e03ee656999da506c4288084a690f234c589812e29825a7687af5942c"
     },
     "x86_64_macos": {
+      "etag": "0x8DBC146C1B5EEFF",
       "checksum": "ca3281c2b5437a1ccd9079ed8121b3dd97c49be74dae32ea803b540a38c334bb"
     },
     "x86_64_windows": {
+      "etag": "0x8DBC1471A1EED32",
       "checksum": "d306a09e552616c1d27f10cebe85848b96970881674ad28d9414cd259a949c39"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBC14696DBD08F",
       "checksum": "359af01b77fbd6bf6243a3f2b2491a37b5480bbb2674eb2d94f91354253b34f4"
     }
   },
   "0.4.34": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB960089B40753",
       "checksum": "dde955d5b3df83ebaed716cf18d53b05678a4b78500cfa33aedd138bd55a1152"
     },
     "x86_64_macos": {
+      "etag": "0x8DB9600AC352D31",
       "checksum": "738f423f1857c58a6175cf35254de4e616ca61db93803766eca5773ca6dbf516"
     },
     "x86_64_windows": {
+      "etag": "0x8DB9600F1DE9574",
       "checksum": "3679b9be098c410423797f14bae01523a2074ad0ffe8668980df074d1d4e5198"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB96007386E3C0",
       "checksum": "b7188119e088dc87a1db13963f78eaffb4a3959109936e26ee4afea74de0df5c"
     }
   },
   "0.4.33": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB94838097A710",
       "checksum": "f56043b14b2d554b98aa6cd5e15bcbe81c095cea67a937c6c724300da4fc4005"
     },
     "x86_64_macos": {
+      "etag": "0x8DB9483D3361C23",
       "checksum": "172e83fea640b41afecf46d5bec3b09d0d54c5e6234b9e3777715b6c6a4a58a3"
     },
     "x86_64_windows": {
+      "etag": "0x8DB94841FEE56C4",
       "checksum": "573acc650654cca12c77d73f0f7c8d22fdce92d7348c0bd4676579c60ee3c0b9"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB948380EC6C8A",
       "checksum": "dbafc64ee0bd616ee10ab367686fc7a000d817ddb7c6634e8b878e6c322bb38f"
     }
   },
   "0.4.32": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB865F709425B6",
       "checksum": "ac38f040eb462752548c865d6c9e900aa862852d42190cd773d5f20cd7b757f9"
     },
     "x86_64_macos": {
+      "etag": "0x8DB865FD592C59E",
       "checksum": "a625001956c903ff7b6864e90bb6380eae0e8ed711040dfeab932ace68e73d79"
     },
     "x86_64_windows": {
+      "etag": "0x8DB865FD6046839",
       "checksum": "c06f2eeb4cfa487931213b830701a3dfa1eab5fcd7ec3756f14ffc68171a4817"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB865F77F604BA",
       "checksum": "e68950f91fa907e89bd7d3f4d3e228a0c7bb4556689ba9e2b3adc42e4e7d6021"
     }
   },
   "0.4.31": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB78DD79E45B4F",
       "checksum": "0332c3149dcc0b6ad1baab6cbf73f90e45b919fea3bd9c55fb5739fa980b2eaf"
     },
     "x86_64_macos": {
+      "etag": "0x8DB78DDB05CCF6B",
       "checksum": "817300d62cff7ed1bf15921934ec9998c07a3ed8e293d8f1c4b32634206c08de"
     },
     "x86_64_windows": {
+      "etag": "0x8DB78DDCAE7BEF0",
       "checksum": "f55c476e298b53d9724933b8a0df5d150f5340ac8a08b64405e402846c3ac5b4"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB78DD771771F0",
       "checksum": "6946e91283380f5a86c9ff8cb98b0449904d66d75ff4dfac759ccbef8800d20e"
     }
   },
   "0.4.30": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB5FC89BCDC696",
       "checksum": "c911f8e5b501707a6b84a5b7162f3c6543f580e5261034d23d2843319da12bb0"
     },
     "x86_64_macos": {
+      "etag": "0x8DB5FC933C44ED8",
       "checksum": "02c80613f57c9d421adc4c60286c680c1e8f75a2d7d0ab4b7837819175eb967a"
     },
     "x86_64_windows": {
+      "etag": "0x8DB5FC907681F7D",
       "checksum": "50c1adcabb37e291b9689b76898e91bf98428e5d5335dd3724f7c223f7a9ebb1"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB5FC8BD83C4A8",
       "checksum": "475fc2ad49d909e8a13a8055bd9a69984e45eb70c1851f8dcf15dbf2b541815c"
     }
   },
   "0.4.29": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB53EA39EF4F1C",
       "checksum": "e46da842fc1cba24efbf0028ef372435cfe2b5a55b87b287e698ae87d6a9e44c"
     },
     "x86_64_macos": {
+      "etag": "0x8DB53EA869375EA",
       "checksum": "7424c8206cfe07e24928bf606e7fb2c386d22db7d1f0058734fa313b58879c37"
     },
     "x86_64_windows": {
+      "etag": "0x8DB53EAD1B5194B",
       "checksum": "ff2b491b41ecd65350137278e72f8ef10c161374cd47c474fc2a196c37f5e03e"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB53E9FB7E7900",
       "checksum": "f89b5937131b5f826330d7ff542d878fe8689f037bf10b1595bfabc390b14da1"
     }
   },
   "0.4.28": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB1D113E148E5B",
       "checksum": "84e3a4982c19e19b1d058af30b8835097109f520cb6c2e9e03413a896c9787aa"
     },
     "x86_64_macos": {
+      "etag": "0x8DB1D11CA33DA7F",
       "checksum": "46605497fac2a379a02fa7287c0e4601a0cdfa2f913a4f1a06d820d91c0c310e"
     },
     "x86_64_windows": {
+      "etag": "0x8DB1D11D5E9BAD3",
       "checksum": "996bc212502e51da1d69090134d13cf51ff21e478be9b7e2aeb1d330c7865e35"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB1D1140A33E9D",
       "checksum": "86b01509773e4011a9372de2932ceb0fdd52063153c7a673f63eeacf16c8426b"
     }
   },
   "0.4.27": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB0DDD48F219C6",
       "checksum": "44ee34f8a6a1e0788f870c0bfd890dfce112c70f63e7254c5d8f20525600bc7b"
     },
     "x86_64_macos": {
+      "etag": "0x8DB0DDDBE5FAB2C",
       "checksum": "107461b477c512c9c9deeed051abf9bbb25858867dc2f0f493fc7c2fadfc3532"
     },
     "x86_64_windows": {
+      "etag": "0x8DB0DDD8FCC0E53",
       "checksum": "18c7eea09bee53f539a11ec965547147afc2083c4cac22563b724aecf57b57bb"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB0DDD41886697",
       "checksum": "4b7a489f1ba35b0b95dfb026b2e46d7e11fb593f2074afb2be10db0f56530dd2"
     }
   },
   "0.4.26": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB0A32B0072B8C",
       "checksum": "8a6334a932f2adf05c2647e86e9ef028714717c0a8e57b1e2d9c85f251f1a734"
     },
     "x86_64_macos": {
+      "etag": "0x8DB0A3358453508",
       "checksum": "14b9d933d5bbc7a4ef4ba476d7fb8ec5d3c4b42a33c0883e6d1ff3b2ef51738d"
     },
     "x86_64_windows": {
+      "etag": "0x8DB0A330B2A9758",
       "checksum": "60c3fa5cd51383dd4e4bc22ded1cca92c5f9b97540ac458cad62b660f9c9a43c"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB0A32AB599E92",
       "checksum": "4461322990ab3b3e65005fdf3b28c4e083cd8504834babf2ad726701596197bf"
     }
   },
   "0.4.25": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAE04B889ACC05",
       "checksum": "f8481706ceda01d170aa02e1d87cf61abb24e5b67f9081f3d306f2861f1af5aa"
     },
     "x86_64_macos": {
+      "etag": "0x8DAE04B978AF3B2",
       "checksum": "5f11014060f557919c5abc44f051d08f08f4ed036d1086b06b5dcdcea1ced64f"
     },
     "x86_64_windows": {
+      "etag": "0x8DAE04B5A1FD558",
       "checksum": "771e5aa0bffbb475a05f8fa1889550475672fbbec229bc1cfa85e16c3c8852c8"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DAE04B6F045230",
       "checksum": "6a49db5a2681c485b59d870d309364537a8d9f646b6f22cce684794f4ea05c0d"
     }
   },
   "0.4.24": {
     "x86_64_linux_musl": {
+      "etag": "0x8DADEAFE5A19B59",
       "checksum": "0795d994a9315d972804b0d2fe119f924db97362f3e855cadfbd5a203002b239"
     },
     "x86_64_macos": {
+      "etag": "0x8DADEB072E24794",
       "checksum": "897d504a556f0a9353292b996acf46b535492bbf1fb773547cde1853878ed91e"
     },
     "x86_64_windows": {
+      "etag": "0x8DADEB094AF26A7",
       "checksum": "08d79f491ff2e5b6886bd2415d80cba2e41be9cf674738b76d9ac3a4c1bc8eff"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DADEB000FC7A98",
       "checksum": "36ba581d277caa0412bdea229104f24ecbab7488497aabd3c4ba2c5c746a6d94"
     }
   },
   "0.4.23": {
     "x86_64_linux_musl": {
+      "etag": "0x8DADE4770D22D2E",
       "checksum": "a31f7f10046d6b4fe229fd5af308187ef76888a232fdd6f3ba085e484182024d"
     },
     "x86_64_macos": {
+      "etag": "0x8DADE48080A631D",
       "checksum": "3ea55b1ff0a961757c0348d759e7acc9a5d1be08c3af6939d02ff18f8b747938"
     },
     "x86_64_windows": {
+      "etag": "0x8DADE47FB5A8D1E",
       "checksum": "5b4aa8a5f875bd51925dfbd844decd91977b5e34fea2364a8fc76411b06fe856"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DADE475C49AC5A",
       "checksum": "4082a16ff8b3b4cc3496b6aa3fc865776c8e71cdc41c539d7c316948953f4d78"
     }
   },
   "0.4.22": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAD16D8C5E10CC",
       "checksum": "ecfaedf19686e0ab487c9028f9796b5ef758a1fb882010fc8ff8a5f8c698f83f"
     },
     "x86_64_macos": {
+      "etag": "0x8DAD16DD382F7FC",
       "checksum": "cb18900671c5c4197583a15380fcd37ffe0ed42fb06eb03f1f5e74f84c08a87d"
     },
     "x86_64_windows": {
+      "etag": "0x8DAD16DD326DBD8",
       "checksum": "a0584811a721b5ebf6de10811afeb49a6efae3a365feff13ddfb6bc7402dbba0"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DAD16D6D66AAD6",
       "checksum": "6dd9b0d49564dee44f5d23b46218437efe69e6f41becaf8d0f92e62d0ad62f5f"
     }
   },
   "0.4.21": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA6C0DAF8A313E",
       "checksum": "ec3c978a255b444987fd6e0805147f4ea75d221f68c6e27dbf3e8a28aba166b7"
     },
     "x86_64_macos": {
+      "etag": "0x8DA6C0E00028A79",
       "checksum": "c1f3e8235f8b3128f6020397061c97444007e090ac42358402d3f25eee8499bd"
     },
     "x86_64_windows": {
+      "etag": "0x8DA6C0E42A88125",
       "checksum": "19e4da3352083ad1de346ec1d1d6108a6143b96e552d0bc9db6626927be65c21"
     }
   },
   "0.4.20": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA65E0645C6F76",
       "checksum": "77e49898e2570370d30d0221393f6114ab66ad138ef4e9e2da2a5e652a090255"
     },
     "x86_64_macos": {
+      "etag": "0x8DA65E0ABEB0F44",
       "checksum": "b4b5c8d2ceb21c133ad87042d13dad50b76fdd4ed3e433c942a921160ff5bce2"
     },
     "x86_64_windows": {
+      "etag": "0x8DA65E0C42F2799",
       "checksum": "8befdc124c4d39c7a5bf715c68fdd5ae48b731ef4d987bdb823ec91d6a8ac828"
     }
   },
   "0.4.19": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA5BB4BC9FA0E9",
       "checksum": "50a419363d8233f42a038ff3c5d977d44b7cb7f860f34b4567161241642aec9a"
     },
     "x86_64_macos": {
+      "etag": "0x8DA5BB4DA01839F",
       "checksum": "f106b2425f9a5b7dfb6db632a593661406584c79670fa663d5369f627b5a0504"
     },
     "x86_64_windows": {
+      "etag": "0x8DA5BB50464C4D7",
       "checksum": "48822e82cee0ae2961318f3c820b001e8deb8819491593ace725d03d75cd3825"
     }
   },
   "0.4.18": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA1F0F6720F1F8",
       "checksum": "d276b0e594d5980de6a7917ce74c348f28d3cb8b353ca4eaae344ae8a4c40bea"
     },
     "x86_64_macos": {
+      "etag": "0x8DA1F0F75D408D3",
       "checksum": "4428d57b073a8d52d04a75bff9fd305285b850437ba57812945dd96cb08f911f"
     },
     "x86_64_windows": {
+      "etag": "0x8DA1F0FC96E3229",
       "checksum": "b775785504a87bfe6e6de52d57857edf97211e281460721921f055909f2dc639"
     }
   },
   "0.4.17": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA1272E12D0F67",
       "checksum": "04f32a87356d3df34e2a3dfbd2bc1fb0d52b01a271bf86ccfdd434c718aab6c8"
     },
     "x86_64_macos": {
+      "etag": "0x8DA12753665FE18",
       "checksum": "6bf52ad9cd90c470fece969109da9b25fb067fb1468f9fb781818f1df5058e33"
     },
     "x86_64_windows": {
+      "etag": "0x8DA12733B7761B2",
       "checksum": "380294a6d8c47fc3064e272dac0b995dfc0fec9daeb4f0ad738c3b20dc286879"
     }
   },
   "0.4.16": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA11E755663062",
       "checksum": "bb658a9185cbff52d95ef1c089b33f77ec3b2784e9dd3db18779a28e2bb446f0"
     },
     "x86_64_macos": {
+      "etag": "0x8DA11E77211DB90",
       "checksum": "dff2304f57607468a9d71cbf7c2eefb6dad0a32de805962b0496e1c1c4e6dc58"
     },
     "x86_64_windows": {
+      "etag": "0x8DA11E7B1E19484",
       "checksum": "698915db56c4620ae02241889ab96af30c8fd5e22574cd252e2fe504e67a81ce"
     }
   },
   "0.4.15": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9D01C9D9FE872",
       "checksum": "4ce861733f08e58ffcd35ed0beb536734fca2543f13b6efc59623234fb17a6fd"
     },
     "x86_64_macos": {
+      "etag": "0x8D9D021E935D458",
       "checksum": "fb65afd8ac5cfaf33b603f70af5342be6b0680a310d7ca0a9703ce60602ccf94"
     },
     "x86_64_windows": {
+      "etag": "0x8D9D02DD518796D",
       "checksum": "15621bd351290897b9823666a888f3d87e5f395f9f8bae6f49143778aec650d1"
     }
   },
   "0.4.14": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B9E0BE32555D",
       "checksum": "0ed75f6e4115f02d806932c4b1a8d9aca276ea1bbc3979524b4a8847bd3510e4"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9E0AD845070",
       "checksum": "bfbe4ab4c949f6fa9e99fc69e5d7666de78f2c59e2bd5f116994f02230708b83"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9E0B8EC8CBB",
       "checksum": "374aa2b79228a0cf4c7be9417bd7598287d125509e09e9e701cfa1c9fcd881af"
     }
   },
   "0.4.13": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B9E0B30D32B3",
       "checksum": "f040334cc62a3779c23a0df6eb648de445ca747d8f87956927a9b13c5bffff40"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9E0AF48C89D",
       "checksum": "c3a92c36700bd037b8eea27056e66f64ab279c21343dfee7b14e750795624f6c"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9E0A99CAC15",
       "checksum": "093a5dcfccb0d5615d0b8ace4389d0c1af6d71ff25b9e86bfb0ffb7403e434e9"
     }
   },
   "0.4.12": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B9E0AB02BE64",
       "checksum": "2a0953c50d8156e84f193f15a506ef0adbac66f1942b794de5210ca9ca73dd33"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9E0AD7B5114",
       "checksum": "9cc8daf78545cd334113a9133c9c77bbca6117cc4ddb65190701aa087db67d14"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9E0BBD9C925",
       "checksum": "114d7f2bfadeadb417d22a627ebe141dbedcf1b98c3060eeca198fe7e35e94b7"
     }
   },
   "0.4.11": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B9E0B56570D4",
       "checksum": "d26c32fa09e0199ffa30705beb05a16b17a2fb2e96977de277f96695f6185049"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9E0BCBBF1B7",
       "checksum": "16615a2b4b5e623f35d27c24fd6651b8e80cdcb315176c3c8feba07161442811"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9E0A99DBD5D",
       "checksum": "2e8aa0458b90d1a282aeeee83af660b5e8013fd315609e1c45c88009f31adfae"
     }
   },
   "0.4.10": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B9E0ABB5797B",
       "checksum": "90e7c8d4866e9837bfdcb89291d26e627db61e53c8678862f11ccea44871b386"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9E0AFCEADE7",
       "checksum": "6eef8d02227517171f7b3f22afc0c49e5ee5b91bec3468baa8ad4a45bd5db0f6"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9E0ACC93220",
       "checksum": "0cf037f2f7fc111db6a2bb4d3eacc97efcfa3b2adab680375fd471b756cd6437"
     }
   },
   "0.4.9": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B9E0AE91C870",
       "checksum": "19e281061a74fdacfe3ac99247b89d6f14e8ee2b950b0c253045b29fdedb78b9"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9E0BB5458FD",
       "checksum": "cd377b6fb02c3de0316c154bfacd50f2ce085f985f404df4788a64ede9953dd6"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9E0B86C24EB",
       "checksum": "60d4b7db9d89d38ce803f57ebb09c380697b43cdc5417c395c9b0500332618c6"
     }
   },
   "0.4.8": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B9E0B210330B",
       "checksum": "4734a224a7bb8f9436fe2cb32065346446f6b34a1bc474156c3c1837a8767e4c"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9E0AD241611",
       "checksum": "8f92fe2f8dbc96ae25ac259258f22b36e7fd05fbb4c1cfa8f8b88da200918d91"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9E0B85878BE",
       "checksum": "beebc51a5705e0247471f57df814c8e9268a00a73c4cbd7fef5c834a9db4be0e"
     }
   },
   "0.4.7": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B9E0B5A72B25",
       "checksum": "6f1f5d41f3b503f0d5b08798c4645af2b7c753e1bebeefef8157e897a70a46b1"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9E0B94749A7",
       "checksum": "d5850cbcbc17ea7c8a61b3dc00496e6f207c865e55f7bb1311c2274739295f54"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9E0BC949957",
       "checksum": "1b40ef9f80f23793d90d0a12b5c7d037ab9a04fbc4791874d276fb2191738d0c"
     }
   },
   "0.4.6": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B9E0BA03EE5C",
       "checksum": "2469cb81f8de93c99bfbeaa6227acad3c7f6a58821d2056a91704e720b79a5c9"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9E0B06B7336",
       "checksum": "9019fc24b53e6c32fbd94bf53d12b053e8d4be85af0699fdb59520db0acf3124"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9E0BDB7E027",
       "checksum": "0b82981ba056b6e6b812d7f8dcf6b70159196ae5efcae0890245c14315144549"
     }
   },
   "0.4.5": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B9E0BB659485",
       "checksum": "c6810849bfdcf9fdeafb693129308c8e4b7811134e1fe413eb7bacac697b9789"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9E0B67E31CA",
       "checksum": "7895d715b8ed842419d433378f2224673451daf27ea5be3f1f5f1b35afcb7557"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9E0B159A7FA",
       "checksum": "0cd0dbee829623a96029ec67a52bb11470773c8d5eb3621eca6419948300a8b8"
     }
   },
   "0.4.4": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B9E0AA6CFCF4",
       "checksum": "a518d005ed6a264e49998917d33e08769ac1d9c812405e7d214673aea625411d"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9E0BB4BCEBB",
       "checksum": "d4631542fbda1efbd5d78d3d1f558949ea9dcf37efee7027d9ee61767e63f49a"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9E0ABBE2AC5",
       "checksum": "7c5632c83889c4fb65dc1bf061253da7e680a8ec63076a14cc117721ecaf79fe"
     }
   },
   "0.4.3": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B9E0B7ABFE4E",
       "checksum": "f493c5900b0267bf62ce135cfdc3f5d79038f3a0d4d29c1b9a71e681b3b36f49"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9E0BC6D8F11",
       "checksum": "c3068d0c9833481ce68d5bf789e9e61dfb2721ac7c14ad838b4d3a1e60d496e7"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9E0BF561138",
       "checksum": "f320e7d588312a1de5f7a6bf0a7a41c141c05c8530ae2992d7677e7b1eed4fcf"
     }
   },
   "0.4.2": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B9E0A9AED1DB",
       "checksum": "bb24820961c9d71e42f2c2bc06915b27624924d40b7d16e6592a465af9b7162e"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9E0ADC658D0",
       "checksum": "bbc431955c47522a572632e5b652c2a8fe4d4df81716fc93425bd6ea3b1edcb9"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9E0B0FDB2BB",
       "checksum": "6c225ef79988bc6f171dd3c9ac6a86195b8e8bb0597cfaba6d48c479918f20b4"
     }
   },
   "0.4.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B9E0B3187BBB",
       "checksum": "a5f6c15107fd5a6c933bbed167d8c130676fa7a0cde225b86fb7fea0e88ac975"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9E0B470112D",
       "checksum": "2da87684a33d7a015e29afb109dceb6ecbc1fc41e49e1843e2d73e3a6e820501"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9E0BC5C057C",
       "checksum": "020112f87404cf08abff760d72ba0bca1a2cab98ea4b0e7b4fe08ce7a2f2778e"
     }
   },
   "0.4.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B9E0B91210A5",
       "checksum": "9a4e11b7a8a7571c0557fda4cbd0b0cf0f2e901e7ce2950ef41a7620b0e86bec"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9E0BB891CE6",
       "checksum": "2ab1f83cb7d29fb1a1b49a2ea3e8028689003ea73d34a9e2bb99a633c76470d2"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9E0B2D7D2AD",
       "checksum": "4f099c12e4487c296311da2a961617c98ec3866bbd3d1f58733433334ac7c94e"
     }
   },
@@ -523,83 +661,105 @@
   },
   "0.3.7": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B9E0BF6E0284",
       "checksum": "9b61fe2476dfd8b8459702966bf2f226f9d6eddc00133adf09e37d30e7eab117"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9E0AF06C03D",
       "checksum": "8c11b8c9006dbd213fecdb965d27cc5f2d53666f8e181cdf66179fb78523372e"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9E0A9C193C2",
       "checksum": "f260ef843690498cb093e9e03cef9aa9c1af353b665d80ebd169c45366dac653"
     }
   },
   "0.3.6": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B9E0BD740339",
       "checksum": "2dc365bb0fe0413acbe612e85363a93677ba245eaf96b3f40de9241333d7e4a6"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9E0B674BD4F",
       "checksum": "4000b76aaf581f904a1edb144199e916888c6e4fe825085ac7b832de465bed46"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9E0B6132398",
       "checksum": "caea9739ff15173ef218a63f10803715d755f077d0a4bf9d11f7497d49f29d35"
     }
   },
   "0.3.5": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B9E0BF3B883E",
       "checksum": "e03cc253650fa0b4780fab4d75df64c48d35d48f452fcf61c5ec0ae652f9bd8e"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9E0B3D4AB42",
       "checksum": "8f1ee9de790dfbad71fa32545920e23c4630cebab39796a80be8f4496cd1f9ff"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9E0BAC1F26B",
       "checksum": "e349550aecdd2b43f9ab134c167932ba478d5d8e7ce00406f6419fe94472a4a1"
     }
   },
   "0.3.4": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B9E0B81A194E",
       "checksum": "c457371017737ebb2c3b6553712d6ab53dda1949397770eb270e5caf2a7080f3"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9E0B3B408A4",
       "checksum": "e561b93002516194834b3006653790f60c7f01fab0a009beb12390a5a8d00176"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9E0B03EC473",
       "checksum": "1baf27b79982bb7fb80967b8cac09b911a4d4f1694590ec17f7ee9e353b4b029"
     }
   },
   "0.3.3": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B9E0BC752F15",
       "checksum": "ec2c0199fb03f0cdaf8456166616553aca0816f909de68fd494bed11a9e0b41f"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9E0B4D37F64",
       "checksum": "291b61b4b653d3d0b231bb1c03a2d1f3dfa7d9ae4179829012da2bf0504151bc"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9E0AAFA0D20",
       "checksum": "50c326cc8f12fe2aeee5daae568b8e1883e99d503c215e338918b51c6720a088"
     }
   },
   "0.3.2": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B9E0B82D776B",
       "checksum": "3410ba48cdd816ccbcd7b7784db1802f023d741e8a4cbbb8fe7c45dce41fed4a"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9E0B7D3F2D5",
       "checksum": "9665ee859ab730b9e4dab9773acba3390f34c5dd90e4a219713d130fcd6ca73f"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9E0AD5B71B1",
       "checksum": "ccc0ff1e18c613f4d4a23e6ef63b32c53dd86ac2ecd65c051bd52a1564aaff71"
     }
   },
   "0.3.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B9E0AB53DFC4",
       "checksum": "4511fb1d4d95331099a4c1777d6af8022ac5783af70b83f018c78c896a4027ab"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9E0B87FF824",
       "checksum": "83c6cf845bb00e6bcdcbbf18257385791ad296f8efd710d8eff063ed20b8f51e"
     }
   },
   "0.3.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B9E0AAF0E6B1",
       "checksum": "4f42e0581be10b89c65007a48e4dab1f0070643498f070ea9cbd67ee92ac906e"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9E0AB56EC92",
       "checksum": "3faeb638f603b7522c234edae4e0e67de4779062349c7aefea06e754e0d0bccb"
     }
   },
@@ -608,17 +768,21 @@
   },
   "0.2.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9E0AB0E0760",
       "checksum": "342b1b5de4b6039b0c73220b5c03f12075d005f4f44276507b9afd64e7f5e06e"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9E0BA1CC9EA",
       "checksum": "07f4ef84cb1890bc2deb26ea12f34f69f0667c37ade5f93d216dbce70a7ccd27"
     }
   },
   "0.2.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B9E0B021CAC8",
       "checksum": "bff39ef5c9cbdbfe03b5294bbc72d30d3c3e4acc350b3551799dcf62bbc79351"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9E0B2111D57",
       "checksum": "ad5ff7d841d4ec6a275a0f5e3e71d3329159ba9b00f3b22b52e0873b47977cdf"
     }
   },
@@ -627,70 +791,87 @@
   },
   "0.1.8": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B9E0B8FF9CC8",
       "checksum": "fbe6ec7bfb38289aae0a31c9aed6ba561c512b8f3c3dca700ccf0f3a28222e6e"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9E0ADE8CFE9",
       "checksum": "dce8bb553ad7d402bec3c1bc7a0149b28db14de563fd4afcd0e1a134e8ed6a85"
     }
   },
   "0.1.7": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B9E0A9E8C519",
       "checksum": "7d290787fabded0363c8218fba24f8b0837937266b533ad90777170066d0738d"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9E0AF8C095F",
       "checksum": "eecdbc7de50992f291845b12f25f05e0a316150c82240a39e237622d0083e251"
     }
   },
   "0.1.6": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B9E0B0A56676",
       "checksum": "76edbb107106df2b9e8f50b77531a46779c46f99e2c13b1cf35b819144bb3716"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9E0BC3067F4",
       "checksum": "b55ad1ec955dbd6ca0f2d81cf9629a609d024db30e75d9e3247e018d88af9ca2"
     }
   },
   "0.1.5": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9E0AFDF263F",
       "checksum": "7d473fb329d11a0b1bcdc50559a8558a512b099a5543f405e11199203389d682"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9E0B0AD7B9B",
       "checksum": "b104c8effe5a9c083359c31aaf96e8a79348e419e94dfd9d7d4af5fd4710f8ba"
     }
   },
   "0.1.4": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9E0B806942B",
       "checksum": "b1cd74ece0ab57ce9617fdc5748acae2d45e24585ce348786c9aae18c49c391a"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9E0AB3279FC",
       "checksum": "40d9b9343305b27dbd9250cc1e59593464128e3da340ebc69c62aa2b794b21d1"
     }
   },
   "0.1.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9E0AF93D066",
       "checksum": "d5304bd023d6ddcbf75a72a32fb9c76ef71ec6007bee6ebd30416245d6c39d51"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9E0B87B8BFD",
       "checksum": "74a88dafd8b73db30f436e883172b069598a66b18ce6c4ee95e7f71b0c985682"
     }
   },
   "0.1.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9E0BF14F310",
       "checksum": "6b078ffe764992df44f42653bf5a4b3ce019072290d51ecbcb11ccf9c18b03a8"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9E0AE320333",
       "checksum": "45352a210ed77ec4bee467d644aec0ff08897e8a9349a3c5b2b40b6bb98f7f02"
     }
   },
   "0.1.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9E0B4FBE90F",
       "checksum": "3c4056df1b416a9cef1f5cdb5eab25c0af91933a575e4baeb960fbc6276c5b40"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9E0ABAB68E1",
       "checksum": "9f7076a01ea8769dc76a81b08f912b149952f0ee003ecc467c81a7807cb03fb5"
     }
   },
   "0.1.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9E0AAC63374",
       "checksum": "29c4218111d7e8a2b00b259f3c3208e24706823c6b4e2cce26e784575817cf09"
     }
   }

--- a/manifests/osv-scanner.json
+++ b/manifests/osv-scanner.json
@@ -14,26 +14,32 @@
   "1.8.1": {
     "x86_64_linux_musl": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.8.1/osv-scanner_linux_amd64",
+      "etag": "0x8DC919C231901F4",
       "checksum": "68905cf614795df742cc7d2b337b82fa5308f0ddf24fbe4e3f885cdf55ff9c76"
     },
     "x86_64_macos": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.8.1/osv-scanner_darwin_amd64",
+      "etag": "0x8DC919C23373D7A",
       "checksum": "ce882a778632544f23840bb094f38d6737daa5d4f54449643239b04e92ddcd36"
     },
     "x86_64_windows": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.8.1/osv-scanner_windows_amd64.exe",
+      "etag": "0x8DC919C23B63EF4",
       "checksum": "2892dbd0efe5418f7811934d45103c2f8b2f4474396258918f4cc3110b56ce4c"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.8.1/osv-scanner_linux_arm64",
+      "etag": "0x8DC919C2311695E",
       "checksum": "962f68d47a9afc2f0c679c3940a0a57abc391391365900b45aa830e324dd6c01"
     },
     "aarch64_macos": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.8.1/osv-scanner_darwin_arm64",
+      "etag": "0x8DC919C23BAF4A2",
       "checksum": "0f3689de6bc3642397121fc77b2da1ef0d0861627216c71a2a945ef20ee26839"
     },
     "aarch64_windows": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.8.1/osv-scanner_windows_arm64.exe",
+      "etag": "0x8DC919C231389E9",
       "checksum": "f8e9d835b3450dc4bb9a328ea6b011033fc93d562646f2cf453a56fad3ad55b5"
     }
   },

--- a/manifests/osv-scanner.json
+++ b/manifests/osv-scanner.json
@@ -43,104 +43,128 @@
   "1.7.4": {
     "x86_64_linux_musl": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.7.4/osv-scanner_linux_amd64",
+      "etag": "0x8DC804A777E1D5B",
       "checksum": "0b35daf50d3a9992836e7f78f56cb21b870da58f15f75c516dfb2c2ab4789d0f"
     },
     "x86_64_macos": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.7.4/osv-scanner_darwin_amd64",
+      "etag": "0x8DC804A77741685",
       "checksum": "19bc3908787cba8c024f384552c429e58cd204641a29abfde48ec8f861c796e3"
     },
     "x86_64_windows": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.7.4/osv-scanner_windows_amd64.exe",
+      "etag": "0x8DC804A778713F8",
       "checksum": "a658e56f6a3324b7e09d7bd407f025a20610176ac9f93d083b8ae13ee7788d94"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.7.4/osv-scanner_linux_arm64",
+      "etag": "0x8DC804A78547970",
       "checksum": "fe26a8bd00e38d2b70bd049a97e03f6c27ac8fd74d5608c2c48b425cf46568ae"
     },
     "aarch64_macos": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.7.4/osv-scanner_darwin_arm64",
+      "etag": "0x8DC804A77702358",
       "checksum": "9259dd6fef1f5f0a504a225e8c3edd6c8222a8a7ff7369a79f94b11bb2be13e1"
     },
     "aarch64_windows": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.7.4/osv-scanner_windows_arm64.exe",
+      "etag": "0x8DC804A7838AC85",
       "checksum": "5aabb5aeeccb0c4e3df1cac269fa907c19112c553452a045f159d9d5b5314108"
     }
   },
   "1.7.3": {
     "x86_64_linux_musl": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.7.3/osv-scanner_linux_amd64",
+      "etag": "0x8DC6FC03FC9737D",
       "checksum": "ae8dc75d66ae6fbdcb7d4010d32567e37cbc3ac21aa649a65cb33e0d45cbe78a"
     },
     "x86_64_macos": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.7.3/osv-scanner_darwin_amd64",
+      "etag": "0x8DC6FC03FC338EE",
       "checksum": "af5c7432fe17f5e3f98658a5f5407ce7e1456eb750153a47ce24a6eedd8cfb1a"
     },
     "x86_64_windows": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.7.3/osv-scanner_windows_amd64.exe",
+      "etag": "0x8DC6FC03FD52620",
       "checksum": "21c5db4fea55c0ede614a338dee586f45b07e18792f78abe127ef0de52a6842d"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.7.3/osv-scanner_linux_arm64",
+      "etag": "0x8DC6FC0405F8C54",
       "checksum": "ed527974c44eca991a6c3a9e4aa8a74199c9a7f460242342b0eccfb400ee4c16"
     },
     "aarch64_macos": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.7.3/osv-scanner_darwin_arm64",
+      "etag": "0x8DC6FC03FCAF865",
       "checksum": "e0c38f4c886036951016ea72c807ff7c9d482ba2b5a65f134182def05316c72e"
     },
     "aarch64_windows": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.7.3/osv-scanner_windows_arm64.exe",
+      "etag": "0x8DC6FC0406CEAC7",
       "checksum": "260383781b33021f5e7f172afd77c3ce28af4afd0889a828359bc7775dbd7416"
     }
   },
   "1.7.2": {
     "x86_64_linux_musl": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.7.2/osv-scanner_linux_amd64",
+      "etag": "0x8DC5FF46F7E7781",
       "checksum": "8e89b8bca569c8abe3614b3ce403c6c0e8a9a555b295d9fa21628af6921e65d0"
     },
     "x86_64_macos": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.7.2/osv-scanner_darwin_amd64",
+      "etag": "0x8DC5FF46FBA52DB",
       "checksum": "4f45e9599bf467ddaf9ff59a444c9cde6d1094d0b51e6ce265c718e0d8c71f2a"
     },
     "x86_64_windows": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.7.2/osv-scanner_windows_amd64.exe",
+      "etag": "0x8DC5FF46F956828",
       "checksum": "0d1f75bb31ed6d0a091e08f2c66bf4d3e815442637b05584f79f9e26bf8fd793"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.7.2/osv-scanner_linux_arm64",
+      "etag": "0x8DC5FF47310932B",
       "checksum": "929eade915a805c350745a76b275ed400b4e8d4c769a17be3f0084cf05197996"
     },
     "aarch64_macos": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.7.2/osv-scanner_darwin_arm64",
+      "etag": "0x8DC5FF470686CCE",
       "checksum": "dd65874c69a21e6f8feeb1c0c9b84f0c0afb9740dc7a181fe239448c549f1eda"
     },
     "aarch64_windows": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.7.2/osv-scanner_windows_arm64.exe",
+      "etag": "0x8DC5FF470578FD9",
       "checksum": "01a0fcf61d27f804837e952db4b78748a54410a744a2ed703d66042e99add4ba"
     }
   },
   "1.7.0": {
     "x86_64_linux_musl": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.7.0/osv-scanner_linux_amd64",
+      "etag": "0x8DC3D93FA9F3043",
       "checksum": "3baa59720f92a37a90b23317d51dcd0a8eb11e612d3218e00859b36bfa2f84bc"
     },
     "x86_64_macos": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.7.0/osv-scanner_darwin_amd64",
+      "etag": "0x8DC3D93F8726799",
       "checksum": "db94288f80a29742e98f0c7e520fae411e16f5c2a251f5bf12d8a30a91fd6bdd"
     },
     "x86_64_windows": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.7.0/osv-scanner_windows_amd64.exe",
+      "etag": "0x8DC3D93F878A226",
       "checksum": "cd85bb140c2406e91f365947f1d3e30b942b2450f3e643cef9a6b1a6c87e6eb0"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.7.0/osv-scanner_linux_arm64",
+      "etag": "0x8DC3D93F995C91E",
       "checksum": "9ac3f0dc3f0fbfae5fc9e8e00d46906e08e5e85f88c5e79950d331d0f139a5c5"
     },
     "aarch64_macos": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.7.0/osv-scanner_darwin_arm64",
+      "etag": "0x8DC3D93F85908B7",
       "checksum": "b814f74155a9bc30794589f74c8fe3ea23c2e50290a437dc530ca5bc90eb5049"
     },
     "aarch64_windows": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.7.0/osv-scanner_windows_arm64.exe",
+      "etag": "0x8DC3D93F8635D55",
       "checksum": "6cded48db94f74f6be3325002d308a5a678c81814b62a07b3ce91b9c5a5ccd5b"
     }
   },
@@ -150,52 +174,64 @@
   "1.6.2": {
     "x86_64_linux_musl": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.6.2/osv-scanner_1.6.2_linux_amd64",
+      "etag": "0x8DC220EDD1BB2A4",
       "checksum": "b8440f451509ea4a4f12b363352659e7c37718d8e170d537ffdd481b031cfd41"
     },
     "x86_64_macos": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.6.2/osv-scanner_1.6.2_darwin_amd64",
+      "etag": "0x8DC220EDD22140C",
       "checksum": "07cd355aa9b0bc3b1013b9e053cf79ebadfe51d48337707194d39807293d79c8"
     },
     "x86_64_windows": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.6.2/osv-scanner_1.6.2_windows_amd64.exe",
+      "etag": "0x8DC220EDD129521",
       "checksum": "2bccba4c1b97906ec9dab4307d2ec701c5636f786e073707880ba91e57a71923"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.6.2/osv-scanner_1.6.2_linux_arm64",
+      "etag": "0x8DC220EDDF53F08",
       "checksum": "57821f223373d259469d5d08bd7710cd228e7c056aaa5ab70045ba3f9d32c991"
     },
     "aarch64_macos": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.6.2/osv-scanner_1.6.2_darwin_arm64",
+      "etag": "0x8DC220EDD854814",
       "checksum": "646bf2564680ef776de5478ec5fd34f2ed3f945345d16aa01f64e388fa40c9d6"
     },
     "aarch64_windows": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.6.2/osv-scanner_1.6.2_windows_arm64.exe",
+      "etag": "0x8DC220EF77BBFF8",
       "checksum": "060270c5499d51890f97812ef92e751b7243e0a76503376d860d083712f62a7d"
     }
   },
   "1.6.1": {
     "x86_64_linux_musl": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.6.1/osv-scanner_1.6.1_linux_amd64",
+      "etag": "0x8DC17C0C36DD388",
       "checksum": "319ad945005166ff4dc72534d3913303466047e7cc8b1f00b1a68f3b265251f1"
     },
     "x86_64_macos": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.6.1/osv-scanner_1.6.1_darwin_amd64",
+      "etag": "0x8DC17C0C487073A",
       "checksum": "70877545acd3a0f0e72c9784542daa7d64939392c333fabe2b2de27f8fc66b6c"
     },
     "x86_64_windows": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.6.1/osv-scanner_1.6.1_windows_amd64.exe",
+      "etag": "0x8DC17C0C386E496",
       "checksum": "e8595d720b2509fb95e326ea1c1faf8ef604d90cc20b6c27d7721050893ffc30"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.6.1/osv-scanner_1.6.1_linux_arm64",
+      "etag": "0x8DC17C0C45BBB36",
       "checksum": "c26ee30805e1038710b0c1ed775dc6c8852612072e7fffc7dd70ab0b03ddc88b"
     },
     "aarch64_macos": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.6.1/osv-scanner_1.6.1_darwin_arm64",
+      "etag": "0x8DC17C0C3AF748F",
       "checksum": "e596f4f6bb1ce706821d36b724c5fff119c652ea9adbac20dd4c8389c08bc756"
     },
     "aarch64_windows": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.6.1/osv-scanner_1.6.1_windows_arm64.exe",
+      "etag": "0x8DC17C0C36798F3",
       "checksum": "07cdf63ef04b3e976131e0d88b8710ed5d7f26533c5790cee6dfc032d552ca81"
     }
   },
@@ -205,26 +241,32 @@
   "1.5.0": {
     "x86_64_linux_musl": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.5.0/osv-scanner_1.5.0_linux_amd64",
+      "etag": "0x8DBF60F237521CB",
       "checksum": "c73e1e90af40a86683a2addc8eb410e300c73f59c7eb224c7f24cf1e57b025b4"
     },
     "x86_64_macos": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.5.0/osv-scanner_1.5.0_darwin_amd64",
+      "etag": "0x8DBF60FB7AB89C2",
       "checksum": "e0f98909fefbdb9d584d5fd90373efd45c3f1783ec67ebf78eedb660a6b8c49b"
     },
     "x86_64_windows": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.5.0/osv-scanner_1.5.0_windows_amd64.exe",
+      "etag": "0x8DBF60F249EBEA0",
       "checksum": "eb975fbe0c933cd782c9f02c72e13d86cff3d78f42b960d10972f5b8f0dd3fbe"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.5.0/osv-scanner_1.5.0_linux_arm64",
+      "etag": "0x8DBF60F26D98299",
       "checksum": "0bdadcbc3cc862af537a3a84360e1f4fbd1c77285c1b7b272e04b7e324fd08b7"
     },
     "aarch64_macos": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.5.0/osv-scanner_1.5.0_darwin_arm64",
+      "etag": "0x8DBF60FB723438C",
       "checksum": "c425e0ffa868bda2384d8f809e32078d59ea7d31d31971f9abc990eef948569e"
     },
     "aarch64_windows": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.5.0/osv-scanner_1.5.0_windows_arm64.exe",
+      "etag": "0x8DBF60FB89EEAC0",
       "checksum": "e76ce919f939cc03cbf2fe5b39ce34d2404c7bcd3bb81b2d334cc7ce3281b7f8"
     }
   },
@@ -234,104 +276,128 @@
   "1.4.3": {
     "x86_64_linux_musl": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.4.3/osv-scanner_1.4.3_linux_amd64",
+      "etag": "0x8DBDB404AB63024",
       "checksum": "12cf86c2febe582ce5711130d10f97a5a76ee8c7f72aea0da1aa4a4dcdcc38a8"
     },
     "x86_64_macos": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.4.3/osv-scanner_1.4.3_darwin_amd64",
+      "etag": "0x8DBDB404DED2452",
       "checksum": "d2d290f14738e4f9f8faa28f78d3fa330d1fb5878e33d1fce584cd2c3577c0e3"
     },
     "x86_64_windows": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.4.3/osv-scanner_1.4.3_windows_amd64.exe",
+      "etag": "0x8DBDB404C67C507",
       "checksum": "eee7e4e0b2f70e7984a1d1d841358a7cbfb60da0c98fb3768f8b117fc15b7c90"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.4.3/osv-scanner_1.4.3_linux_arm64",
+      "etag": "0x8DBDB404B737B2C",
       "checksum": "c95680e0839afbc33b183b79fc16a0a9bd0270628cab2e9a81197f8ad665a946"
     },
     "aarch64_macos": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.4.3/osv-scanner_1.4.3_darwin_arm64",
+      "etag": "0x8DBDB404BD771EC",
       "checksum": "5e92128ebac68abcea294c572daed4882bc671721a5f6140c1fb22c71644accf"
     },
     "aarch64_windows": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.4.3/osv-scanner_1.4.3_windows_arm64.exe",
+      "etag": "0x8DBDB404C68FC1C",
       "checksum": "fa25ffd2f5e045b9de3f7fbb7cbaa4114a98fe978813f80323591ef5313e73f2"
     }
   },
   "1.4.2": {
     "x86_64_linux_musl": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.4.2/osv-scanner_1.4.2_linux_amd64",
+      "etag": "0x8DBD50BB6DB7B4D",
       "checksum": "c984a605ab1abc629fb2c80edbf6374a36a62e5996c064b5e987d832a06f90ad"
     },
     "x86_64_macos": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.4.2/osv-scanner_1.4.2_darwin_amd64",
+      "etag": "0x8DBD50EF3733427",
       "checksum": "5df26d494e5544088aa6c516705d418cf2693b2a27c18d7b9ee7cf043d0a87b9"
     },
     "x86_64_windows": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.4.2/osv-scanner_1.4.2_windows_amd64.exe",
+      "etag": "0x8DBD50C1917E5A6",
       "checksum": "d61ceec1a6df1414c235318d7085230926bf5bc45b2f85f39f98b4817108a973"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.4.2/osv-scanner_1.4.2_linux_arm64",
+      "etag": "0x8DBD50EF445760A",
       "checksum": "b0f823350294e704eb647c7e556b29027c110d69e7509038efff9de3678aacf7"
     },
     "aarch64_macos": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.4.2/osv-scanner_1.4.2_darwin_arm64",
+      "etag": "0x8DBD50C1857DEBA",
       "checksum": "62a4c21024dacf044d56796760d4e1a0ded7a02243d2b6c8b1b677c44df4a666"
     },
     "aarch64_windows": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.4.2/osv-scanner_1.4.2_windows_arm64.exe",
+      "etag": "0x8DBD50BB81D18D6",
       "checksum": "5e42614d73d9218a4d0352270f2261e77b232cab2378dd673a50e2da5ae24d9a"
     }
   },
   "1.4.1": {
     "x86_64_linux_musl": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.4.1/osv-scanner_1.4.1_linux_amd64",
+      "etag": "0x8DBC5609BDD42CE",
       "checksum": "7e6a55e4f26b33dec0714a1d9fbd81421e6a581492445f5b8f27ff53ddbf78ec"
     },
     "x86_64_macos": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.4.1/osv-scanner_1.4.1_darwin_amd64",
+      "etag": "0x8DBC5609D372F52",
       "checksum": "c48bb3ec271b6dc437cb54e18441584297d4257a338f3fb0e86361bcaaf30eaf"
     },
     "x86_64_windows": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.4.1/osv-scanner_1.4.1_windows_amd64.exe",
+      "etag": "0x8DBC5609C212B63",
       "checksum": "a5d091bbd80753a639637d0e9a1a291e456bb2235ba4ac742a88a88ba43077a2"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.4.1/osv-scanner_1.4.1_linux_arm64",
+      "etag": "0x8DBC5609CF14D18",
       "checksum": "5b06a68b64b0415c84239daea77543179a9e33101bb8bb5839ecebf5eadb6ce2"
     },
     "aarch64_macos": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.4.1/osv-scanner_1.4.1_darwin_arm64",
+      "etag": "0x8DBC5609E48F240",
       "checksum": "514cfd1e5d454dee32842bb4ef278c6f3c0d383e294795cfa47b7571567a3ff9"
     },
     "aarch64_windows": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.4.1/osv-scanner_1.4.1_windows_arm64.exe",
+      "etag": "0x8DBC5609DF42CA3",
       "checksum": "7cc1f6430be37901310b63928e7f8be3d3bc6bd3ed55a32c0f7a025b49d13ee5"
     }
   },
   "1.4.0": {
     "x86_64_linux_musl": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.4.0/osv-scanner_1.4.0_linux_amd64",
+      "etag": "0x8DBB4C1D4EE3C2D",
       "checksum": "48e8ca1ed33ac6bb1adf3ee33d323519a2b4a8af4d59219aab0fcb03ff71de29"
     },
     "x86_64_macos": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.4.0/osv-scanner_1.4.0_darwin_amd64",
+      "etag": "0x8DBB4C1D4F2CAF0",
       "checksum": "d6c6d63a34b304785234fb4fad945714538e180243eee23997a20adfd8a32d30"
     },
     "x86_64_windows": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.4.0/osv-scanner_1.4.0_windows_amd64.exe",
+      "etag": "0x8DBB4C1D43B6CA8",
       "checksum": "1f8d50c74563f811b4c99e1c3ba2bf4a4462876e5c1534abfd7f9e4f49a5afe9"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.4.0/osv-scanner_1.4.0_linux_arm64",
+      "etag": "0x8DBB4C1D428484F",
       "checksum": "30f68ff06a52de80c56cbe05f7716fe9e94275efc750147da8cd47d5a2da9389"
     },
     "aarch64_macos": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.4.0/osv-scanner_1.4.0_darwin_arm64",
+      "etag": "0x8DBB4C1DBABE6BF",
       "checksum": "6c3cf2aa98bc12f8a4f9ebdaa29701b0f4d7147e4893aea43a4042f76510c130"
     },
     "aarch64_windows": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.4.0/osv-scanner_1.4.0_windows_arm64.exe",
+      "etag": "0x8DBB4C1DB6C8CF8",
       "checksum": "88ee304d9734c9b13e1b5d85e580e7108b7cd0828ab9d0707bc3af278bcd892a"
     }
   },
@@ -341,182 +407,224 @@
   "1.3.6": {
     "x86_64_linux_musl": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.3.6/osv-scanner_1.3.6_linux_amd64",
+      "etag": "0x8DB881A881A6CB9",
       "checksum": "ac9766ba926d98094aef6f3e9ccb9bff5d1f10bfc7dc9831984737d84b699a88"
     },
     "x86_64_macos": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.3.6/osv-scanner_1.3.6_darwin_amd64",
+      "etag": "0x8DB881A88222C3F",
       "checksum": "3f75c0d4887cde3d963aa702a7e351005781a74347d52087c870e63bb9a0f44f"
     },
     "x86_64_windows": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.3.6/osv-scanner_1.3.6_windows_amd64.exe",
+      "etag": "0x8DB881A879274FB",
       "checksum": "f0ebec92386fca9ce3c224fc58a7b2431b52e38c139ec4aff5c5437a61c1d08f"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.3.6/osv-scanner_1.3.6_linux_arm64",
+      "etag": "0x8DB881A88CEC0C5",
       "checksum": "d396ff3c07b8b510e33dd2811f7ebd7f3483fe379a2c602a9ca1fbcbde1f567a"
     },
     "aarch64_macos": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.3.6/osv-scanner_1.3.6_darwin_arm64",
+      "etag": "0x8DB881A88D01EC5",
       "checksum": "0fa5d723ebca643946a1a8ce959f1206f05a9be432fcc79c023567b3b162fc0f"
     },
     "aarch64_windows": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.3.6/osv-scanner_1.3.6_windows_arm64.exe",
+      "etag": "0x8DB881A87491471",
       "checksum": "b853955a79449cdedf7b29080400a630b144904d1162bf4d362fd0bcabf7c073"
     }
   },
   "1.3.5": {
     "x86_64_linux_musl": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.3.5/osv-scanner_1.3.5_linux_amd64",
+      "etag": "0x8DB779E7E5D097E",
       "checksum": "39fb4263afa493d6058e7ad9e1fe699ce070871b7b67b5f5f9eead358c7ab2ee"
     },
     "x86_64_macos": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.3.5/osv-scanner_1.3.5_darwin_amd64",
+      "etag": "0x8DB779E819F3C33",
       "checksum": "65001b8c97559ed6fb632ae3ee574f9f4b2fb05184d3049876fd56f7557fe915"
     },
     "x86_64_windows": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.3.5/osv-scanner_1.3.5_windows_amd64.exe",
+      "etag": "0x8DB779E7E7FD3BD",
       "checksum": "08a78e3b30ee9c6f5f71d78d43cd6d27bdb5289e56d65efd464b0e79958f20cb"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.3.5/osv-scanner_1.3.5_linux_arm64",
+      "etag": "0x8DB779E80949D31",
       "checksum": "f71396c832d727fb90e1c072d912ece0b9a5359cae5df47d54e88ef712d99e41"
     },
     "aarch64_macos": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.3.5/osv-scanner_1.3.5_darwin_arm64",
+      "etag": "0x8DB779E7F4138EF",
       "checksum": "303c1a27843fef36fd7ec06fb972e92cb120380f32dbfdc1a0af2d565103cef4"
     },
     "aarch64_windows": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.3.5/osv-scanner_1.3.5_windows_arm64.exe",
+      "etag": "0x8DB779E7F528A9B",
       "checksum": "47ad6d7a48f64c3dce8011ff864129f81f0257d2e2d6fe5e309361b19f96a343"
     }
   },
   "1.3.4": {
     "x86_64_linux_musl": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.3.4/osv-scanner_1.3.4_linux_amd64",
+      "etag": "0x8DB6709A2FE775D",
       "checksum": "588c42cdc23b64947ebbd0756193fd800c5d281e8fa6df4c309943060b398fcc"
     },
     "x86_64_macos": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.3.4/osv-scanner_1.3.4_darwin_amd64",
+      "etag": "0x8DB6709A30E6AFB",
       "checksum": "32e343998d892baf309b76b131f2b8cfb6b58a589bba52512d6538db052ba656"
     },
     "x86_64_windows": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.3.4/osv-scanner_1.3.4_windows_amd64.exe",
+      "etag": "0x8DB6709A44282F2",
       "checksum": "7987894ce343c07a72dd054fb2b600ee1fab7035e2639a1e9d69af94498bc4fe"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.3.4/osv-scanner_1.3.4_linux_arm64",
+      "etag": "0x8DB6709A219ACC3",
       "checksum": "7e12aedda030c0a9bef4b5efcd2cdde5fedcc657b050ae48b97bb43b9e5e773c"
     },
     "aarch64_macos": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.3.4/osv-scanner_1.3.4_darwin_arm64",
+      "etag": "0x8DB6709A218EA49",
       "checksum": "0edc0d9769a1ee69607a085669bfdbd86c5dcd1b5550439820d6ef148fa9d555"
     },
     "aarch64_windows": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.3.4/osv-scanner_1.3.4_windows_arm64.exe",
+      "etag": "0x8DB6709A3FA0BAA",
       "checksum": "f330f117590693599d526d1fa8acc6ba09ab099d4fde18f078bd3084d37a7639"
     }
   },
   "1.3.3": {
     "x86_64_linux_musl": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.3.3/osv-scanner_1.3.3_linux_amd64",
+      "etag": "0x8DB56924B29EEFF",
       "checksum": "deddb04c36915c1c9e79ae6769cb8b3ca7cb091fb42e3a5d087df42dee974a98"
     },
     "x86_64_macos": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.3.3/osv-scanner_1.3.3_darwin_amd64",
+      "etag": "0x8DB56924C3B3D14",
       "checksum": "44eed376ea2e59238c264ace637e20e78e3bc40d648eeee270d8ce7a159e6e04"
     },
     "x86_64_windows": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.3.3/osv-scanner_1.3.3_windows_amd64.exe",
+      "etag": "0x8DB56924A607CB1",
       "checksum": "3a7fc1c9df14363618d27238ce589d247245b473dfaae5d98686870d1c50a9bd"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.3.3/osv-scanner_1.3.3_linux_arm64",
+      "etag": "0x8DB56924B4B0D60",
       "checksum": "aaec809ae95223a9142671402d9b1c99d529557178b5966958f93e842a92dbdd"
     },
     "aarch64_macos": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.3.3/osv-scanner_1.3.3_darwin_arm64",
+      "etag": "0x8DB56924C3308EA",
       "checksum": "ab60e7e651c94399e844a44ddca36e7b285727e24ea3d8434872a095789eab01"
     },
     "aarch64_windows": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.3.3/osv-scanner_1.3.3_windows_arm64.exe",
+      "etag": "0x8DB56924A670501",
       "checksum": "1f2e1c650896cfbf3c7e9bba5a3a9328448f02fff0602ec7cb26e06e165b9021"
     }
   },
   "1.3.2": {
     "x86_64_linux_musl": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.3.2/osv-scanner_1.3.2_linux_amd64",
+      "etag": "0x8DB4611288914A4",
       "checksum": "fcaf82e159abdaadedb81e940d1149f2262fcb4164d9f3e2540d751381682dbf"
     },
     "x86_64_macos": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.3.2/osv-scanner_1.3.2_darwin_amd64",
+      "etag": "0x8DB4611295542AA",
       "checksum": "9ab2c6f8288192d35fcbbe23e26cc216287c0214a5e61920ed3e4c25402c0690"
     },
     "x86_64_windows": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.3.2/osv-scanner_1.3.2_windows_amd64.exe",
+      "etag": "0x8DB4611287506FD",
       "checksum": "eff05ee74c4a673070f1364dde3bc784bd400c94227f2456389fdcf6aae1e842"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.3.2/osv-scanner_1.3.2_linux_arm64",
+      "etag": "0x8DB46112936929B",
       "checksum": "d0ad9a973eda4ec8a53272ae3c7248071c93e773c9c4c1d6e78ff67d342ded66"
     },
     "aarch64_macos": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.3.2/osv-scanner_1.3.2_darwin_arm64",
+      "etag": "0x8DB461127DFFE8B",
       "checksum": "719743a2e90369970bbcb3161af7cfb9fd8c3b89b03c039a0034b6b5213530dc"
     },
     "aarch64_windows": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.3.2/osv-scanner_1.3.2_windows_arm64.exe",
+      "etag": "0x8DB461127C395DF",
       "checksum": "ac99665986e3f3d2df1c8a243b3056abd9dc54e41fc8f14fd8f6ef0b1ba4b5db"
     }
   },
   "1.3.1": {
     "x86_64_linux_musl": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.3.1/osv-scanner_1.3.1_linux_amd64",
+      "etag": "0x8DB30D296206BAA",
       "checksum": "6a54e74b1d6adc9241862f28498765033af3079ffd6c20af0455f6e821e51dbd"
     },
     "x86_64_macos": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.3.1/osv-scanner_1.3.1_darwin_amd64",
+      "etag": "0x8DB30D2964700E9",
       "checksum": "34c093f430eed512ec62b708d070e4ca2b24605da7d23b8e855523fcee057bf5"
     },
     "x86_64_windows": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.3.1/osv-scanner_1.3.1_windows_amd64.exe",
+      "etag": "0x8DB30D297C023EC",
       "checksum": "45f06809582799e4a772a84d19a38aa3045b861a3a78b8b37c43f3e1784e74ab"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.3.1/osv-scanner_1.3.1_linux_arm64",
+      "etag": "0x8DB30D297CC5728",
       "checksum": "4e3931f461d5177e98d870f25d29d480481dd0f7358936d573f9a28791bd9a7c"
     },
     "aarch64_macos": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.3.1/osv-scanner_1.3.1_darwin_arm64",
+      "etag": "0x8DB30D296F9953F",
       "checksum": "ca33dabf95320430a2026d2ef074d3297e9935f0d740f9559d132ed72f23a5df"
     },
     "aarch64_windows": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.3.1/osv-scanner_1.3.1_windows_arm64.exe",
+      "etag": "0x8DB30D297130D05",
       "checksum": "123174ca0ec605493581bcac61f6a226d239001d401ee047a4e9f69e27e16843"
     }
   },
   "1.3.0": {
     "x86_64_linux_musl": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.3.0/osv-scanner_1.3.0_linux_amd64",
+      "etag": "0x8DB2F3B6F471D50",
       "checksum": "9559d734e9afd6f736a4b35af68d9ba6e8e5a3640e77d5b898660978dc97a3e0"
     },
     "x86_64_macos": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.3.0/osv-scanner_1.3.0_darwin_amd64",
+      "etag": "0x8DB2F3B708E141D",
       "checksum": "52df112d157730727e261608aac34c4073904e2e670f30623cec8b699855f118"
     },
     "x86_64_windows": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.3.0/osv-scanner_1.3.0_windows_amd64.exe",
+      "etag": "0x8DB2F3B6F36A4F3",
       "checksum": "653116402b37ee9ac54b281629cd8643efc21637da907accd0c355c70022f937"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.3.0/osv-scanner_1.3.0_linux_arm64",
+      "etag": "0x8DB2F3B6FEDCC8F",
       "checksum": "d34f97fc73e7ca37d3ea845bcaceb49604b344e94139127e3428c52c5a1353ee"
     },
     "aarch64_macos": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.3.0/osv-scanner_1.3.0_darwin_arm64",
+      "etag": "0x8DB2F3B70AF52EF",
       "checksum": "ca0ccce2b22766a6c2b139c758fb20268edb06063dbfa3a7ef76a9930ad90305"
     },
     "aarch64_windows": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.3.0/osv-scanner_1.3.0_windows_arm64.exe",
+      "etag": "0x8DB2F3B70321EB2",
       "checksum": "0af2954893d5b3297466baff4827ffb6217a71ceb6a65fdce3e161ee40cc3445"
     }
   },
@@ -526,26 +634,32 @@
   "1.2.0": {
     "x86_64_linux_musl": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.2.0/osv-scanner_1.2.0_linux_amd64",
+      "etag": "0x8DB153E543EFE14",
       "checksum": "50937fa0456d6a41e61455f35bb9b40760d345aab6113a83b2d0aa334edd29c2"
     },
     "x86_64_macos": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.2.0/osv-scanner_1.2.0_darwin_amd64",
+      "etag": "0x8DB153E54F84846",
       "checksum": "23497bd395cdde5a6dbf5a32468853e12e99c0a09c93873522e8d3395a33634d"
     },
     "x86_64_windows": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.2.0/osv-scanner_1.2.0_windows_amd64.exe",
+      "etag": "0x8DB153E55A008E4",
       "checksum": "ec811a39119726d8834a7501cf61712cd71f5f45c984ed66df5bec57617157ec"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.2.0/osv-scanner_1.2.0_linux_arm64",
+      "etag": "0x8DB153E54453EBD",
       "checksum": "2e0c517250d80593de2e28edd705222a6006d91feefd0aae63895f5f32f06385"
     },
     "aarch64_macos": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.2.0/osv-scanner_1.2.0_darwin_arm64",
+      "etag": "0x8DB153E54F27CBB",
       "checksum": "1b00100ecc5ec31b79001ae9675850d72449215984d6613d712e051f105ed2d4"
     },
     "aarch64_windows": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.2.0/osv-scanner_1.2.0_windows_arm64.exe",
+      "etag": "0x8DB153E57C4E3B2",
       "checksum": "95e378acdc3ad65f719e2b3da0740efc4a95f7f76ace4aad3b4041fe38c0c92d"
     }
   },
@@ -555,26 +669,32 @@
   "1.1.0": {
     "x86_64_linux_musl": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.1.0/osv-scanner_1.1.0_linux_amd64",
+      "etag": "0x8DAF4500C23C755",
       "checksum": "73b3b297f0a9a3fa28ea45fd45b3b9e74e5a0044ec1c03693a4e8aff0d169f86"
     },
     "x86_64_macos": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.1.0/osv-scanner_1.1.0_darwin_amd64",
+      "etag": "0x8DAF4500CCA27CC",
       "checksum": "fdb19c0f3b4bec887940f73de49b524cebe93e8e5acd74123eb62f90b5a0451f"
     },
     "x86_64_windows": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.1.0/osv-scanner_1.1.0_windows_amd64.exe",
+      "etag": "0x8DAF4500DA43ACB",
       "checksum": "7da5337a25771fa8ebfec1d00304a8948b9ef5f6e04e75dcb3a01ccb64ce95bb"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.1.0/osv-scanner_1.1.0_linux_arm64",
+      "etag": "0x8DAF4500C21A4C7",
       "checksum": "fed5a1109f45410d8bcecba852aab48f1812b5254e3cfdd2950ef9330e9e29c2"
     },
     "aarch64_macos": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.1.0/osv-scanner_1.1.0_darwin_arm64",
+      "etag": "0x8DAF4500CC12874",
       "checksum": "65fa9c435535fd58cc1fd6878a09009c44d608c749c41b8f7a7e4727cda0e6ee"
     },
     "aarch64_windows": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.1.0/osv-scanner_1.1.0_windows_arm64.exe",
+      "etag": "0x8DAF4500D8B1133",
       "checksum": "e01ae91abe3c5f34da01b7a90741663bbc606f85030520946169965b64bd6c5c"
     }
   },
@@ -584,66 +704,81 @@
   "1.0.2": {
     "x86_64_linux_musl": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.0.2/osv-scanner_1.0.2_linux_amd64",
+      "etag": "0x8DAE240B2723685",
       "checksum": "5b550521d7ca7f708059daff6a45bae776bbefa4c0f1a4ce5298cd50808a3d7a"
     },
     "x86_64_macos": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.0.2/osv-scanner_1.0.2_darwin_amd64",
+      "etag": "0x8DAE240B2E4217F",
       "checksum": "0e64408697ff1e80f4e0866e890d1dc842dd8316296d7d2659db23c200bf0f3b"
     },
     "x86_64_windows": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.0.2/osv-scanner_1.0.2_windows_amd64.exe",
+      "etag": "0x8DAE240B3B00633",
       "checksum": "ac9c77d9a5e91e8050b2aa5af9e13c5547775ae969d51ae957e08a8dc3804764"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.0.2/osv-scanner_1.0.2_linux_arm64",
+      "etag": "0x8DAE240B25C8ED5",
       "checksum": "35286ae9ef2c1b24a5900398f1039a268d602279e82ff03695a24e0979f2dc7d"
     },
     "aarch64_macos": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.0.2/osv-scanner_1.0.2_darwin_arm64",
+      "etag": "0x8DAE240B2FF1F97",
       "checksum": "9f3bf97708adb3cd25f609519440ec6b675f8b4c6ca0a71e4de68967bc3bee3e"
     },
     "aarch64_windows": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.0.2/osv-scanner_1.0.2_windows_arm64.exe",
+      "etag": "0x8DAE240B36C5059",
       "checksum": "d04936bff72361efe97cb03f8badb53d743cee2a3664900ca928be9649a0bd6a"
     }
   },
   "1.0.1": {
     "x86_64_linux_musl": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.0.1/osv-scanner_1.0.1_linux_amd64",
+      "etag": "0x8DADF08C26F61E1",
       "checksum": "a5fe0ecc63a730c73e4aad1e0bc13aac51d3fe00222c5982e0978550f8efd6a6"
     },
     "x86_64_macos": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.0.1/osv-scanner_1.0.1_darwin_amd64",
+      "etag": "0x8DADF08C27BBC18",
       "checksum": "52e3c0082ced8f70558eb9776744585d25bca08f0aeddd93d854344e133bfe5e"
     },
     "x86_64_windows": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.0.1/osv-scanner_1.0.1_windows_amd64.exe",
+      "etag": "0x8DADF08C39ABD5A",
       "checksum": "9d871f7ffe368dc24c5b01fa4b746f363270277806d1209dbc85076bb291a03f"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.0.1/osv-scanner_1.0.1_linux_arm64",
+      "etag": "0x8DADF08C39FC5B1",
       "checksum": "7b02b7330b255c25e91fe1fce85ab9461b925a92894fa82c17cbce1e7ce017c2"
     },
     "aarch64_macos": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.0.1/osv-scanner_1.0.1_darwin_arm64",
+      "etag": "0x8DADF08C3008FE7",
       "checksum": "ff87ff3add4062bfc1a0c5894df9d256cca4a6c9189a2a778c92c932f667de91"
     },
     "aarch64_windows": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.0.1/osv-scanner_1.0.1_windows_arm64.exe",
+      "etag": "0x8DADF08C3060D64",
       "checksum": "f1bebaad4fb464da0387e4e6bb7245fbb80bd97b9e22cec70bd1291e5319f74b"
     }
   },
   "1.0.0": {
     "x86_64_linux_musl": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.0.0/osv-scanner_1.0.0_linux_amd64",
+      "etag": "0x8DADCC2AD91EEDB",
       "checksum": "998c7060e4f78bc0a933dd3e41ff92404ff70df792939ca48fcb02a9dc94b8e8"
     },
     "x86_64_macos": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.0.0/osv-scanner_1.0.0_darwin_amd64",
+      "etag": "0x8DADCC2ACE43C51",
       "checksum": "267b672fd8f2ad422b9fd55fcb319ee04b38d605500b95e8343fe6f65854222c"
     },
     "x86_64_windows": {
       "url": "https://github.com/google/osv-scanner/releases/download/v1.0.0/osv-scanner_1.0.0_windows_amd64.exe",
+      "etag": "0x8DADCC2ACF502B3",
       "checksum": "d9347ad3cc64a47706ab3bcf261be04d26ef0c34fea2ac69089aca4b971cda52"
     }
   }

--- a/manifests/parse-changelog.json
+++ b/manifests/parse-changelog.json
@@ -11,234 +11,288 @@
   "0.6.8": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.8/parse-changelog-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DC60E7C05C6CD1",
       "checksum": "c5d34291892c66cf5e2d45e61f822c420a86c48c54631422863894eeee8d11f1"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.8/parse-changelog-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DC60E807A4279A",
       "checksum": "37a3fb9b9e1a46c99ca306a2a68a8c317d3011375d7274256389d16986b5c3f4"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.8/parse-changelog-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DC60E7E0F4C3D7",
       "checksum": "e4f971462c2fb29387af7269634027d57b06c05b644d7412249c8d0c25cfc799"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.8/parse-changelog-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DC60E816FAAF44",
       "checksum": "a3f1705c925d0b158c0a555a97848baa952d160cc7952dc66e1be1735d787316"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.8/parse-changelog-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DC60E86F67F72D",
       "checksum": "76314b47a0b6f60b5f635ad9af7577d618ea69759306b954dbe3b0196b32550e"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.8/parse-changelog-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DC60E9C6C5D9D0",
       "checksum": "c9e7db9dff60ec0adff8658968d0d9430db9a7c77fd1885b21d688a0d82e88ee"
     }
   },
   "0.6.7": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.7/parse-changelog-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DC607DBFA22109",
       "checksum": "ca2aa9c8982059327da84bde3bc76df01766d0a2c0e2941fbb88e44d472a3621"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.7/parse-changelog-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DC607E131D6910",
       "checksum": "825747ef16033b9b5cf73d0d8b349ffd6a6ad32366b29f6d637d84d4ed4685d5"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.7/parse-changelog-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DC607DDE58EEE1",
       "checksum": "ce1b92ac2aee88572dc09cf7870ff8f75224a14993af8c2c59063caeaf01f78b"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.7/parse-changelog-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DC607DBA0E3A21",
       "checksum": "5f9c3f5673f828b9c2ab0dc70e54abfbf2d731b333667de42816352e85e8a184"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.7/parse-changelog-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DC607DD5C3B478",
       "checksum": "ff7c1e6d662ad0a89e0af923b6a1a6b63038d26bc18a0b0758b30cc0c740b073"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.7/parse-changelog-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DC607DCD4CB58C",
       "checksum": "543e4df2bc66b767557c64b226d6722fe483a147a6fc7ef203919b2c5c8f2d4a"
     }
   },
   "0.6.6": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.6/parse-changelog-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DC555E584F90E6",
       "checksum": "b69f876c15d0152ae1272a0a39568b43cec3736b6e66c3300405ae9d6fdc4760"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.6/parse-changelog-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DC555EAA94B5E5",
       "checksum": "7ddd89ab37f2989e1ab61c899e17aeded29a7949412bc782c9bc30c0a00e9a26"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.6/parse-changelog-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DC555E64040466",
       "checksum": "4c8152394762570a10da52251af56d390a9f98675fa863d1de65a2a6c93b0a69"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.6/parse-changelog-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DC555E585BDF1E",
       "checksum": "ad1242a89ab72b3f36f0a5e1989510ed2ef4b286dba9f5c078bbee2078508a32"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.6/parse-changelog-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DC555E63738ACE",
       "checksum": "5ee2f83a32a7373e2022d79cb637763c35a45d03601ca5505131c265d6329e9d"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.6/parse-changelog-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DC555E8697BB6C",
       "checksum": "6bcd17c384673d6dda79dae590eaefc4ce4796500a4c4a7fc8d091f9e9a0f143"
     }
   },
   "0.6.5": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.5/parse-changelog-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DC3D2B89FB4FEF",
       "checksum": "73ab820f50a26cce5548e1c6d3e4e97fa008bbad80c4bc844fcc5e89a2b540ca"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.5/parse-changelog-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DC3D2C7FDF9F78",
       "checksum": "aa12781c8d57865d18217286fdf10c1eb772636e7e86b20425335858d76aad03"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.5/parse-changelog-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DC3D2B9FA81753",
       "checksum": "98d13ef997a8da38d5b419d516c48da302042f054d3a89238cfab0f1ba6971ba"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.5/parse-changelog-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DC3D2B5C910A3D",
       "checksum": "33f67cfed6d4ed71da5e873026723a70d79ca99a53bcb1ab2121b33c591ad45d"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.5/parse-changelog-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DC3D2C68FF3CB8",
       "checksum": "77dffac8a8f562172ba0b19a998665a02c0a60f876eea047dc6126e5118378b9"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.5/parse-changelog-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DC3D2BCF975EA6",
       "checksum": "e4f39aef6fe8e233cdac88e5029d785f48805a65ec31c511fbf3200e26ded97e"
     }
   },
   "0.6.4": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.4/parse-changelog-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DBCFE989170E5E",
       "checksum": "df2d97039ede5d93785a801a5d998627ba28bc5d2b092d6602356f7aa9149706"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.4/parse-changelog-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DBCFE9A7EFDA4D",
       "checksum": "071cd442ad95ea97f14b71cf005558ee08ec33b76e0456c933c6ed9f9033cf16"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.4/parse-changelog-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DBCFE9C37A4DC2",
       "checksum": "200bd6074d65e715aee01ea44be992081409c95bd6f852dc59327a14882f820b"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.4/parse-changelog-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DBCFE99FECA151",
       "checksum": "ca6d8407b30647465ecc9188f0b1ee83479f05ed378db504ddbe666e15612409"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.4/parse-changelog-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DBCFE99803B092",
       "checksum": "2d3ad67d62a806d2f62e741a53375900e886cb8d414c804cd8c6bb596fb4f06d"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.4/parse-changelog-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DBCFE9AE642234",
       "checksum": "e206f5699322ed0e2b91d14b26687cf2040be863dd035490ae68ada19872b416"
     }
   },
   "0.6.3": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.3/parse-changelog-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DBC0EC4E1F1F1F",
       "checksum": "b01992d759aad7e861363e1d4bbb808b28d530844da1efbc9f8f0f54bad2f813"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.3/parse-changelog-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DBC0EC519E3AAA",
       "checksum": "5d0fa26aa6e742b96d1ef8c7aeccdf63469512a706961921242bde2de7640d89"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.3/parse-changelog-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DBC0EC7A80DA24",
       "checksum": "31c7bbe5b64ce66e948166e71e7d9c0ab5fb694daec7730ccb17b3448300e029"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.3/parse-changelog-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DBC0EC4ABA24DC",
       "checksum": "6aa06d96c2a7c89786f9925e6c54472c77fda0c813c335566f870ecb4ca34d8e"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.3/parse-changelog-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DBC0EC4F6A006B",
       "checksum": "963e1b4614cd42a28090365522efc9d7a4f1220ffe9d7bc0b1da8ae29fa6fba9"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.3/parse-changelog-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DBC0EC83E85161",
       "checksum": "67fb1af8515d0b531bcea8686570d600fbe80c95994cb0c4cf7216b21a48aac4"
     }
   },
   "0.6.2": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.2/parse-changelog-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DB9663A1E04230",
       "checksum": "e64e446ba613599ca51583fc94fd1062bd79550e5e75bab9ef3047d021b6bb3a"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.2/parse-changelog-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DB9663C671F325",
       "checksum": "11898a671fa48b328fc80d3287b9b9e36c1d97e22031c3bdd2c24fc1b9209ef9"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.2/parse-changelog-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DB9663D0AFEA80",
       "checksum": "8ef3f5dacd2f47811a6ba0559c2474d266c616a3bb76aea9bf3c5236b30891bb"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.2/parse-changelog-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DB96639C632958",
       "checksum": "1bcee8f53807c5a571460db33fcd12d00b22220a5e5a1ab6c536c904ef47c604"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.2/parse-changelog-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DB9663A506A4BF",
       "checksum": "76f77e36fec9c4b57190aabdd36fb140121088d3bfa1b2672be2999b71eb6a48"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.2/parse-changelog-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DB9663C251F657",
       "checksum": "c9315d7352538cbe67dc9547ee8fbd6bf196fb0ae6317b903dbb6bc57b0420ff"
     }
   },
   "0.6.1": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.1/parse-changelog-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DB7BC9FBD5232E",
       "checksum": "852a84c345787f959b5838958cd9d2f322059cce59fb5b005070b84182231a98"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.1/parse-changelog-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DB7BC9E2ACA7B0",
       "checksum": "fcb4c8c48628967cbc2e52efbdb1a9b9151ff8de7cbb64fd60c8fc0cb5c12e73"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.1/parse-changelog-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DB7BCA076C47D3",
       "checksum": "a0bf79cdfb76aa2ccb546c9734d3d06535858419485acb42dc3cce68088dc0be"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.1/parse-changelog-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DB7BC9E4A46BAC",
       "checksum": "5e31f9eefdc1b0db62bfd022e217b84d644db9f75b3eafaacd716dbb9361efdd"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.1/parse-changelog-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DB7BC9DC26C100",
       "checksum": "9f699a48e43af8a9ba92ad8c5e0400c57963be89297a0e0e318ef143c9f8cc8e"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.1/parse-changelog-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DB7BCA27107C41",
       "checksum": "a1b07108447f59bd3a8cb1055791b4cde570e7c6f8d1f953d850b5370da78b70"
     }
   },
   "0.6.0": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.0/parse-changelog-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DB75FDE0A4F3BC",
       "checksum": "80e57ee43411646c8b3adf0f4417c6155418385e1755f26a1dcc92069ef26bfc"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.0/parse-changelog-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DB75FDE508B286",
       "checksum": "4521b4264e3b1bf07580bfaef405d32ba4f4e31323160d999a3ab38c00d3470d"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.0/parse-changelog-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DB75FDE5AAA4B1",
       "checksum": "53d689b247d5e49ef5596c8a9e1d806ec08eabcc201542f2cc5394965cb5966a"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.0/parse-changelog-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DB75FDD81FB2A6",
       "checksum": "8626ac4c3e6868b2bc4820a32b3533ab8265737908ee8335442942c8fa8d4d72"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.0/parse-changelog-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DB75FDC7C40C00",
       "checksum": "5eb69fda7e62869bae81f22db57d76d1fefabe0e9721c4941a4adcfea112d15a"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.6.0/parse-changelog-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DB75FE06841F32",
       "checksum": "e435cd91923f4afdf3499a53cdb63446fd4a42a6b580209e93be2e2d47cb6d93"
     }
   },
@@ -248,122 +302,150 @@
   "0.5.4": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.5.4/parse-changelog-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DB6760AD762D9E",
       "checksum": "b2a430ebd0d23a3608258446d9f93162ca324fd2ca691ca3baa11625c9d7fec3"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.5.4/parse-changelog-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DB6760BCCF6F34",
       "checksum": "4476f9ce9de07ddba76f77e6260e3cbece3801654882c8161694d742f8f01a59"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.5.4/parse-changelog-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DB6760C3C65DBF",
       "checksum": "e00a6a87be6c71a7f246cf3066cba8b76f02094ab6c482186eec9d037447bb21"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.5.4/parse-changelog-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DB6760A6D78312",
       "checksum": "73f85fdda5937ac3ee0fd3a4385998cc6a640736b3e73923b0afd061abb575be"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.5.4/parse-changelog-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DB6760A5304361",
       "checksum": "164936f970d8ab870aa3355411db736994dbb86019630bf2818d0958d30768b5"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.5.4/parse-changelog-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DB6760B0107FBB",
       "checksum": "b7c1c92c83fce15746c1d289fbf14b31b3f43a043e28b25638ae8ed7b1005ea0"
     }
   },
   "0.5.3": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.5.3/parse-changelog-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DAF3DA71A0A379",
       "checksum": "7ec427621565a6bb67d7e46397471b374435bc4622339595afa42d74d2f2a2cf"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.5.3/parse-changelog-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DAF3DBC00B2654",
       "checksum": "9ab883043949d6b2080720dd88575774cb09bb8c97cacf8e8db06b46f91bc4a3"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.5.3/parse-changelog-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DAF3DA8116A240",
       "checksum": "2567460b8c516d6cb6425db18f8cfdd17f0e999b452ba74ed2b1b3c60013ffa8"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.5.3/parse-changelog-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DAF3DA6C300146",
       "checksum": "d887eab1fd39ac54202058595efda8e4ef28d30697aea5b1d901e0922682db64"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.5.3/parse-changelog-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DAF3DB80469D19",
       "checksum": "ceca49aff58a2ebd6cef9c54684c8311e71012ef2d9eb6b69524635ce13df0bc"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.5.3/parse-changelog-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DAF3DA73ED233C",
       "checksum": "bf9e1df974e64704ed063442c500a274d627398279715061fb29c1fd417efc9a"
     }
   },
   "0.5.2": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.5.2/parse-changelog-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DAB6A165DAF502",
       "checksum": "bcaa72cf77aac0b897a8f6380106acb44b1dd28e53feefdd8f91bb4becbf355f"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.5.2/parse-changelog-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DAB6A19BF73137",
       "checksum": "3f0df01fe56c3e93747a252c4fa00cd40af53238747c5532665dc5ffea2e0016"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.5.2/parse-changelog-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DAB6A1C5036534",
       "checksum": "0de85d219007b5e4844378e61d095bb199f456827d0c22bc7a3389c4e1193cf0"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.5.2/parse-changelog-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DAB6A147ACAB42",
       "checksum": "41f4adb16160f2d31df32aebaae4a4966af9d8136b092f0e94d1788ff1c84866"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.5.2/parse-changelog-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DAB6A19C8970B2",
       "checksum": "ea4029f555127d082e4f4873ae1382f32b1d0afdaac6952eb346c5ae82c55fee"
     },
     "aarch64_windows": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.5.2/parse-changelog-aarch64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DAB6A17989933D",
       "checksum": "a1981ac1f0cf6601561f903809cb874ed3141dba240253509e34a8219d002517"
     }
   },
   "0.5.1": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.5.1/parse-changelog-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DA91A59A6CA14E",
       "checksum": "c2591b7921d548f628cb2ce59cd6c0fab1fab44dac62d98a23c75b84d2f2b935"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.5.1/parse-changelog-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DA91A584797344",
       "checksum": "9fc483f5404131fc4ca68e6b200dfce3248c1eed72656b17258273090ea496fa"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.5.1/parse-changelog-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DA91A5B7515AA9",
       "checksum": "decca568f51dc5ce2c827a724b02ef257fbbb0c36d6183ae4ba710a43d69b9c7"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.5.1/parse-changelog-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DA91A584326297",
       "checksum": "1471f2bcdb4ccff7b525335149cd0b1baddc1243c1d7c4f1a093def61e5d3a10"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.5.1/parse-changelog-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DA91A5C95BD3BC",
       "checksum": "604301690c6d8a104a268a149690fdc819635fc529d0f80cab15871e6548f150"
     }
   },
   "0.5.0": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.5.0/parse-changelog-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DA6D2A0FBF648A",
       "checksum": "ea5a58854c97bb1be800831bd9d0253cc9c78d7f8df2e3593fd899b587d5f4cf"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.5.0/parse-changelog-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DA6D29C2286718",
       "checksum": "c284fd62849b4996ac7ca3a8c4a835a74fd22ff7b5e2557fafb8c7059ca82cd2"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.5.0/parse-changelog-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DA6D29DF41748E",
       "checksum": "b62e7c044bb300834687f71db78f5a44844de89575b2bb98949ada45f8ee8185"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.5.0/parse-changelog-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DA6D2A019062E6",
       "checksum": "d2de3a2efcf7f507d4fbe24c9752e62c5c6ae8872a83efe31e05128887e8530c"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.5.0/parse-changelog-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DA6D29C1261526",
       "checksum": "c687c0344c73fda35d3d78c5ff508240a25b7c54a32b56e7f4322b034528997a"
     }
   },
@@ -373,160 +455,195 @@
   "0.4.9": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.4.9/parse-changelog-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DA61083A1A70A6",
       "checksum": "097ff59514f84cbc9b43406c9e8ff656fcfcbb821251eef538654e1cd0aac624"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.4.9/parse-changelog-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DA61080B444FD3",
       "checksum": "4d31a7bb6b4c68f0b47faaec9680fa6eb5a69e47ddbdc76e9d85086585857ad0"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.4.9/parse-changelog-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DA610823C7ABFC",
       "checksum": "d5893d72dd63f1466b68f5d768b6eecbb6454943e43f0d25a237bdc7f73ec057"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.4.9/parse-changelog-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DA61083E27BDFB",
       "checksum": "c25095aa111756b1600a418a06346e7e728211f040e5f3fa99e5f9e72f744001"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.4.9/parse-changelog-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DA6108238C326B",
       "checksum": "e894a0ffb7cd16086f3ecfbe2fc3ccc4775828dd336dfb74c53770fe4bf86150"
     }
   },
   "0.4.8": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.4.8/parse-changelog-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DA449932035A6A",
       "checksum": "41bc030a00e13a83faf6021b7be3ab50af7479f5c6ca6ca0a00ae29a0d71bcc8"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.4.8/parse-changelog-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8DA449968FE72DA",
       "checksum": "88c591fdf537064c64fde8f916065afacd845a5929c949aa6b4cd4b38a81437b"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.4.8/parse-changelog-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DA44991F0B76BE",
       "checksum": "98161b2e194a19f774358fd1882788f978b45c671571f253aee5d3a5dc6fba08"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.4.8/parse-changelog-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DA4499129A82F1",
       "checksum": "9756134014b0d24c300b54da03d554cdac710f3c2ba48beeb4031a151f3a2479"
     },
     "aarch64_macos": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.4.8/parse-changelog-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DA44990FDB5614",
       "checksum": "6340bb46d3daf9920512e578d5f6fb0e34e5a26e71845bc93797b87445584191"
     }
   },
   "0.4.7": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.4.7/parse-changelog-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8D9DCF663318BB6",
       "checksum": "b9869865ea79e3bf4931cca16a82f7226c84ffca9b508d2279b626e1c63e5151"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.4.7/parse-changelog-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9DCF654999254",
       "checksum": "d760dc945f491e37248d8446e8d373377e32bb1c1186e38be783c76147d91654"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.4.7/parse-changelog-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8D9DCF6B05B7A54",
       "checksum": "a847379af44c795270a6bef976b20e5bb4bcdf2f0f559e4ec6267f049dbd7dfc"
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.4.7/parse-changelog-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8D9DCF660BF603A",
       "checksum": "f4b1e860561adce28cbbf1ddebd6464830addf4157a6b4ea5dbfbd199c788cbf"
     }
   },
   "0.4.6": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.4.6/parse-changelog-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8D9CED1EB9CF03A",
       "checksum": "976d47ff81eafeda2d8d7bd4ed7bb13e466c46fe701e6ad9e6386ee615ea65a6"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.4.6/parse-changelog-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9CEC20A6D2C7B",
       "checksum": "b76556015fc0346b28322869cf13fc637e1258d3e97416228da46135423d63cd"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.4.6/parse-changelog-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8D9CED3241BD281",
       "checksum": "f67bb072cdad0d740b44b950b50a8a42891b39290e8f28936c0783b7539e5162"
     }
   },
   "0.4.5": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.4.5/parse-changelog-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8D9B9B07A440EF2",
       "checksum": "0da8fab497c50ee139e6595649fa532d18d37e0db72ef7974f38671ac4449432"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.4.5/parse-changelog-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9B9B079A660AD",
       "checksum": "4c9cfa68728db25c7cb81664be53125accad3a38b2c155efb2dc8fa9ca23b643"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.4.5/parse-changelog-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8D9B9B06AC2BE37",
       "checksum": "19fd27e72c9822a9a620c821107f8d0ca93febf2f20185317035cb0d63db0caa"
     }
   },
   "0.4.4": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.4.4/parse-changelog-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8D9B9B07B2C283E",
       "checksum": "6092da0f65f9853220d96bce57d0bed1dbe904f594f66f6e546ce765a202d8cb"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.4.4/parse-changelog-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9B9B066F7F43E",
       "checksum": "4ea7d8b471fb1729d8943f9aefcfd16febbbf2409e83ba19efc03c67516931e2"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.4.4/parse-changelog-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8D9B9B06CC34815",
       "checksum": "76729ddd7729374d5b8923a0d85a0de5edf645ef6e2f3cf8c6d0230458164513"
     }
   },
   "0.4.3": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.4.3/parse-changelog-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8D9B9B07489CF83",
       "checksum": "f4120023ad79b68e3287e775c4e55773db8a298e7c995fde67c99c31ab1d38c6"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.4.3/parse-changelog-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9B9B07FA1BDC9",
       "checksum": "7f717140cc8cc8531e443195f5ae1913d3ab01033d3538f7394622c561c5c470"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.4.3/parse-changelog-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8D9B9B06DE7C4C9",
       "checksum": "65ca90a7da79484466e65888bf3894d925d1924617d6a881f64c95a2a2bf59c5"
     }
   },
   "0.4.2": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.4.2/parse-changelog-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8D9B9B074EC52A1",
       "checksum": "6bbe76fb0d634b5a84017ccc80bf97bb8af81a44b5c44fc5f08954671d4f63ef"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.4.2/parse-changelog-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9B9B065C3C28B",
       "checksum": "3cc003763118f9d4d83f68f3a1e804cd6e33c2f7c4678bbf54ee0a54a11e3878"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.4.2/parse-changelog-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8D9B9B0766F8283",
       "checksum": "147919f6909058b09c9e9dd7f11681a177127c2ec05016472964aba36e1e7b7a"
     }
   },
   "0.4.1": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.4.1/parse-changelog-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8D9B9B076044E24",
       "checksum": "95b904b065cc246de7e7b82d7aa3d6ee4a96dd9d2f2e195237c234d3e3395500"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.4.1/parse-changelog-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9B9B0673A4A2F",
       "checksum": "5bce895e3f57e958eb4ce4a5552e749a74593e2fc9d8e04422ed94df0b3b2056"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.4.1/parse-changelog-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8D9B9B0716DC82D",
       "checksum": "78a57352c2903c9818be71d8e44a143442e5e0d4de70b6b84e8f7dfe02f1c398"
     }
   },
   "0.4.0": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.4.0/parse-changelog-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8D9B9B06FBA40F1",
       "checksum": "53a655b0763b12d421d625c7a53c08220883b6f081d9463d1b1dbf4aa5ad1d23"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.4.0/parse-changelog-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9B9B067362C22",
       "checksum": "7049ccce500c2edcb7853b3e5a3761d0657e29833e6453b46a64123b95813dfe"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.4.0/parse-changelog-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8D9B9B07C9E91D4",
       "checksum": "b69da4c94be3e57c14cab8fecbfe795e52fc5c4fa709b7ece5de39281533b67c"
     }
   },
@@ -536,14 +653,17 @@
   "0.3.0": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.3.0/parse-changelog-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8D9B9B06C5CF4F4",
       "checksum": "2d9c383127227c2544ef57a9bcaff0b2db7598adc12fcdbfd6c8187cae6d52eb"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.3.0/parse-changelog-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9B9B0714E100F",
       "checksum": "8d71e1ff24efeb15d15ecef8973c1dcae94879a4b125149170117a054ada624c"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.3.0/parse-changelog-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8D9B9B07CFFDCB2",
       "checksum": "41544b1e17d9f3d2f20af1d464250ee0d55de0c399c8019b22d62fd060835ebe"
     }
   },
@@ -553,42 +673,51 @@
   "0.2.2": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.2.2/parse-changelog-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8D9B9B074A08845",
       "checksum": "c1ec7ce2f2eff915e5803106d02b4eac2a31eb80a88d86d4713d984004037e52"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.2.2/parse-changelog-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9B9B07E08E65F",
       "checksum": "c5ed5285a427da8fe776f76a4b9c783124803bdbf6ec88fe81a2ca237c268bcf"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.2.2/parse-changelog-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8D9B9B065719089",
       "checksum": "5315e763ceb0d1e27c14a0e7fdbcd6113b77cb835c25dff9d82cf585c537ac1b"
     }
   },
   "0.2.1": {
     "x86_64_linux_musl": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.2.1/parse-changelog-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8D9B9B06F48F2FE",
       "checksum": "18f567e99bb588bab69a8c33c3e9c6d58bdede0eddde14b9d08f7ba9f6b00868"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.2.1/parse-changelog-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9B9B06A311C01",
       "checksum": "1a1317858ff1207f3483adf4a4140d439655e6c2c5ec107e94bc65f3a663cd59"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.2.1/parse-changelog-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8D9B9B0702B40CD",
       "checksum": "b4d713f937e3a3214c657b67bed9ce8474a7919e0d3064c4dd854f615be1b5e5"
     }
   },
   "0.2.0": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.2.0/parse-changelog-x86_64-unknown-linux-gnu.tar.gz",
+      "etag": "0x8D9B9B06583B631",
       "checksum": "7fcb2a7a99d08b544ba7950558514a741edc023e689748f1045aa7f0f3cde10a"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.2.0/parse-changelog-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9B9B07A517A63",
       "checksum": "38eb988ea3c017ad6794360050d1f8c79ef7720a09db5c5d2c7a9b030b7501d9"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.2.0/parse-changelog-x86_64-pc-windows-msvc.zip",
+      "etag": "0x8D9B9B069FE5405",
       "checksum": "12e6f5c0ddbd423d8ecffc18c36f6684f7b8be2f29f04bc9a6b62a8612cf9265"
     }
   },
@@ -598,14 +727,17 @@
   "0.1.0": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.1.0/parse-changelog-x86_64-unknown-linux-gnu.tar.gz",
+      "etag": "0x8D9B9B07F77A70D",
       "checksum": "9c293e52e217d7669d2e18ff9cb226b108f50deffd8c501208996c7e498a05cc"
     },
     "x86_64_macos": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.1.0/parse-changelog-x86_64-apple-darwin.tar.gz",
+      "etag": "0x8D9B9B06984A2F4",
       "checksum": "a39b5ab20f52712e65347e141cc4cafbd3bb0808f82af2d9bc8442c1202ef48e"
     },
     "x86_64_windows": {
       "url": "https://github.com/taiki-e/parse-changelog/releases/download/v0.1.0/parse-changelog-x86_64-pc-windows-msvc.zip",
+      "etag": "0x8D9B9B069A65696",
       "checksum": "dc2e44b4a7f9cf0cf11a7ac75b2a42f70f6e97d6269917bcf09182ede4282bff"
     }
   }

--- a/manifests/protoc.json
+++ b/manifests/protoc.json
@@ -14,44 +14,54 @@
   "3.27.1": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v27.1/protoc-27.1-linux-x86_64.zip",
+      "etag": "0x8DC85913C354FA9",
       "checksum": "8970e3d8bbd67d53768fe8c2e3971bdd71e51cfe2001ca06dacad17258a7dae3"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v27.1/protoc-27.1-osx-x86_64.zip",
+      "etag": "0x8DC85913C443314",
       "checksum": "8520d944f3a3890fa296a3b3b0d4bb18337337e2526bbbf1b507eeea3c2a1ec4"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v27.1/protoc-27.1-win64.zip",
+      "etag": "0x8DC85913C685B7F",
       "checksum": "da531c51ccd1290d8d34821f0ce4e219c7fbaa6f9825f5a3fb092a9d03fe6206"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v27.1/protoc-27.1-linux-aarch_64.zip",
+      "etag": "0x8DC85913BD0E46C",
       "checksum": "8809c2ec85368c6b6e9af161b6771a153aa92670a24adbe46dd34fa02a04df2f"
     },
     "aarch64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v27.1/protoc-27.1-osx-aarch_64.zip",
+      "etag": "0x8DC85913C22EDD2",
       "checksum": "03b7af1bf469e7285dc51976ee5fa99412704dbd1c017105114852a37b165c12"
     }
   },
   "3.27.0": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v27.0/protoc-27.0-linux-x86_64.zip",
+      "etag": "0x8DC7B34D5DDEE9F",
       "checksum": "e2bdce49564dbad4676023d174d9cdcf932238bc0b56a8349a5cb27bbafc26b0"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v27.0/protoc-27.0-osx-x86_64.zip",
+      "etag": "0x8DC7B34D6140402",
       "checksum": "d956cf3a9e91a687aa4d1026e9261e5a587e4e0b545db0174509f6c448b8ce21"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v27.0/protoc-27.0-win64.zip",
+      "etag": "0x8DC7B34D6385329",
       "checksum": "80888b2a38786861c7b3aaf4e0bd5b933a51d750219ee8c61093655fc2924926"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v27.0/protoc-27.0-linux-aarch_64.zip",
+      "etag": "0x8DC7B34D5754254",
       "checksum": "1e4b2d8b145afe99a36602f305165761e46d2525aa94cbb907e2e983be6717ac"
     },
     "aarch64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v27.0/protoc-27.0-osx-aarch_64.zip",
+      "etag": "0x8DC7B34D5DD79EF",
       "checksum": "2cf59e3e3463bede1f10b7517efdddd97a3bd8cfd9cacc286407b657290dc781"
     }
   },
@@ -61,44 +71,54 @@
   "3.26.1": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v26.1/protoc-26.1-linux-x86_64.zip",
+      "etag": "0x8DC4E9BECFDDA80",
       "checksum": "a7be2928c0454f132c599e25b79b7ad1b57663f2337d7f7e468a1d59b98ec1b0"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v26.1/protoc-26.1-osx-x86_64.zip",
+      "etag": "0x8DC4E9BED12AAA0",
       "checksum": "febd8821c3a2a23f72f4641471e0ab6486f4fb07b68111490a27a31681465b3c"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v26.1/protoc-26.1-win64.zip",
+      "etag": "0x8DC4E9BED484B47",
       "checksum": "9090d135a1159042b13b4e51b210e40cb820d85a5032a6eca5f9b3ca3bdfb539"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v26.1/protoc-26.1-linux-aarch_64.zip",
+      "etag": "0x8DC4E9BECAC6CC2",
       "checksum": "64a3b3b5f7dac0c8f9cf1cb85b2b1a237eb628644f6bcb0fb8f23db6e0d66181"
     },
     "aarch64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v26.1/protoc-26.1-osx-aarch_64.zip",
+      "etag": "0x8DC4E9BECEB9F92",
       "checksum": "26a29befa8891ecc48809958c909d284f2b9539a2eb47f22cadc631fe6abe8fd"
     }
   },
   "3.26.0": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v26.0/protoc-26.0-linux-x86_64.zip",
+      "etag": "0x8DC43778ADC4020",
       "checksum": "3ed20f841fd9cb7a8344dd4158f6fcb67d333c8206b33a7dbb899bcbc08d92eb"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v26.0/protoc-26.0-osx-x86_64.zip",
+      "etag": "0x8DC43778AF184E6",
       "checksum": "2624286cf7787c5b75af68d7766fe62bf92f459f1ee77f9a9a8cdae63bd285d1"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v26.0/protoc-26.0-win64.zip",
+      "etag": "0x8DC437791ACBCFA",
       "checksum": "f5a0e21c09e823fe5cc18d6057f8db7a3d5df420c09314d548b9139c4193156d"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v26.0/protoc-26.0-linux-aarch_64.zip",
+      "etag": "0x8DC43778A6BADA1",
       "checksum": "556e4f77fd3a04c0b31e3560540241e86ec576d447733f19a3f9c056724e9b03"
     },
     "aarch64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v26.0/protoc-26.0-osx-aarch_64.zip",
+      "etag": "0x8DC43778AB278FF",
       "checksum": "218537fbdbd0054b516a346b89892a48626cb08bb8351c8d771c1545fd80c7c1"
     }
   },
@@ -108,88 +128,108 @@
   "3.25.3": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v25.3/protoc-25.3-linux-x86_64.zip",
+      "etag": "0x8DC2E75AE56BDBC",
       "checksum": "f853e691868d0557425ea290bf7ba6384eef2fa9b04c323afab49a770ba9da80"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v25.3/protoc-25.3-osx-x86_64.zip",
+      "etag": "0x8DC2E75AE5E088B",
       "checksum": "247e003b8e115405172eacc50bd19825209d85940728e766f0848eee7c80e2a1"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v25.3/protoc-25.3-win64.zip",
+      "etag": "0x8DC2E75AE9F5BF8",
       "checksum": "d6b336b852726364313330631656b7f395dde5b1141b169f5c4b8d43cdf01482"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v25.3/protoc-25.3-linux-aarch_64.zip",
+      "etag": "0x8DC2E75AF23AEB3",
       "checksum": "9eae1f20f70cccc912d1c318c3929b86aebf5afd4b0f32c196ef682c222ed5ae"
     },
     "aarch64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v25.3/protoc-25.3-osx-aarch_64.zip",
+      "etag": "0x8DC2E75AE3A54FD",
       "checksum": "d0fcd6d3b3ef6f22f1c47cc30a80c06727e1eccdddcaf0f4a3be47c070ffd3fe"
     }
   },
   "3.25.2": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v25.2/protoc-25.2-linux-x86_64.zip",
+      "etag": "0x8DC116D6BE2C25B",
       "checksum": "78ab9c3288919bdaa6cfcec6127a04813cf8a0ce406afa625e48e816abee2878"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v25.2/protoc-25.2-osx-x86_64.zip",
+      "etag": "0x8DC116D6C1A0ED7",
       "checksum": "5fe89993769616beff1ed77408d1335216379ce7010eee80284a01f9c87c8888"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v25.2/protoc-25.2-win64.zip",
+      "etag": "0x8DC116D706FD5F0",
       "checksum": "74cf3a0ead50be525ad393f820fce64baed3776202ff3b8423acf3bf0daaf542"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v25.2/protoc-25.2-linux-aarch_64.zip",
+      "etag": "0x8DC116D6BCB5CFF",
       "checksum": "07683afc764e4efa3fa969d5f049fbc2bdfc6b4e7786a0b233413ac0d8753f6b"
     },
     "aarch64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v25.2/protoc-25.2-osx-aarch_64.zip",
+      "etag": "0x8DC116D6BE29B68",
       "checksum": "8822b090c396800c96ac652040917eb3fbc5e542538861aad7c63b8457934b20"
     }
   },
   "3.25.1": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v25.1/protoc-25.1-linux-x86_64.zip",
+      "etag": "0x8DBE62A0BC95027",
       "checksum": "ed8fca87a11c888fed329d6a59c34c7d436165f662a2c875246ddb1ac2b6dd50"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v25.1/protoc-25.1-osx-x86_64.zip",
+      "etag": "0x8DBE62A0BEA6E94",
       "checksum": "72c6d6b2bc855ff8688c3b7fb31288ccafd0ab55256ff8382d5711ecfcc11f4f"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v25.1/protoc-25.1-win64.zip",
+      "etag": "0x8DBE62A09AD14E1",
       "checksum": "b55901fc748d1679f3a803bdc2a920e1897eb02433c501b5a589ea08c4623844"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v25.1/protoc-25.1-linux-aarch_64.zip",
+      "etag": "0x8DBE62A088D57CD",
       "checksum": "99975a8c11b83cd65c3e1151ae1714bf959abc0521acb659bf720524276ab0c8"
     },
     "aarch64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v25.1/protoc-25.1-osx-aarch_64.zip",
+      "etag": "0x8DBE62A0925DF2E",
       "checksum": "320308ce18c359564948754f51748de41cf02a4e7edf0cf47a805b9d38610f16"
     }
   },
   "3.25.0": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v25.0/protoc-25.0-linux-x86_64.zip",
+      "etag": "0x8DBDB2CA0F6377F",
       "checksum": "d26c4efe0eae3066bb560625b33b8fc427f55bd35b16f246b7932dc851554e67"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v25.0/protoc-25.0-osx-x86_64.zip",
+      "etag": "0x8DBDB2CA12B8A61",
       "checksum": "15eefb30ba913e8dc4dd21d2ccb34ce04a2b33124f7d9460e5fd815a5d6459e3"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v25.0/protoc-25.0-win64.zip",
+      "etag": "0x8DBDB2CA1596B95",
       "checksum": "ce2955439c6bb4c7d599d6ace2dabe4cb31f62c34808e542a7af57a3c6627d8a"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v25.0/protoc-25.0-linux-aarch_64.zip",
+      "etag": "0x8DBDB2CA0AC3B62",
       "checksum": "fe79d0eb356422917279c9580f74d2a486a8173fd020843f3b28ea6b71fba327"
     },
     "aarch64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v25.0/protoc-25.0-osx-aarch_64.zip",
+      "etag": "0x8DBDB2CA1733F26",
       "checksum": "76a997df5dacc0608e880a8e9069acaec961828a47bde16c06116ed2e570588b"
     }
   },
@@ -199,110 +239,135 @@
   "3.24.4": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v24.4/protoc-24.4-linux-x86_64.zip",
+      "etag": "0x8DBC4F9D7EAB634",
       "checksum": "5871398dfd6ac954a6adebf41f1ae3a4de915a36a6ab2fd3e8f2c00d45b50dec"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v24.4/protoc-24.4-osx-x86_64.zip",
+      "etag": "0x8DBC4F9D7FF11B6",
       "checksum": "6c3b6bf4038d733b6d31f1cc4516a656570b5b5aafb966b650f8182afd0b98cf"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v24.4/protoc-24.4-win64.zip",
+      "etag": "0x8DBC4F9D87B3018",
       "checksum": "8f3f92fbf7dd2995129e6fe223c07c0aaa97fb182f19cecfb424e9146b273eb6"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v24.4/protoc-24.4-linux-aarch_64.zip",
+      "etag": "0x8DBC4F9D770B84A",
       "checksum": "83ac000ff540e242b6a2ff221a3ac88d2d8e55443801b7a28e9697e5f40e8937"
     },
     "aarch64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v24.4/protoc-24.4-osx-aarch_64.zip",
+      "etag": "0x8DBC4F9DCC6C94E",
       "checksum": "d80544480397fe8a05d966fba291cf1233ad0db0ebc24ec72d7bd077d6e7ac59"
     }
   },
   "3.24.3": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v24.3/protoc-24.3-linux-x86_64.zip",
+      "etag": "0x8DBAFCC7890415F",
       "checksum": "fc793561283d9ea6813fb757ae54f1afea6770afcd930904bdf3e590910420aa"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v24.3/protoc-24.3-osx-x86_64.zip",
+      "etag": "0x8DBAFCC78DDE2EC",
       "checksum": "13b45cdcde9b2101e982de897d5490cfd81dfa181605749c23982379ba0e3288"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v24.3/protoc-24.3-win64.zip",
+      "etag": "0x8DBAFCC78EA311F",
       "checksum": "c8f8c87e2eb6ba1e45f1f0b7b6c17f129309fff421c04290e272de1f7defd8f1"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v24.3/protoc-24.3-linux-aarch_64.zip",
+      "etag": "0x8DBAFCC7801259A",
       "checksum": "77a5a41f3e9712af6a35de13143b9b2b77f075aa1ab18a63cca4483b30f6e3cd"
     },
     "aarch64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v24.3/protoc-24.3-osx-aarch_64.zip",
+      "etag": "0x8DBAFCC78D00FD5",
       "checksum": "cca53adb73a6686dd60bb3b0da33961e6b9dab1f833c851b5e1bb7b5df02b36f"
     }
   },
   "3.24.2": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v24.2/protoc-24.2-linux-x86_64.zip",
+      "etag": "0x8DBA5B15215D908",
       "checksum": "1bfa935466cf902200cfba0e80d0ac60fec8e4c61aad3debc9fc97a135604b72"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v24.2/protoc-24.2-osx-x86_64.zip",
+      "etag": "0x8DBA5B152136AC3",
       "checksum": "335d8623065234734d35b284f36326fbeded4bad88ca20a2df181761f67ca1a5"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v24.2/protoc-24.2-win64.zip",
+      "etag": "0x8DBA5B1526BFC9F",
       "checksum": "e0cbca02e34aca5c76059f8b78000512a83c77409f7137ec6977fc554609f79f"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v24.2/protoc-24.2-linux-aarch_64.zip",
+      "etag": "0x8DBA5B15183B331",
       "checksum": "6593cf94c8d66f367e6526fda6c0ee0fdd442171a9e302c4625e6eb0958c06c1"
     },
     "aarch64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v24.2/protoc-24.2-osx-aarch_64.zip",
+      "etag": "0x8DBA5B1520D3031",
       "checksum": "9624e53cd0c061afb5eab9e50fc0372383585dcc22bd2b1fb54fd5a4c3294989"
     }
   },
   "3.24.1": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v24.1/protoc-24.1-linux-x86_64.zip",
+      "etag": "0x8DBA023CA7C562D",
       "checksum": "1b9d1467205530986d58d24d2b89b9db3c8a9e3c31ed40b2a223913480ca8987"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v24.1/protoc-24.1-osx-x86_64.zip",
+      "etag": "0x8DBA023CA98E5BD",
       "checksum": "476782d4220ff7b2d8b333a648a1f8a52c200211db85e76347e668d9d4c07515"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v24.1/protoc-24.1-win64.zip",
+      "etag": "0x8DBA023CAD1426E",
       "checksum": "dad1efed75cb772a0c9e5d4646006bf87e1e051191473a2a30c9db66ee223cfd"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v24.1/protoc-24.1-linux-aarch_64.zip",
+      "etag": "0x8DBA023CA32A7D6",
       "checksum": "676a38ff5584c913bbab3991bb1a515b8cbd22a12c029e24c440d9b05c816f1c"
     },
     "aarch64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v24.1/protoc-24.1-osx-aarch_64.zip",
+      "etag": "0x8DBA023CA82B79F",
       "checksum": "e7c622512ad2133f25bc6369e1330809daa7ae2742611bf596bbc904e18ca8d5"
     }
   },
   "3.24.0": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v24.0/protoc-24.0-linux-x86_64.zip",
+      "etag": "0x8DB985C852E1352",
       "checksum": "4feef12d91c4e452eac8c45bd11f43d51541db7fc6c18b4ca7bdd38af52c9d15"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v24.0/protoc-24.0-osx-x86_64.zip",
+      "etag": "0x8DB985C856EF1F2",
       "checksum": "c438ae68427aa848f4e2dbf7d6cbd4e6a13e30a6bcc61007fd95cfc90451264a"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v24.0/protoc-24.0-win64.zip",
+      "etag": "0x8DB985C85F67519",
       "checksum": "8c84d3d36936424a99934a9e5034f8a573615bf7f1b4246d536f33c120af60cd"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v24.0/protoc-24.0-linux-aarch_64.zip",
+      "etag": "0x8DB985C849E352F",
       "checksum": "d27f1479fc4707f275eaa952cef548f9fa0c8ef2d8cb5977f337d2ce61430682"
     },
     "aarch64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v24.0/protoc-24.0-osx-aarch_64.zip",
+      "etag": "0x8DB985C85638D1E",
       "checksum": "e4cc0739f0f8ae31633fb11335f11e6fbe067ecda8fd1b4716e80cfe3661ee1d"
     }
   },
@@ -312,110 +377,135 @@
   "3.23.4": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v23.4/protoc-23.4-linux-x86_64.zip",
+      "etag": "0x8DB7E670DA980FF",
       "checksum": "0502f286ac9ed860b629a7965a14527b1f2dd131e4283fa23c2d7f184672aa9a"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v23.4/protoc-23.4-osx-x86_64.zip",
+      "etag": "0x8DB7E670E213798",
       "checksum": "07e5fdcf1b0708d3367dc5e6eb8d135de7e407d75316c93155cfd8ab362eec80"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v23.4/protoc-23.4-win64.zip",
+      "etag": "0x8DB7E670E3EFE5D",
       "checksum": "a309c39442fb75f0db343cb22c111a00f91cdf0767f332e170644b9378e2bcc6"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v23.4/protoc-23.4-linux-aarch_64.zip",
+      "etag": "0x8DB7E670D475D00",
       "checksum": "1c7750b6e038305b5a7fc3d0cda1ebefdf106a4f30a787bf826ed2fc47c3967d"
     },
     "aarch64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v23.4/protoc-23.4-osx-aarch_64.zip",
+      "etag": "0x8DB7E670DC91A76",
       "checksum": "8c7afae8626b6811e7b5897d16d940c2dbf50b1e135ed958a01db6566bdda726"
     }
   },
   "3.23.3": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v23.3/protoc-23.3-linux-x86_64.zip",
+      "etag": "0x8DB6D09CAA96DF8",
       "checksum": "8f5abeb19c0403a7bf6e48f4fa1bb8b97724d8701f6823a327922df8cc1da4f5"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v23.3/protoc-23.3-osx-x86_64.zip",
+      "etag": "0x8DB6D09CA8D5302",
       "checksum": "82becd1c2dc887a7b3108981d5d6bb5f5b66e81d7356e3e2ab2f36c7b346914f"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v23.3/protoc-23.3-win64.zip",
+      "etag": "0x8DB6D09CAD507E3",
       "checksum": "a55295e95fd803351eacd40143d11c037a917beceb4db5894dfd188224627239"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v23.3/protoc-23.3-linux-aarch_64.zip",
+      "etag": "0x8DB6D09C978865E",
       "checksum": "4e5154e51744c288ca1362f9cca942188003fc7b860431a984a30cb1e73aed9e"
     },
     "aarch64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v23.3/protoc-23.3-osx-aarch_64.zip",
+      "etag": "0x8DB6D09CA247FBD",
       "checksum": "edb432e4990c23fea1040a2a76b87ab0f738e384cd25d650cc35683603fe8cdc"
     }
   },
   "3.23.2": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v23.2/protoc-23.2-linux-x86_64.zip",
+      "etag": "0x8DB5E01022E0151",
       "checksum": "179a759581bf4b32cc5edae4ffce6b8ee16ba4f4ab99ad3a309c31113f98d472"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v23.2/protoc-23.2-osx-x86_64.zip",
+      "etag": "0x8DB5E00FE1F2D23",
       "checksum": "0c19eb51f450687557dd61b9859ae898f52143c39372e8cb6f0b648d5423e24a"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v23.2/protoc-23.2-win64.zip",
+      "etag": "0x8DB5E00FFCE7A2A",
       "checksum": "ca92eb9ca61ada5410211a9f8be7f0a5118f490e402c821ec1f61bb12b132c36"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v23.2/protoc-23.2-linux-aarch_64.zip",
+      "etag": "0x8DB5E01026D0D4F",
       "checksum": "12c9385da533dd5fe6fd57e0c5cdb7004d8c08af94a80c75614c50f1f31d92e0"
     },
     "aarch64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v23.2/protoc-23.2-osx-aarch_64.zip",
+      "etag": "0x8DB5E0102904C1E",
       "checksum": "9fffa243509db34492c6dee031b361c538b2b65720ac253c319034e7f38e2cc8"
     }
   },
   "3.23.1": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v23.1/protoc-23.1-linux-x86_64.zip",
+      "etag": "0x8DB56FAAD43E587",
       "checksum": "031f8e7504eb359df58389b31752f8081c01b01132a2f3f768a3792ac4b06f3f"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v23.1/protoc-23.1-osx-x86_64.zip",
+      "etag": "0x8DB56FAB57747F7",
       "checksum": "5d0367dfd58ea894f87d1d6efbd800bf52820842e9151d265db17471bc69fe94"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v23.1/protoc-23.1-win64.zip",
+      "etag": "0x8DB56FAAD8B4C8E",
       "checksum": "420cd7a1548a9c3ef5b5a7e969b6fcf8ee6a5a09cec99d7a3209406f028e5dce"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v23.1/protoc-23.1-linux-aarch_64.zip",
+      "etag": "0x8DB56FAACA4FCF9",
       "checksum": "f174eb3a6bd812e9946be3a9ef3fb8f8ac4a6f8acd0a01c928fb2fecb22b6fb0"
     },
     "aarch64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v23.1/protoc-23.1-osx-aarch_64.zip",
+      "etag": "0x8DB56FAB560A519",
       "checksum": "8d0af9adbbde1a9791d10125f4742a4c9fa84f85ee46fe69adde6bf5e8a4a428"
     }
   },
   "3.23.0": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v23.0/protoc-23.0-linux-x86_64.zip",
+      "etag": "0x8DB4FF11CF8B2F9",
       "checksum": "635f2dd1c7d0d1fc7e47f5744eda658858f7a235a5e478d1f1f984cf0b7eb483"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v23.0/protoc-23.0-osx-x86_64.zip",
+      "etag": "0x8DB4FF11CDFA1DF",
       "checksum": "0506eac95bf3ca8fc944a862e90ab82079426633eb70c6eeb52eb4f6fb06165d"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v23.0/protoc-23.0-win64.zip",
+      "etag": "0x8DB4FF11D3FF316",
       "checksum": "031f00a9b46ce9a2253ee681ff05d43b8f842780cac4e9f5eb3c9a3a61a33e3e"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v23.0/protoc-23.0-linux-aarch_64.zip",
+      "etag": "0x8DB4FF11C61B0D5",
       "checksum": "cf911a9bfaed00b1f2ae82eef9a0cfdb43d12822ee4b28207d76fd10ee8384de"
     },
     "aarch64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v23.0/protoc-23.0-osx-aarch_64.zip",
+      "etag": "0x8DB4FF11CDC4A44",
       "checksum": "5e2a59d1df9aff70237cb08cbb4311af31da245eb882271a1bba9bd6fdc67258"
     }
   },
@@ -425,132 +515,162 @@
   "3.22.5": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v22.5/protoc-22.5-linux-x86_64.zip",
+      "etag": "0x8DB510A15D59741",
       "checksum": "c11692013bbffb7c257de7f82cd02d323700ebcdb8a4923ed02fea812f70f5e3"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v22.5/protoc-22.5-osx-x86_64.zip",
+      "etag": "0x8DB510A0CC9B8E5",
       "checksum": "3edd0c65e2a8efc83f24918db27e1bbc72f3abe7618cb4cfb1842630a830b562"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v22.5/protoc-22.5-win64.zip",
+      "etag": "0x8DB510A0D5728E2",
       "checksum": "f99d1e9e28f7704b22d4254fab293477ea0d4ef3e5b9aa940a8fccfc99c1ce4c"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v22.5/protoc-22.5-linux-aarch_64.zip",
+      "etag": "0x8DB510A0BDB5C16",
       "checksum": "1890f845b333fe040ec002a659a4ff7515cd93f8db0066c3885d1fce9f70b208"
     },
     "aarch64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v22.5/protoc-22.5-osx-aarch_64.zip",
+      "etag": "0x8DB510A0CAE3986",
       "checksum": "b7fc6c6099ad10149d90f8b107871537ca030980354b402d8e034055ce082b77"
     }
   },
   "3.22.4": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v22.4/protoc-22.4-linux-x86_64.zip",
+      "etag": "0x8DB4CDB277CEF0D",
       "checksum": "b3cff4d4076efe2965e8560cae6307c429349eda0af7755950d6ea5db6d72870"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v22.4/protoc-22.4-osx-x86_64.zip",
+      "etag": "0x8DB4CDB27CA2F68",
       "checksum": "5f70ca85b2e3f53559cc470ab3f5084862ae6fc9515bf6154ad6462a8385b51a"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v22.4/protoc-22.4-win64.zip",
+      "etag": "0x8DB4CDB27C80EED",
       "checksum": "689b1d493f26b6bca05b8af1705f25f2129dc52e15138dbfda58df95c634076b"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v22.4/protoc-22.4-linux-aarch_64.zip",
+      "etag": "0x8DB4CDB2715B43B",
       "checksum": "a534857d0c51c44dad9704a6929fb4069a7f2e0b5e1949dd0569edcb95e634c8"
     },
     "aarch64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v22.4/protoc-22.4-osx-aarch_64.zip",
+      "etag": "0x8DB4CDB27AA5B9F",
       "checksum": "9da1a5e494687a5b88c5c8f82afd808f8c6554def47842f945f43a6475259d91"
     }
   },
   "3.22.3": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v22.3/protoc-22.3-linux-x86_64.zip",
+      "etag": "0x8DB3BAF76AD4993",
       "checksum": "0f8070d762eb8a2f5a13a47713a553f989f9d9b556e7e3ebfa2bd6464e2ecaeb"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v22.3/protoc-22.3-osx-x86_64.zip",
+      "etag": "0x8DB3BAF771753AF",
       "checksum": "d644a65064a97fa3ed033a4a2314ab35816abbd9aed052f9b1b3374d2deaaae4"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v22.3/protoc-22.3-win64.zip",
+      "etag": "0x8DB3BAF7FF1A7AE",
       "checksum": "fa7fe21bf6e204a4e1eec3ffee1d53c84e216289bc4762e072258e5bca113a3c"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v22.3/protoc-22.3-linux-aarch_64.zip",
+      "etag": "0x8DB3BAF76781DA3",
       "checksum": "c6068d9d151c39723bc7db920759b55737a770b0c2ec544dd0197d4078d7a956"
     },
     "aarch64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v22.3/protoc-22.3-osx-aarch_64.zip",
+      "etag": "0x8DB3BAF76F98CFC",
       "checksum": "79cc15d1b528061ea0a818b0abcf3be1e0bdcb063a0cc999af27974cccdc5cce"
     }
   },
   "3.22.2": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v22.2/protoc-22.2-linux-x86_64.zip",
+      "etag": "0x8DB2196017B9F26",
       "checksum": "15f281b36897e0ffbbe3a02f687ff9108c7a0f98bb653fb433e4bd62e698abe7"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v22.2/protoc-22.2-osx-x86_64.zip",
+      "etag": "0x8DB219601E045CA",
       "checksum": "8bb75680c376190d960ef1d073618c1103960f70dc4fafa7bde872029562aec1"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v22.2/protoc-22.2-win64.zip",
+      "etag": "0x8DB2196023389C3",
       "checksum": "6c2bba387b8a3d2d254eddb68376217314de8d6e9b3a43d3cd2e69c054457638"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v22.2/protoc-22.2-linux-aarch_64.zip",
+      "etag": "0x8DB21960044850E",
       "checksum": "aa2efbb2d481b7ad3c2428e0aa4dd6d813e4538e6c0a1cd4d921ac998187e07e"
     },
     "aarch64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v22.2/protoc-22.2-osx-aarch_64.zip",
+      "etag": "0x8DB219601934263",
       "checksum": "a196fd39acd312688b58e81266fd88e9f7799967c5439738c10345a29049261d"
     }
   },
   "3.22.1": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v22.1/protoc-22.1-linux-x86_64.zip",
+      "etag": "0x8DB1F5AA8720632",
       "checksum": "3c830b09192a8c40c599856eb184c89ee5029d7dab9df8ec6d3d6741dcb94b93"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v22.1/protoc-22.1-osx-x86_64.zip",
+      "etag": "0x8DB1F5AA87A425E",
       "checksum": "3cc8d30d8bffc63bb2b8b0aea0d6a126acb4f69d4c720c142f7de6b9f4f562c6"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v22.1/protoc-22.1-win64.zip",
+      "etag": "0x8DB1F5AA8DC0338",
       "checksum": "359a390f6124c067026e212995e402d2e6fcd525d07e3b69d1d81cb06b5690f2"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v22.1/protoc-22.1-linux-aarch_64.zip",
+      "etag": "0x8DB1F5AA7D197D5",
       "checksum": "204e23069dc59bda1df5d66425c12373be39d71946fa378c3d7af44abbd651e9"
     },
     "aarch64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v22.1/protoc-22.1-osx-aarch_64.zip",
+      "etag": "0x8DB1F5AA870A6D2",
       "checksum": "213e82e423baf44bad1eef99cf3e21d52ce1ac2942e3bbd25a63b1f737cf6ec6"
     }
   },
   "3.22.0": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v22.0/protoc-22.0-linux-x86_64.zip",
+      "etag": "0x8DB1048BA549942",
       "checksum": "9ceff6c3945d521d1d0f42f9f57f6ef7cf3f581a9d303a027ba19b192045d1a2"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v22.0/protoc-22.0-osx-x86_64.zip",
+      "etag": "0x8DB1048BA9827AB",
       "checksum": "1e0ad38fcf20a4b1cdeffe40f9188c4d1c30a9dd515cf92c8b57f629227f0eb3"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v22.0/protoc-22.0-win64.zip",
+      "etag": "0x8DB1048BAEE77E8",
       "checksum": "dd2a24c091f684ce9589fc76f9b5ed55dffdc0e0733bde20112f32b00771dbdb"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v22.0/protoc-22.0-linux-aarch_64.zip",
+      "etag": "0x8DB1048B9A4EC07",
       "checksum": "af403bd3009132b418b364e9df29cdbecff5f6ab560c392d48e9944f708d7778"
     },
     "aarch64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v22.0/protoc-22.0-osx-aarch_64.zip",
+      "etag": "0x8DB1048BA429AA6",
       "checksum": "834f35b26082ff2dc372df17cae4a4b7cded944756f1c99bac8c624214b542cc"
     }
   },
@@ -560,286 +680,351 @@
   "3.21.12": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-linux-x86_64.zip",
+      "etag": "0x8DADDE18584E111",
       "checksum": "3a4c1e5f2516c639d3079b1586e703fc7bcfa2136d58bda24d1d54f949c315e8"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-osx-x86_64.zip",
+      "etag": "0x8DADDE1841CF976",
       "checksum": "9448ff40278504a7ae5139bb70c962acc78c32d8fc54b4890a55c14c68b9d10a"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-win64.zip",
+      "etag": "0x8DADDE1835384F2",
       "checksum": "71852a30cf62975358edfcbbff93086e8857a079c8e4d6904881aa968d65c7f9"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-linux-aarch_64.zip",
+      "etag": "0x8DADDE187456336",
       "checksum": "2dd17f75d66a682640b136e31848da9fb2eefe68d55303baf8b32617374f6711"
     },
     "aarch64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-osx-aarch_64.zip",
+      "etag": "0x8DADDE184FD2703",
       "checksum": "96839af0caed64352442fc8236f4bdf7c1cd6efcfaa98fa5db37307a73fc7c70"
     }
   },
   "3.21.11": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.11/protoc-21.11-linux-x86_64.zip",
+      "etag": "0x8DAD8E6335B85D2",
       "checksum": "3c3eaee739187ad375daae3d74648efd4bc3eaf82c92b57d0fa2cce6460eb291"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.11/protoc-21.11-osx-x86_64.zip",
+      "etag": "0x8DAD8E63445E84B",
       "checksum": "fda0465e692aee500a6b459c07612e85843e01c8207f2fbe3e0388b64c1bc2b6"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.11/protoc-21.11-win64.zip",
+      "etag": "0x8DAD8E635D17AA7",
       "checksum": "bd948c18291cabab37249f451f29acca11893945c9498c2545247dcb245798c1"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.11/protoc-21.11-linux-aarch_64.zip",
+      "etag": "0x8DAD8E63221621C",
       "checksum": "9c46ab41ec6cc1f0e24e5b9d5ce052137c12878a6d83577ab721226b6e900774"
     },
     "aarch64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.11/protoc-21.11-osx-aarch_64.zip",
+      "etag": "0x8DAD8E63399E4A5",
       "checksum": "45eb1032b44a4f60d964e572fa47d853014f6e99f3e4ce26c15fe4aaf8fbdd5b"
     }
   },
   "3.21.10": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.10/protoc-21.10-linux-x86_64.zip",
+      "etag": "0x8DAD306069AA8D1",
       "checksum": "0d13805474b85611c74f00c738a85ad00a25828dbf6e501de29d7f56b3dbcc03"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.10/protoc-21.10-osx-x86_64.zip",
+      "etag": "0x8DAD306058AC331",
       "checksum": "96126be6f421b2417e54cd4cf79afeea98a4ca035fa39fa2bd7bf29e6c5afe0b"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.10/protoc-21.10-win64.zip",
+      "etag": "0x8DAD30604F9E498",
       "checksum": "bdbec1380ba41514f3881b56bcaa5a1578f7fa4e3725bef79ede84b1f15317ef"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.10/protoc-21.10-linux-aarch_64.zip",
+      "etag": "0x8DAD30607DA9784",
       "checksum": "68835a6482d423b086dd636416389a40acdadabb49143bd73d4a1a0511ea60e5"
     },
     "aarch64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.10/protoc-21.10-osx-aarch_64.zip",
+      "etag": "0x8DAD306062DA048",
       "checksum": "dfa3e0a72f7eeec8c0a52de82aa4846ec06a784975c91849e264891f279fdddf"
     }
   },
   "3.21.9": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.9/protoc-21.9-linux-x86_64.zip",
+      "etag": "0x8DAB7907E3CB4CB",
       "checksum": "3cd951aff8ce713b94cde55e12378f505f2b89d47bf080508cf77e3934f680b6"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.9/protoc-21.9-osx-x86_64.zip",
+      "etag": "0x8DAB7907C4E2556",
       "checksum": "a6419520a063242b0dedd433cbfc617424da2e8357ef96bf694d6ba3bca51887"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.9/protoc-21.9-win64.zip",
+      "etag": "0x8DAB7907B2AB776",
       "checksum": "784d100b65c8eeb841bffdb885332391321740064865ead1ebc29561ed66cee1"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.9/protoc-21.9-linux-aarch_64.zip",
+      "etag": "0x8DAB790807BF08D",
       "checksum": "a584286dfa8ebb17032ece206ed74d5e9931e2edb9016e427be2a0dab3b21071"
     },
     "aarch64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.9/protoc-21.9-osx-aarch_64.zip",
+      "etag": "0x8DAB7907DA545E0",
       "checksum": "d935f396a05cb02d4a1338db181c78f47884466a9f57d5ed4b7a4811816b69cf"
     }
   },
   "3.21.8": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.8/protoc-21.8-linux-x86_64.zip",
+      "etag": "0x8DAB13562DB8AD5",
       "checksum": "f90d0dd59065fef94374745627336d622702b67f0319f96cee894d41a974d47a"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.8/protoc-21.8-osx-x86_64.zip",
+      "etag": "0x8DAB13563CE29BE",
       "checksum": "e1f32612386601ce703dfa10c4ec8b8187e1bf89762b3241f0caa481339cad46"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.8/protoc-21.8-win64.zip",
+      "etag": "0x8DAB1356458EF2B",
       "checksum": "3657053024faa439ff5f8c1dd2ee06bac0f9b9a3d660e99944f015a7451e87ec"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.8/protoc-21.8-linux-aarch_64.zip",
+      "etag": "0x8DAB1356174432C",
       "checksum": "f3d8eb5839d6186392d8c7b54fbeabbb6fcdd90618a500b77cb2e24faa245cad"
     },
     "aarch64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.8/protoc-21.8-osx-aarch_64.zip",
+      "etag": "0x8DAB1356333AF53",
       "checksum": "430b644f190e9def5034d641d4e1e0939d59c4bef28a73656a390c3314d44d88"
     }
   },
   "3.21.7": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.7/protoc-21.7-linux-x86_64.zip",
+      "etag": "0x8DAA2500D07867D",
       "checksum": "0a260c6df439bcf1ecdd5e38e7a7648e4edf99c1a22a4cc66ce8e62c53bdb837"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.7/protoc-21.7-osx-x86_64.zip",
+      "etag": "0x8DAA2500DEA7264",
       "checksum": "cd3609fa1efc73db9c58fc63e40b240558eb2a8080b4fbfbe1c4b93bbedecc20"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.7/protoc-21.7-win64.zip",
+      "etag": "0x8DAA2500E7F22A2",
       "checksum": "954cc5dfdb1d95d4c448c40f274d3720c018f73187b0c19b3c4f9bacc48d1ff0"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.7/protoc-21.7-linux-aarch_64.zip",
+      "etag": "0x8DAA2500BE180DF",
       "checksum": "2696a8f9a61ce67c510d000c88e2d0a8b5adf1f90514e461e8d8943c46d04737"
     },
     "aarch64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.7/protoc-21.7-osx-aarch_64.zip",
+      "etag": "0x8DAA2500D56103A",
       "checksum": "f79a67d708aba6ff2c6208578a6f2bf94f1528795aed646b65e99d4a678c97f8"
     }
   },
   "3.21.6": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.6/protoc-21.6-linux-x86_64.zip",
+      "etag": "0x8DA968D0236C1DC",
       "checksum": "6a9fc36363a2d05d73fc363a46cd57d849068d33305db39f77daac8ba073e818"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.6/protoc-21.6-osx-x86_64.zip",
+      "etag": "0x8DA968D03198505",
       "checksum": "45ac9e669af0708a472021efe18753c7957c2f3d359100202f80d309c1c39708"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.6/protoc-21.6-win64.zip",
+      "etag": "0x8DA968D03C93215",
       "checksum": "f14764a3af330dd0231da43b10340db46171a6f4af9667573fe370239d7ef751"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.6/protoc-21.6-linux-aarch_64.zip",
+      "etag": "0x8DA968D01192196",
       "checksum": "4fa9797ebf391687e39397e5822bdd025b919705ed47f874e251ba749c97bf49"
     },
     "aarch64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.6/protoc-21.6-osx-aarch_64.zip",
+      "etag": "0x8DA968D028DAE26",
       "checksum": "0ff1958362db716b93135ccdb1084bdccb0eb420284dce8203835c8572cabe0b"
     }
   },
   "3.21.5": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.5/protoc-21.5-linux-x86_64.zip",
+      "etag": "0x8DA7A40AD148E5F",
       "checksum": "92fb4f5066a6f7b870e09c73115a2c861852af8f6555d8da9955fdb80710bf7f"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.5/protoc-21.5-osx-x86_64.zip",
+      "etag": "0x8DA7A40ADCB67D2",
       "checksum": "495d86aaaf5e8b536fbf04471ee9d7b21addeee5f1e949742c67bd09bb59c890"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.5/protoc-21.5-win64.zip",
+      "etag": "0x8DA7A40AE65207A",
       "checksum": "1ecae2968d2f28364c3f43c55f687dd159568dc6b1b0dc7e1e93d99bccb896a6"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.5/protoc-21.5-linux-aarch_64.zip",
+      "etag": "0x8DA7A40ABF760D7",
       "checksum": "60744ee6be123f86921c86d83d0060a7261410e246eca9e7a5c195100a89d391"
     },
     "aarch64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.5/protoc-21.5-osx-aarch_64.zip",
+      "etag": "0x8DA7A40AD511963",
       "checksum": "b22aed8dce62656687c6c4a323aab4e6baf1cb81ee423e77bc671bd69679e2c3"
     }
   },
   "3.21.4": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.4/protoc-21.4-linux-x86_64.zip",
+      "etag": "0x8DA6E92A6345F1A",
       "checksum": "d51e8f030162f08823a4738ab0ac00bee537e30b583a562e6962dbb040d86736"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.4/protoc-21.4-osx-x86_64.zip",
+      "etag": "0x8DA6E92A38844DE",
       "checksum": "27ac01aee3e8b95ebec017b7b3aee55d4eb095cbd2a5148d2a20350af006072e"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.4/protoc-21.4-win64.zip",
+      "etag": "0x8DA6E92ABD725D2",
       "checksum": "090af381392abaf5fd8ae3070d8fc2a4ba2d0a9f8e52915d69b439c33be72da5"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.4/protoc-21.4-linux-aarch_64.zip",
+      "etag": "0x8DA6E92A556CB0A",
       "checksum": "5a377b505cf8c3ed29ad0b6e3827c5eb27273c00147fcfd833b9686192143e8d"
     },
     "aarch64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.4/protoc-21.4-osx-aarch_64.zip",
+      "etag": "0x8DA6E92A402B968",
       "checksum": "6a677c88a5e5b032aaff96767461788a316408d4ed0afef3f1455390a689ec18"
     }
   },
   "3.21.3": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.3/protoc-21.3-linux-x86_64.zip",
+      "etag": "0x8DA6AA4ADE3834B",
       "checksum": "214b670884972d09a1ccf7b7b4c65a12bdd73d55ebea6b5207b5eb2333ae32ec"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.3/protoc-21.3-osx-x86_64.zip",
+      "etag": "0x8DA6AA4A720F799",
       "checksum": "b988e06fed5279865445978efd97ec92990ca24b0fe16c04aafe85d6cee71eeb"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.3/protoc-21.3-win64.zip",
+      "etag": "0x8DA6AA4A2BB6176",
       "checksum": "2713c1a89a0f5d7450e27ddb955693abcae1aac26fca1f2e6f9de8193834887d"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.3/protoc-21.3-linux-aarch_64.zip",
+      "etag": "0x8DA6AA4B5F7141D",
       "checksum": "e22ad6908e197ac326a02ddabc49046846b64d051f3bef16f5d3afd50ffdec18"
     },
     "aarch64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.3/protoc-21.3-osx-aarch_64.zip",
+      "etag": "0x8DA6AA4ABF6CACA",
       "checksum": "3f1b2a59ba111e3227adf47e5513b3ea9133d9621dc5df70cd1ffed6dc756877"
     }
   },
   "3.21.2": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.2/protoc-21.2-linux-x86_64.zip",
+      "etag": "0x8DA561C479425D1",
       "checksum": "997dfc13189bd0af1051cbc026a095a520e171fbeb0e7460f959ae236b00aa2e"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.2/protoc-21.2-osx-x86_64.zip",
+      "etag": "0x8DA561C4890FEAE",
       "checksum": "b791ee763faad751505680fa8d2935af37ba014184354df6db4268cb413bc6a1"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.2/protoc-21.2-win64.zip",
+      "etag": "0x8DA561C48CCED88",
       "checksum": "06387cd52e84c3853ff1bd81fd0c1bbdc5eed07433aef4bd291e96763228fb07"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.2/protoc-21.2-linux-aarch_64.zip",
+      "etag": "0x8DA561C46DA189B",
       "checksum": "953beb8aade43f55a6f8e0aef5314236582c5cc2712d90a09221dd0bc35da71e"
     },
     "aarch64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.2/protoc-21.2-osx-aarch_64.zip",
+      "etag": "0x8DA561C486E6082",
       "checksum": "04d79d6c1da178d38867486a861bc878f5daaa084bd5697110abd27460d1112a"
     }
   },
   "3.21.1": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.1/protoc-21.1-linux-x86_64.zip",
+      "etag": "0x8DA402C092E52F5",
       "checksum": "c9ac47cddd90d4c79bc55964ca9aec2f7fa06034f9bcc8215dd655b975ffd425"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.1/protoc-21.1-osx-x86_64.zip",
+      "etag": "0x8DA402C09E41AC8",
       "checksum": "47c69e483148423de93aa466d7b7b763ca90d7ce699c5393b0025a678d396021"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.1/protoc-21.1-win64.zip",
+      "etag": "0x8DA402C0A6545D0",
       "checksum": "f27e4646a5b1aab9e2c16024f909da50bd4ae28744c6d0162e6af5fa48676fce"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.1/protoc-21.1-linux-aarch_64.zip",
+      "etag": "0x8DA402C0832D9CD",
       "checksum": "b8add83f1908d417c1089167ee0e6d946d84600887ded4240e837b8b0c84202e"
     },
     "aarch64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.1/protoc-21.1-osx-aarch_64.zip",
+      "etag": "0x8DA402C097AE121",
       "checksum": "885915096dfcdbc3462bd41a88505f6cba6255bf8425b07f4857e6762e1e41ae"
     }
   },
   "3.21.0": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.0/protoc-21.0-linux-x86_64.zip",
+      "etag": "0x8DA3EAAC50A1C86",
       "checksum": "a2a92003da7b8c0c08aab530a3c1967d377c2777723482adb9d2eb38c87a9d5f"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.0/protoc-21.0-osx-x86_64.zip",
+      "etag": "0x8DA3EAAC5CFE632",
       "checksum": "79cf6298d80b997d6e896e81df5f342e1db86e6b0a4c8c3f9c435c54818f8e15"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.0/protoc-21.0-win64.zip",
+      "etag": "0x8DA3EAAC65B47ED",
       "checksum": "2e9e932087722c3b975c704b4b0d91ece9165e3ec0c7b1c035ebb574feec50c2"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.0/protoc-21.0-linux-aarch_64.zip",
+      "etag": "0x8DA3EAAC3EB9221",
       "checksum": "72f063d96e4616995dfd24ba2c545ef741b7bf4b25e6077b86f19b41553b79e5"
     },
     "aarch64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.0/protoc-21.0-osx-aarch_64.zip",
+      "etag": "0x8DA3EAAC543E854",
       "checksum": "4cd865cfe59c18bdae7eaa08f2e18b2ddd29ef8d71602c90ab8ea402c5ba5555"
     }
   },
@@ -849,84 +1034,103 @@
   "3.20.3": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.20.3/protoc-3.20.3-linux-x86_64.zip",
+      "etag": "0x8DAA260AFF42A8F",
       "checksum": "44a6b498e996b845edef83864734c0e52f42197e85c9d567af55f4e3ff09d755"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.20.3/protoc-3.20.3-osx-x86_64.zip",
+      "etag": "0x8DAA260B01C6D2A",
       "checksum": "f3ac8c37e87cb345a509eef7ec614092995d9423b8effb42c207c8fbdacb97ee"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.20.3/protoc-3.20.3-win64.zip",
+      "etag": "0x8DAA260B067EA16",
       "checksum": "08e885a5d4dc1306cf31d0861527abd1d0953d6b8ad9a1fbadccecda6c4e4ba0"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.20.3/protoc-3.20.3-linux-aarch_64.zip",
+      "etag": "0x8DAA260AEDC059D",
       "checksum": "220aaf1d56327388acd30f869d7ee097bf8066c891bd0c9f72b64365e6bad73f"
     }
   },
   "3.20.2": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.20.2/protoc-3.20.2-linux-x86_64.zip",
+      "etag": "0x8DA967EF658E73E",
       "checksum": "d97227fd8bc840dcb1cf7332c8339a2d8f0fc381a98b028006e5c9a911d07c2a"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.20.2/protoc-3.20.2-osx-x86_64.zip",
+      "etag": "0x8DA967EF6F81C22",
       "checksum": "bf4abeff0678eba602b7f17d718574f394ac8455324a1563d10e4896c9037e1a"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.20.2/protoc-3.20.2-win64.zip",
+      "etag": "0x8DA967EF76488F7",
       "checksum": "c19c84b003fe9eb84a77d108f072a958ee4bcfeb91fc040a391f16138aa5174c"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.20.2/protoc-3.20.2-linux-aarch_64.zip",
+      "etag": "0x8DA967EF540EB49",
       "checksum": "c4b4903f356f2dbebf08137e51c7596cd1f2884ec7d711b2bf202c3e0ab38c0b"
     },
     "aarch64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.20.2/protoc-3.20.2-osx-aarch_64.zip",
+      "etag": "0x8DA967EF69E710D",
       "checksum": "4a9df5c4921dc3ea6d166da12178f7c40c398643b16844e61737e2bd6c765619"
     }
   },
   "3.20.1": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.20.1/protoc-3.20.1-linux-x86_64.zip",
+      "etag": "0x8DA23D3A54FE9F6",
       "checksum": "3a0e900f9556fbcac4c3a913a00d07680f0fdf6b990a341462d822247b265562"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.20.1/protoc-3.20.1-osx-x86_64.zip",
+      "etag": "0x8DA23D3A5D448A5",
       "checksum": "b4f36b18202d54d343a66eebc9f8ae60809a2a96cc2d1b378137550bbe4cf33c"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.20.1/protoc-3.20.1-win64.zip",
+      "etag": "0x8DA23D3A65266AC",
       "checksum": "897bf86b9c989f91c4171c7f99e3886fedfceb077a94dd150f1401cfe922cd46"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.20.1/protoc-3.20.1-linux-aarch_64.zip",
+      "etag": "0x8DA23D3A415EABA",
       "checksum": "8a5a51876259f934cd2acc2bc59dba0e9a51bd631a5c37a4b9081d6e4dbc7591"
     },
     "aarch64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.20.1/protoc-3.20.1-osx-aarch_64.zip",
+      "etag": "0x8DA23D3A58BFFB7",
       "checksum": "b362acae78542872bb6aac8dba73aaf0dc6e94991b8b0a065d6c3e703fec2a8b"
     }
   },
   "3.20.0": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.20.0/protoc-3.20.0-linux-x86_64.zip",
+      "etag": "0x8DA0EBD229059FF",
       "checksum": "75d8a9d7a2c42566e46411750d589c51276242d8b6247a5724bac0f9283e05a8"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.20.0/protoc-3.20.0-osx-x86_64.zip",
+      "etag": "0x8DA0EBD233B9C1D",
       "checksum": "8b35a679c99b36caef5899e596281fe0b943ed248f7d5f70b3e705684bf67cb4"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.20.0/protoc-3.20.0-win64.zip",
+      "etag": "0x8DA0EBD23C4DC46",
       "checksum": "70fbfdb38f2337c44da00b69eb4ba5d68182bbaab3f805a1a07ccdf1ff3923cc"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.20.0/protoc-3.20.0-linux-aarch_64.zip",
+      "etag": "0x8DA0EBD21557008",
       "checksum": "9bf7091569462e8349fe7d7584502b5d2c3bf8f4aafb4fcbdc465895158fd13e"
     },
     "aarch64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.20.0/protoc-3.20.0-osx-aarch_64.zip",
+      "etag": "0x8DA0EBD22E8CD48",
       "checksum": "dc5ad98c7b1d7ad90475ed333f023946e8fe5bef748cb54dc463069adb3fb5aa"
     }
   },
@@ -936,126 +1140,154 @@
   "3.19.6": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.19.6/protoc-3.19.6-linux-x86_64.zip",
+      "etag": "0x8DAA25BBBCB1FA2",
       "checksum": "f51152d0926ccf18d89e2b4e4f31c4bf16ee5f94499d379029f80ddb8304bdd0"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.19.6/protoc-3.19.6-osx-x86_64.zip",
+      "etag": "0x8DAA25BBC13DDDC",
       "checksum": "c9bb6829452d2f8ed7a589f8a6d2a31d4a07cec8d03e34277bcd60c743bc8855"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.19.6/protoc-3.19.6-win64.zip",
+      "etag": "0x8DAA25BBCB8434D",
       "checksum": "2d7816ab93a575341dc9989cd4e73517dcf4114f5d7dd6d5b88bc3dc8b77c75d"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.19.6/protoc-3.19.6-linux-aarch_64.zip",
+      "etag": "0x8DAA25BBAAEB570",
       "checksum": "c1028039721e2f3fa44d138f9ac35707966c6c81ccd79a07667a4dafb8751df7"
     }
   },
   "3.19.5": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.19.5/protoc-3.19.5-linux-x86_64.zip",
+      "etag": "0x8DA96991B088446",
       "checksum": "a6370d9a04eb26205cf68f4fb653b446a2d2e1f42f4ec4d791c85e207c579a80"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.19.5/protoc-3.19.5-osx-x86_64.zip",
+      "etag": "0x8DA96991B3B7364",
       "checksum": "9c6723f8237993220ba668530687bde3972ec850b37300994232b547a378e139"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.19.5/protoc-3.19.5-win64.zip",
+      "etag": "0x8DA96991BD8379C",
       "checksum": "e3c063905accde6f310ce57b59db2e6f215af2d6f5b9d12007c0475c7cc9f641"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.19.5/protoc-3.19.5-linux-aarch_64.zip",
+      "etag": "0x8DA96991BD8379C",
       "checksum": "ddd81bb0e9ee349e184efff20ba744ac764962867dc3f4260d3b3be26115817f"
     }
   },
   "3.19.4": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.19.4/protoc-3.19.4-linux-x86_64.zip",
+      "etag": "0x8D9E27E3E119817",
       "checksum": "058d29255a08f8661c8096c92961f3676218704cbd516d3916ec468e139cbd87"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.19.4/protoc-3.19.4-osx-x86_64.zip",
+      "etag": "0x8D9E27E3BBF4B57",
       "checksum": "d8b55cf1e887917dd43c447d77bd5bd213faff1e18ac3a176b35558d86f7ffff"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.19.4/protoc-3.19.4-win64.zip",
+      "etag": "0x8D9E27E41BADEE6",
       "checksum": "828d2bdfe410e988cfc46462bcabd34ffdda8cc172867989ec647eadc55b03b5"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.19.4/protoc-3.19.4-linux-aarch_64.zip",
+      "etag": "0x8D9E27E3714E643",
       "checksum": "95584939e733bdd6ffb8245616b2071f565cd4c28163b6c21c8f936a9ee20861"
     }
   },
   "3.19.3": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.19.3/protoc-3.19.3-linux-x86_64.zip",
+      "etag": "0x8D9D5C3FA8E4589",
       "checksum": "e7acbd3f3477c593cee58cd995490c0f95dcb4058dd4677d015535fc20a372f3"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.19.3/protoc-3.19.3-osx-x86_64.zip",
+      "etag": "0x8D9D5C3FCC4CF9C",
       "checksum": "2321216f9e928499c1637e4267a6c516b7d8c9aa1581e4e723ae924dc07a7d61"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.19.3/protoc-3.19.3-win64.zip",
+      "etag": "0x8D9D5C1CA8B4693",
       "checksum": "bebc4581a2cef829fd20c7b36d3d55e70305e85b1fc8530762c0155c51c46f31"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.19.3/protoc-3.19.3-linux-aarch_64.zip",
+      "etag": "0x8D9D5C1C939559F",
       "checksum": "a3c90277592b91e2e2d80a2e1d87157f266129b05fb8b626f54015fff61e0f73"
     }
   },
   "3.19.2": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.19.2/protoc-3.19.2-linux-x86_64.zip",
+      "etag": "0x8D9D10924FE816D",
       "checksum": "595ac0beaa7d2d6a672911b3b39a27fea964a5e76eeeba418a4bd3c4e8f72405"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.19.2/protoc-3.19.2-osx-x86_64.zip",
+      "etag": "0x8D9D104C41E6099",
       "checksum": "1af3bdcd1e684d7cbf498749f630574609f75bc33e50b03e0c9f7243d9986771"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.19.2/protoc-3.19.2-win64.zip",
+      "etag": "0x8D9D104C3EA3949",
       "checksum": "465eabb87b38c1f26f0c5404561611ad5ed9f961bd0cda095a112f641846c3d0"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.19.2/protoc-3.19.2-linux-aarch_64.zip",
+      "etag": "0x8D9D106E6AEB793",
       "checksum": "d14af76a12eaf22cb96c9eec4c82b2132f3b1ee29bd43e07551e4a3cef5cc16a"
     }
   },
   "3.19.1": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.19.1/protoc-3.19.1-linux-x86_64.zip",
+      "etag": "0x8D9B964D643762E",
       "checksum": "4b18a69b3093432ee0531bc9bf3c4114f81bde1670ade2875f694180ac8bd7f6"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.19.1/protoc-3.19.1-osx-x86_64.zip",
+      "etag": "0x8D9B964E46844C9",
       "checksum": "9dbe9128eeba41a969d1e87207e97a3884f68718d84ec5debc92115d5a957286"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.19.1/protoc-3.19.1-win64.zip",
+      "etag": "0x8D9B964EA259B27",
       "checksum": "7e904214696702285aa5b503a86fa38a14c9eeb0f3fe10ff3115a74e3a90dae8"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.19.1/protoc-3.19.1-linux-aarch_64.zip",
+      "etag": "0x8D9B96501A482AE",
       "checksum": "086e40c1658d241b2aefae659778637055b7c02e166fe2c835929a3066d41be3"
     }
   },
   "3.19.0": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.19.0/protoc-3.19.0-linux-x86_64.zip",
+      "etag": "0x8D9B964E83E5E5B",
       "checksum": "2994b7256f7416b90ad831dbf76a27c0934386deb514587109f39141f2636f37"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.19.0/protoc-3.19.0-osx-x86_64.zip",
+      "etag": "0x8D9B964E5C6B6B3",
       "checksum": "dea4733454469f796d671dd3d18c3bf24a11396d3f63a954e1828d3298928800"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.19.0/protoc-3.19.0-win64.zip",
+      "etag": "0x8D9B964D7FDDD2E",
       "checksum": "fe97c59a47c3d0ea8be3b8e06eec92fd164c227ed7d9463c9f5134eba77e615c"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.19.0/protoc-3.19.0-linux-aarch_64.zip",
+      "etag": "0x8D9B965008B73F4",
       "checksum": "f6a3a33ae4207292c25277ad3a00a67a85706b890acc6e29c08b6835ff006f83"
     }
   },
@@ -1065,72 +1297,88 @@
   "3.18.3": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.18.3/protoc-3.18.3-linux-x86_64.zip",
+      "etag": "0x8DA969438C53C74",
       "checksum": "c9c48c28ef222d9ade52ab3d1c1e775b07d93e41e816d51145ca3210619c4485"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.18.3/protoc-3.18.3-osx-x86_64.zip",
+      "etag": "0x8DA96943902B132",
       "checksum": "4094621eb6aa932201456d559a74aa580f187300716327aec9cd32c2eb23324d"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.18.3/protoc-3.18.3-win64.zip",
+      "etag": "0x8DA969439DB8AD3",
       "checksum": "505bde1240bd7dda1fc8ac29596cc0f8d8527b1e30b155d26c541499c678edcb"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.18.3/protoc-3.18.3-linux-aarch_64.zip",
+      "etag": "0x8DA969437FF72B5",
       "checksum": "06884e0b148b15603e79b825436d579dfa8c4cb36f47d17fa085a6b203f0291d"
     }
   },
   "3.18.2": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.18.2/protoc-3.18.2-linux-x86_64.zip",
+      "etag": "0x8D9D10BD24C3DB0",
       "checksum": "a6bc623860f07fc3d18626f2b86bab9bf3e3dc49c3752a086e8816dcaf432d48"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.18.2/protoc-3.18.2-osx-x86_64.zip",
+      "etag": "0x8D9D11654A0D146",
       "checksum": "51e338555f8fb100fa6a987dbbae74d0b133f06d6c35bf417781b57d366570cd"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.18.2/protoc-3.18.2-win64.zip",
+      "etag": "0x8D9D106B222AC70",
       "checksum": "9439c45a44c8b05aa239a91be13f87f6bcf42ea80062afbfb49dbe40dd4d538a"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.18.2/protoc-3.18.2-linux-aarch_64.zip",
+      "etag": "0x8D9D10BD2238652",
       "checksum": "87e7eb1e2a2e6b462be21974174b016a4c78c6b8d3826e3d7c4b7d819db6a040"
     }
   },
   "3.18.1": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.18.1/protoc-3.18.1-linux-x86_64.zip",
+      "etag": "0x8D9B964E0730F13",
       "checksum": "220bd1704c73dbf4d0a91399a2ecf9d19938b5cd80c8a38839a023d8b87bb772"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.18.1/protoc-3.18.1-osx-x86_64.zip",
+      "etag": "0x8D9B964E7F74DB8",
       "checksum": "66cc93e7f9e6a3f8c19050e4ac09dc06006cf86fdf6be972e32ad8fcb7c92ee3"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.18.1/protoc-3.18.1-win64.zip",
+      "etag": "0x8D9B964EF45B747",
       "checksum": "9a011a301b9e4fe760b2322b3c58900a9f837281db97d95217b66b7368a5bae8"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.18.1/protoc-3.18.1-linux-aarch_64.zip",
+      "etag": "0x8D9B9650EFF4150",
       "checksum": "c199349928f597635d43da8233fbdb02c35742bd38744c6428e7ee593dae513c"
     }
   },
   "3.18.0": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.18.0/protoc-3.18.0-linux-x86_64.zip",
+      "etag": "0x8D9B964D972E107",
       "checksum": "8b6b0c82f730212801d9cce4653abb1a1f4204555a92e8e2b5f625d61e66f1b4"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.18.0/protoc-3.18.0-osx-x86_64.zip",
+      "etag": "0x8D9B964F437EC5B",
       "checksum": "18c6b9585a0ceff7be1673271b30497f13c3eb8e6894354066c269d2846337c1"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.18.0/protoc-3.18.0-win64.zip",
+      "etag": "0x8D9B965005D17CB",
       "checksum": "222ecf84acdaacf2883b95fd83e14f1b3ffb8598f92ad8f595a90e8fd0a8feb8"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.18.0/protoc-3.18.0-linux-aarch_64.zip",
+      "etag": "0x8D9B964D57D0F23",
       "checksum": "02c8d20b792705d0e5131c6507257d0dc0d131705e2e280c5f0e0b8498d4fff5"
     }
   },
@@ -1140,72 +1388,88 @@
   "3.17.3": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.17.3/protoc-3.17.3-linux-x86_64.zip",
+      "etag": "0x8D9B964CEBD3BFC",
       "checksum": "d4246a5136cf9cd1abc851c521a1ad6b8884df4feded8b9cbd5e2a2226d4b357"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.17.3/protoc-3.17.3-osx-x86_64.zip",
+      "etag": "0x8D9B964E29B90F8",
       "checksum": "68901eb7ef5b55d7f2df3241ab0b8d97ee5192d3902c59e7adf461adc058e9f1"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.17.3/protoc-3.17.3-win64.zip",
+      "etag": "0x8D9B965009D72B0",
       "checksum": "c78d42bea30771b81bb3839128ad7ef528b376680bba489998b4a3cd5a495a47"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.17.3/protoc-3.17.3-linux-aarch_64.zip",
+      "etag": "0x8D9B964EC8DDBCD",
       "checksum": "ceb29d4890a31ba871829d22c2b7fa28f237d2b91ce4ea2a53e893d60a1cd502"
     }
   },
   "3.17.2": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.17.2/protoc-3.17.2-linux-x86_64.zip",
+      "etag": "0x8D9B964CF8A0AB4",
       "checksum": "98e2253e513620bb6cb6f5654c3586107cafcd789cc1c778bba780607b335c03"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.17.2/protoc-3.17.2-osx-x86_64.zip",
+      "etag": "0x8D9B964DCF8275F",
       "checksum": "d6f71643e0e56e4775ae915bb8a942b84629e8620722549b6cbab485fbbcf84e"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.17.2/protoc-3.17.2-win64.zip",
+      "etag": "0x8D9B964D89AF067",
       "checksum": "73451257945cc889eea6fc912bdf02023a5f12054b4ec39e8c5ba048b6b1d8fc"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.17.2/protoc-3.17.2-linux-aarch_64.zip",
+      "etag": "0x8D9B964F2823F99",
       "checksum": "220e81977ebbd86a39fea2ca794d0305d765c6b94ca8d9ef1a3603a6415f7311"
     }
   },
   "3.17.1": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.17.1/protoc-3.17.1-linux-x86_64.zip",
+      "etag": "0x8D9B964E185DD24",
       "checksum": "5c67fed93a7817be8d579dd0c03884e1ef341780acdf25d683e55225d54cce25"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.17.1/protoc-3.17.1-osx-x86_64.zip",
+      "etag": "0x8D9B96507AF2A50",
       "checksum": "acd3ce18bdf4bbbff46354e140fad03315f7c17f67d38289ff35f802539cc09f"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.17.1/protoc-3.17.1-win64.zip",
+      "etag": "0x8D9B96505B4686B",
       "checksum": "4d1ab199f90fab09e20e5dfc45b4afe7d08ab1f4fe2762aaddcd4fafaa6bcd61"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.17.1/protoc-3.17.1-linux-aarch_64.zip",
+      "etag": "0x8D9B964DE5C64D5",
       "checksum": "00993203265b01379d706f2e916ac3d8e4a62c44af3dc017ff172583c548ae14"
     }
   },
   "3.17.0": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.17.0/protoc-3.17.0-linux-x86_64.zip",
+      "etag": "0x8D9B9650F963AE5",
       "checksum": "aad5cfd2daf9d49f5ec9b14c4e7e7af0392324706c0e5bb3e44ad5e70a7add5e"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.17.0/protoc-3.17.0-osx-x86_64.zip",
+      "etag": "0x8D9B964F76227E4",
       "checksum": "f51e7d285e9e8fcfe04ac6834d9dab56571e39dbcb01d0437b0eb3ee8a5a76c9"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.17.0/protoc-3.17.0-win64.zip",
+      "etag": "0x8D9B964FF5174A0",
       "checksum": "f504bd885835c10d3adc819d8cd442567b7145454f4aaff0caabd341868be90e"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.17.0/protoc-3.17.0-linux-aarch_64.zip",
+      "etag": "0x8D9B964FCD9CCEF",
       "checksum": "d635e9ab32d5b33fb1e5f7e4964709b2f42a281c464c9cd7ded3743a11bf6af8"
     }
   },
@@ -1215,54 +1479,66 @@
   "3.16.3": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.16.3/protoc-3.16.3-linux-x86_64.zip",
+      "etag": "0x8DAA26859D4247B",
       "checksum": "fedf08a990cd05bfaadcd2160f7929ba0ff9ca1434ed7193d4a44124d1380a4e"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.16.3/protoc-3.16.3-osx-x86_64.zip",
+      "etag": "0x8DAA2685A1EB737",
       "checksum": "22507a2c03d4d59edae00993b64549ccb280dbcd05b2a5d6e256c76a57715922"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.16.3/protoc-3.16.3-win64.zip",
+      "etag": "0x8DAA2685A9C395A",
       "checksum": "cce885dddfb7f496f58c1e1ff362e3ae903a5366af87a8305f73be8124c78963"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.16.3/protoc-3.16.3-linux-aarch_64.zip",
+      "etag": "0x8DAA26858BDFAFF",
       "checksum": "141cb4d8275016b162c71dcb199e3385061a3b727ce47cc5eb596cd798864048"
     }
   },
   "3.16.1": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.16.1/protoc-3.16.1-linux-x86_64.zip",
+      "etag": "0x8D9D1130FA8DB04",
       "checksum": "dffb7209d31b7e87e8e8ba2d5d869ceda5a5cea8883c4b13a726611a0dbd8a7c"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.16.1/protoc-3.16.1-osx-x86_64.zip",
+      "etag": "0x8D9D1130EACEEBE",
       "checksum": "a24923eee959e8b8f8c558b5da827a2a4361650593c8f9c9fb7c2891be771fcc"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.16.1/protoc-3.16.1-win64.zip",
+      "etag": "0x8D9D1130FE258AC",
       "checksum": "3c68996a44091402789c112d38bc864250165d120b7deb05e02048001fd5d196"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.16.1/protoc-3.16.1-linux-aarch_64.zip",
+      "etag": "0x8D9D10F224346DD",
       "checksum": "a680ffea29884ac31d4f5bed93076f05c56c495f929720023bd1ed797bb51118"
     }
   },
   "3.16.0": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.16.0/protoc-3.16.0-linux-x86_64.zip",
+      "etag": "0x8D9B964D1DA0BF5",
       "checksum": "de1143cd00a3b23207e893bed51cd6c8c3ccc35db35f1a09cab94786bfba791c"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.16.0/protoc-3.16.0-osx-x86_64.zip",
+      "etag": "0x8D9B96507A2A907",
       "checksum": "c5b259e8989b063b62bc5479f206fd9b45ea850cb95f6eb3cd8997cd5939ffb2"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.16.0/protoc-3.16.0-win64.zip",
+      "etag": "0x8D9B964F59DD73F",
       "checksum": "26fe0f8a01d7618b3084634871486de735598a4f236850c65901e7e1d33c74df"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.16.0/protoc-3.16.0-linux-aarch_64.zip",
+      "etag": "0x8D9B964FC022A6A",
       "checksum": "1ff8ade56c3e34c5cd3cadd64b9d9565bfa04243de4d0713e936024ebc8f30a8"
     }
   },
@@ -1272,162 +1548,198 @@
   "3.15.8": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.15.8/protoc-3.15.8-linux-x86_64.zip",
+      "etag": "0x8D9B964E9C894C2",
       "checksum": "b9ff821d2a4f9e9943dc2a13e6a76d99c7472dac46ddd3718a3a4c3b877c044a"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.15.8/protoc-3.15.8-osx-x86_64.zip",
+      "etag": "0x8D9B964F324D038",
       "checksum": "ab11029340de61bb707a4d564ceeb580d31436f5466fad2194c91beb040aa828"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.15.8/protoc-3.15.8-win64.zip",
+      "etag": "0x8D9B964CEAD86DE",
       "checksum": "43ae4e797e4a0a82e65e27adf624c3d6f314f1ed2a18e492632a91dd3c9673c1"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.15.8/protoc-3.15.8-linux-aarch_64.zip",
+      "etag": "0x8D9B964E43A5DBE",
       "checksum": "c60bd7942267fdf4108eea40c0a9781ea56c9261538b03b2bd96b3b898958033"
     }
   },
   "3.15.7": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.15.7/protoc-3.15.7-linux-x86_64.zip",
+      "etag": "0x8D9B9650ACAC1F5",
       "checksum": "28b8ca3c0f91441ca80598ced2584e58f8281ebfaf0e6377fea45301eddee94f"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.15.7/protoc-3.15.7-osx-x86_64.zip",
+      "etag": "0x8D9B96509C97D80",
       "checksum": "4f568bea2fd0087c9726e43a6610fd726d0fb17a447f40f7e4f5490a63b69b90"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.15.7/protoc-3.15.7-win64.zip",
+      "etag": "0x8D9B964D7C63395",
       "checksum": "d592c46b83f1700dfe9588afdd19ef4eaa0c6b114daeb19ce26e98df5e46c123"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.15.7/protoc-3.15.7-linux-aarch_64.zip",
+      "etag": "0x8D9B964E1FCD057",
       "checksum": "2474949b912baff9dfcdcde8a0fc5fffad8c2d453687d4df09954be9dcaaf2d5"
     }
   },
   "3.15.6": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.15.6/protoc-3.15.6-linux-x86_64.zip",
+      "etag": "0x8D9B9650F56CA41",
       "checksum": "38a2f024a0ce68897b1868c59b613939bd41f16c0c8d8890843eccdbbf46ab00"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.15.6/protoc-3.15.6-osx-x86_64.zip",
+      "etag": "0x8D9B96500396872",
       "checksum": "ca025c889efbe02f390b251c153c752a05fb04f5ac8c93929f8dba2818a5392a"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.15.6/protoc-3.15.6-win64.zip",
+      "etag": "0x8D9B964FB6E3D95",
       "checksum": "d4cd42275a32c3dbc194aa3c884a5b487688befcf5e03e5aa7837702a779ba30"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.15.6/protoc-3.15.6-linux-aarch_64.zip",
+      "etag": "0x8D9B96505ABB71F",
       "checksum": "13f6ee95d36165b8a1b566379abb211d76a5a6add38aa912541a27ce4e8de63d"
     }
   },
   "3.15.5": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.15.5/protoc-3.15.5-linux-x86_64.zip",
+      "etag": "0x8D9B964DF623C81",
       "checksum": "7358bf688ddad8d6ba430240b44e644c88c4678a21221987cd8d2a0dbf119beb"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.15.5/protoc-3.15.5-osx-x86_64.zip",
+      "etag": "0x8D9B964D0454FCB",
       "checksum": "32486315264e9c296009ae7148297c599b935dd62a886e82be2a599c380f7f88"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.15.5/protoc-3.15.5-win64.zip",
+      "etag": "0x8D9B964E08E823F",
       "checksum": "e603e725375e4f38cc08cedcd354847109a261ec44561480e216458a4c904afd"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.15.5/protoc-3.15.5-linux-aarch_64.zip",
+      "etag": "0x8D9B965076E815A",
       "checksum": "bf61b1d48d00fb592d54308f24fbfa60579a643388e8582f08ab15ad1f18259e"
     }
   },
   "3.15.4": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.15.4/protoc-3.15.4-linux-x86_64.zip",
+      "etag": "0x8D9B964D7F8ADD8",
       "checksum": "14cca6414353c965ecf3c6bfc5aefb5b54cbd2f572b61aa67bf1ca435b086db9"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.15.4/protoc-3.15.4-osx-x86_64.zip",
+      "etag": "0x8D9B964F85934A8",
       "checksum": "c65087e20508ccbcf051e17e518289033af18d497fe6a6cf68f9e20c1501fa47"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.15.4/protoc-3.15.4-win64.zip",
+      "etag": "0x8D9B964F2AC569D",
       "checksum": "fb9f4acbfec05d0a6bc6bd42d3c6e513fbb62374990f60165e7f60c16eb62990"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.15.4/protoc-3.15.4-linux-aarch_64.zip",
+      "etag": "0x8D9B9650739E48F",
       "checksum": "ab3a48ac7e6506bf306be5dd1323b0a124c8e1fb5bc5a94bf3daafff36e39a2f"
     }
   },
   "3.15.3": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.15.3/protoc-3.15.3-linux-x86_64.zip",
+      "etag": "0x8D9B964D8B13438",
       "checksum": "acf79987ffaac565f24a59b738f932377c783fb9615347fd6fade5dadd863242"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.15.3/protoc-3.15.3-osx-x86_64.zip",
+      "etag": "0x8D9B964FE5F4916",
       "checksum": "ed3a657ea591eb7b314b81a01aac55e2fbb1cf82966bff1603de0bbae80cb9b9"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.15.3/protoc-3.15.3-win64.zip",
+      "etag": "0x8D9B96505996A53",
       "checksum": "bf600c6cab7d6928195d5719f2a0169a9e9ebd3c5d6425c0a215284087e775b3"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.15.3/protoc-3.15.3-linux-aarch_64.zip",
+      "etag": "0x8D9B964DDEF5B40",
       "checksum": "5e5dd98d328f167296403d512a0789acb622089d99ed9833edf6fc498d6d0cdc"
     }
   },
   "3.15.2": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.15.2/protoc-3.15.2-linux-x86_64.zip",
+      "etag": "0x8D9B964D661810E",
       "checksum": "dfccc331d57b398b29ab8cadb380b8912edaa1c8c181cf994fb1c2f3aa67ca15"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.15.2/protoc-3.15.2-osx-x86_64.zip",
+      "etag": "0x8D9B964CF22CCA5",
       "checksum": "48e19901248cd94047c7830b10570fdf6a23e2a09c33eeb279cfcad37798d857"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.15.2/protoc-3.15.2-win64.zip",
+      "etag": "0x8D9B964FD4A7F80",
       "checksum": "1e1307ade376e181bc16c9893ee6fea9f4088e789083d4963ef92c458e617e76"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.15.2/protoc-3.15.2-linux-aarch_64.zip",
+      "etag": "0x8D9B964CF2B56DB",
       "checksum": "07f034eecb0201666410808a77dbe6bed272481ef140ceda1cec958b4382777c"
     }
   },
   "3.15.1": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.15.1/protoc-3.15.1-linux-x86_64.zip",
+      "etag": "0x8D9B965049E3F77",
       "checksum": "fa92e5ecc5a8d079eeb3059d6889bd2c97820e74ee58d8cf11db98dace11b856"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.15.1/protoc-3.15.1-osx-x86_64.zip",
+      "etag": "0x8D9B964D757076E",
       "checksum": "84e2a2dad9662a98d934107ee4d6f531cce8096b0b183e17484b107e3213a8bc"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.15.1/protoc-3.15.1-win64.zip",
+      "etag": "0x8D9B964E132E75D",
       "checksum": "73582b81cbc0ee7fbb91245305b3c4ba1fa80eeeac5b943522ad432e44c77e6d"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.15.1/protoc-3.15.1-linux-aarch_64.zip",
+      "etag": "0x8D9B964E86B341E",
       "checksum": "0bf0a7d297cbe4a4c6280dc4eecb0eed76e86043b7983223e51c26fca5a231c5"
     }
   },
   "3.15.0": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.15.0/protoc-3.15.0-linux-x86_64.zip",
+      "etag": "0x8D9B964D19B5E8C",
       "checksum": "fbfab762b252a6ccb894a8207c9631f88dedf63066508152de65c2812e14377c"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.15.0/protoc-3.15.0-osx-x86_64.zip",
+      "etag": "0x8D9B9650097801D",
       "checksum": "7a9f9edfbf61144d7c64398b21d5e3cfdbbfa26825253239e61b1668e1f64503"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.15.0/protoc-3.15.0-win64.zip",
+      "etag": "0x8D9B964DDDC9952",
       "checksum": "78dfdf220248b90bdc058a205b77b6f16b4fe76998508b4050ce4fbce2c3d85f"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.15.0/protoc-3.15.0-linux-aarch_64.zip",
+      "etag": "0x8D9B964FB8607D5",
       "checksum": "aa27d657668a8608f4f91d80d6e58505500987a07ddad7a05e471a71329945a1"
     }
   },
@@ -1437,18 +1749,22 @@
   "3.14.0": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.14.0/protoc-3.14.0-linux-x86_64.zip",
+      "etag": "0x8D9B9650D13233E",
       "checksum": "a2900100ef9cda17d9c0bbf6a3c3592e809f9842f2d9f0d50e3fba7f3fc864f0"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.14.0/protoc-3.14.0-osx-x86_64.zip",
+      "etag": "0x8D9B964D029DC9E",
       "checksum": "699ceee7ef0988ecf72bf1c146dee5d9d89351a19d4093d30ebea3c04008bb8c"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.14.0/protoc-3.14.0-win64.zip",
+      "etag": "0x8D9B964D567DC90",
       "checksum": "642554ed4dd2dba94e1afddcccdd7d832999cea309299cc5952f13db389894f8"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.14.0/protoc-3.14.0-linux-aarch_64.zip",
+      "etag": "0x8D9B964FC9C57D3",
       "checksum": "67db019c10ad0a151373278383e4e9b756dc90c3cea6c1244d5d5bd230af7c1a"
     }
   },
@@ -1458,18 +1774,22 @@
   "3.13.0": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.13.0/protoc-3.13.0-linux-x86_64.zip",
+      "etag": "0x8D9B964FFF53D92",
       "checksum": "4a3b26d1ebb9c1d23e933694a6669295f6a39ddc64c3db2adf671f0a6026f82e"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.13.0/protoc-3.13.0-osx-x86_64.zip",
+      "etag": "0x8D9B964F0E6A6A3",
       "checksum": "a201954cc7d1a309b5f4feacd23a0abcf3ffc20eb15e79c9a0856a5804f6c34c"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.13.0/protoc-3.13.0-win64.zip",
+      "etag": "0x8D9B964DB4671A6",
       "checksum": "326a18c917cce8bc58fa6741260f6fb733186ffdab728a952b4cf31e57a76b91"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.13.0/protoc-3.13.0-linux-aarch_64.zip",
+      "etag": "0x8D9B964F669469F",
       "checksum": "5f6f59be05ce91425195dc689f5faa59284efb4799526b6f92a7a91efe5702fd"
     }
   },
@@ -1479,90 +1799,110 @@
   "3.12.4": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.12.4/protoc-3.12.4-linux-x86_64.zip",
+      "etag": "0x8D9B964D3861D40",
       "checksum": "d0d4c7a3c08d3ea9a20f94eaface12f5d46d7b023fe2057e834a4181c9e93ff3"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.12.4/protoc-3.12.4-osx-x86_64.zip",
+      "etag": "0x8D9B965033A501B",
       "checksum": "210227683a5db4a9348cd7545101d006c5829b9e823f3f067ac8539cb387519e"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.12.4/protoc-3.12.4-win64.zip",
+      "etag": "0x8D9B964DA422060",
       "checksum": "61b843af43afd5291897be1348b58e22764a3402db51538dce9d7f242091fa76"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.12.4/protoc-3.12.4-linux-aarch_64.zip",
+      "etag": "0x8D9B964F0B90DAE",
       "checksum": "30b4597db5d7c5c1c473f7c51d965890f025009917e1e02f06a6a72a44135002"
     }
   },
   "3.12.3": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.12.3/protoc-3.12.3-linux-x86_64.zip",
+      "etag": "0x8D9B9650874CE27",
       "checksum": "90257aed22e983a6772fb5af259a14d8f78deac0814a7df76a741975ffeea1c0"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.12.3/protoc-3.12.3-osx-x86_64.zip",
+      "etag": "0x8D9B964F9CEAD9A",
       "checksum": "e900edb8f19b8583ed2c2115138f40fb7ddbe2a71a05207ee3a0476e75ccaaa9"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.12.3/protoc-3.12.3-win64.zip",
+      "etag": "0x8D9B964F9582F8C",
       "checksum": "88dd84d8df26950edd2af41f4ccdbad7461eba7cf9383f5025a99218395a308f"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.12.3/protoc-3.12.3-linux-aarch_64.zip",
+      "etag": "0x8D9B964D2551D3B",
       "checksum": "f856295c89d040987908e5b1abfb6e65943ed92407cbff9f545395aee354160c"
     }
   },
   "3.12.2": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.12.2/protoc-3.12.2-linux-x86_64.zip",
+      "etag": "0x8D9B964ED06CA7F",
       "checksum": "54002e5da8ad2a7bd9b58f536d46d9eec3db5f1d9821bf653e16c543ba4de6de"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.12.2/protoc-3.12.2-osx-x86_64.zip",
+      "etag": "0x8D9B964D6F67F1F",
       "checksum": "8841df8ca86f85c2be519b15e7529171800144d121603612b0242bbf01c83976"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.12.2/protoc-3.12.2-win64.zip",
+      "etag": "0x8D9B964D3374589",
       "checksum": "79252db5071cf287b29c83a41b9aa78776f1ac8854b3040867c73fca49936bec"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.12.2/protoc-3.12.2-linux-aarch_64.zip",
+      "etag": "0x8D9B964E1B5719A",
       "checksum": "8c43b18f31955ed041b3f85e6dcb2dba07723c68a5e073de159d81376c1ab14b"
     }
   },
   "3.12.1": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.12.1/protoc-3.12.1-linux-x86_64.zip",
+      "etag": "0x8D9B964F650B924",
       "checksum": "d85fa734ac71eb7c1ea140b695511c00f678c14e11543c812ac2d348c03c379f"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.12.1/protoc-3.12.1-osx-x86_64.zip",
+      "etag": "0x8D9B964D6D762F3",
       "checksum": "8b259356819dbdd7eabfd5dec14ba7e00e4d417a12d55b2e987a9fe93b0f0415"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.12.1/protoc-3.12.1-win64.zip",
+      "etag": "0x8D9B964E5D1637E",
       "checksum": "49f974bd6f405558ae042d6710a6a02ab636e2a2fa6dd50a7879c115511194f4"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.12.1/protoc-3.12.1-linux-aarch_64.zip",
+      "etag": "0x8D9B964E2B68F0A",
       "checksum": "993eff712d16f65fe38a4f408d30c5592864861465d4e52035ab193d43d72d8f"
     }
   },
   "3.12.0": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.12.0/protoc-3.12.0-linux-x86_64.zip",
+      "etag": "0x8D9B964ED08C5FF",
       "checksum": "3af5f90ad973c36bdaf5c4bd0082cfdc8881593ddf530fc6aa1442ee3d7a4e4b"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.12.0/protoc-3.12.0-osx-x86_64.zip",
+      "etag": "0x8D9B964FC9E7A66",
       "checksum": "3e9d607bd732429318bf3543e8ed3ad4864d43cee9e120ecff5cf37f2f9c88f1"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.12.0/protoc-3.12.0-win64.zip",
+      "etag": "0x8D9B964D8CDB8B5",
       "checksum": "6b0015aee76d88471e248ee507b2ec012b4cc2643c65e9d385dabaffc082a5fe"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.12.0/protoc-3.12.0-linux-aarch_64.zip",
+      "etag": "0x8D9B964E0DD80FF",
       "checksum": "b3424449e466a201b16d9d13f34ce8d06f351849ebe9f87019a00264a59f26fb"
     }
   },
@@ -1572,90 +1912,110 @@
   "3.11.4": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.11.4/protoc-3.11.4-linux-x86_64.zip",
+      "etag": "0x8D9B964F8DC0CF9",
       "checksum": "6d0f18cd84b918c7b3edd0203e75569e0c8caecb1367bbbe409b45e28514f5be"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.11.4/protoc-3.11.4-osx-x86_64.zip",
+      "etag": "0x8D9B964DF4D30FF",
       "checksum": "8c6af11e1058efe953830ecb38324c0e0fd2fb67df3891896d138c535932e7db"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.11.4/protoc-3.11.4-win64.zip",
+      "etag": "0x8D9B964CF3BCF2E",
       "checksum": "93d006549a4b87fbc0a2e931c248e83c75a6b8d5318575c4a29521b7ed3e736d"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.11.4/protoc-3.11.4-linux-aarch_64.zip",
+      "etag": "0x8D9B964F7E6FBB3",
       "checksum": "f24c9fa1fc4a7770b8a5da66e515cb8a638d086ad2afa633abb97137c5f029a8"
     }
   },
   "3.11.3": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.11.3/protoc-3.11.3-linux-x86_64.zip",
+      "etag": "0x8D9B964F03C9D06",
       "checksum": "39f5d64b0f31117c94651c880d0a776159e49eab42b2066229569934b936a5e7"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.11.3/protoc-3.11.3-osx-x86_64.zip",
+      "etag": "0x8D9B964EDA2A55E",
       "checksum": "a02dc07c3776de214c3dff4025b33269aebd0fc03aa8e791e7025df43c06e219"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.11.3/protoc-3.11.3-win64.zip",
+      "etag": "0x8D9B964CEB833B1",
       "checksum": "1490944d3bbf77b58bcbd175fef6fbf14cc9c20f79be06c4be827641af1c6ca2"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.11.3/protoc-3.11.3-linux-aarch_64.zip",
+      "etag": "0x8D9B964EFDBEDAC",
       "checksum": "3994233e61c287a377a9134e658ca3034924849f0e3a82d12b0e6efa2bed4b46"
     }
   },
   "3.11.2": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.11.2/protoc-3.11.2-linux-x86_64.zip",
+      "etag": "0x8D9B964D7EF6065",
       "checksum": "c0c666fb679a8221bed01bffeed1f80727c6c7827d0cbd8f162195efb12df9e0"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.11.2/protoc-3.11.2-osx-x86_64.zip",
+      "etag": "0x8D9B964CECF88C8",
       "checksum": "172993febdebdb495ba397aa734d9dd1f8332c5ed578168c39bc5ab94bc8c09c"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.11.2/protoc-3.11.2-win64.zip",
+      "etag": "0x8D9B964E7AD304A",
       "checksum": "35286113a033edf0d23bca6e43c6e8f2918946067945ffe5bc6facfc4fb0ebb3"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.11.2/protoc-3.11.2-linux-aarch_64.zip",
+      "etag": "0x8D9B964E490FC77",
       "checksum": "870cb20a5581ef60731bdc6a69f6537eb4a48d630b5904fdffcaed724c87bf3a"
     }
   },
   "3.11.1": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.11.1/protoc-3.11.1-linux-x86_64.zip",
+      "etag": "0x8D9B964F11B9180",
       "checksum": "1102323cdaacd589e50b8b7770595f220f54d18a1d76ee3c445198f80ab865b8"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.11.1/protoc-3.11.1-osx-x86_64.zip",
+      "etag": "0x8D9B964E23870F6",
       "checksum": "1cebd2446b10edae723bbf62f5f762b30438cdedc6bb67fcc4a87ae0e293b75e"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.11.1/protoc-3.11.1-win64.zip",
+      "etag": "0x8D9B9650F6E947F",
       "checksum": "18a91ba24a7bad38e929613ccebcb3ce1e010a912329fa55cb9767274a89dd66"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.11.1/protoc-3.11.1-linux-aarch_64.zip",
+      "etag": "0x8D9B964E5400E62",
       "checksum": "13e3fa1ae5003c989f9081ea620ef0675e8847c44e20d354d183b1b837146448"
     }
   },
   "3.11.0": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.11.0/protoc-3.11.0-linux-x86_64.zip",
+      "etag": "0x8D9B964D72FFD34",
       "checksum": "43dbd9200006152559de2fb9370dbbaac4e711a317a61ba9c1107bb84a27a213"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.11.0/protoc-3.11.0-osx-x86_64.zip",
+      "etag": "0x8D9B964FAF9BB06",
       "checksum": "d35dfbb430cd242eb0405557c7e189c68abb1d85b11674bf8b302ed6c6360646"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.11.0/protoc-3.11.0-win64.zip",
+      "etag": "0x8D9B96500E3E725",
       "checksum": "0498478f00946b7e2fb7802670ec8fb8c9683437d62ae4f9bee9bd52fb6bf6c4"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.11.0/protoc-3.11.0-linux-aarch_64.zip",
+      "etag": "0x8D9B964F06DB7EA",
       "checksum": "25ee47f69174e10d0b99c3895640739b4b024bac44968973046e5f559dca3ca1"
     }
   },
@@ -1665,36 +2025,44 @@
   "3.10.1": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.10.1/protoc-3.10.1-linux-x86_64.zip",
+      "etag": "0x8D9B964D0396AAD",
       "checksum": "0c97a75c8f8fafc55323599053626a0a822e5b66299f6643a2b086f859b56afd"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.10.1/protoc-3.10.1-osx-x86_64.zip",
+      "etag": "0x8D9B964E0FBD9F3",
       "checksum": "ee3f4051e55830596729efe48183218bdb44cf2f83b188460859bd63b2a09576"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.10.1/protoc-3.10.1-win64.zip",
+      "etag": "0x8D9B964E542CD19",
       "checksum": "a0a27d5c2fa7d8c43e36076fc10600d371c3b60f5011485f5f3ce2792697b3cd"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.10.1/protoc-3.10.1-linux-aarch_64.zip",
+      "etag": "0x8D9B964D74A3812",
       "checksum": "278384663f7ffb9c94533423c1cffe07e12e5a91c59b1932ccc7787b894e54c1"
     }
   },
   "3.10.0": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.10.0/protoc-3.10.0-linux-x86_64.zip",
+      "etag": "0x8D9B9650089ED91",
       "checksum": "213a591b42acb9e145ef9f3fe5f6037f14a14686065c508fcd547031243cc5d5"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.10.0/protoc-3.10.0-osx-x86_64.zip",
+      "etag": "0x8D9B965030FEAF9",
       "checksum": "345d0b7652e37b7811e31b9659dee2b5418375197ab60d3cdc49213187310525"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.10.0/protoc-3.10.0-win64.zip",
+      "etag": "0x8D9B964D18BF778",
       "checksum": "eca7c20ad11ae31abffee1f593dc5a0b2e3b97e5eff275125413d196a7513090"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.10.0/protoc-3.10.0-linux-aarch_64.zip",
+      "etag": "0x8D9B9650CC7F48F",
       "checksum": "45276570e524c50f6ce82ed71ba87c75f0c8c69ca89adbf86ce0000049df27e5"
     }
   },
@@ -1704,54 +2072,66 @@
   "3.9.2": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.9.2/protoc-3.9.2-linux-x86_64.zip",
+      "etag": "0x8D9B964FB928922",
       "checksum": "0d9034a3b02bd77edf5ef926fb514819a0007f84252c5e6a6391ddfc4189b904"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.9.2/protoc-3.9.2-osx-x86_64.zip",
+      "etag": "0x8D9B964E630DA88",
       "checksum": "f02de67311645bbc5a05d8dfc6f7ea6fe56f0db38546cb5327d1544a798a5612"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.9.2/protoc-3.9.2-win64.zip",
+      "etag": "0x8D9B964DF4EDE6A",
       "checksum": "512534bc619707e626ec5cc4b3cf7cc3400db88bb910c9bd7b4f4f813b411aab"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.9.2/protoc-3.9.2-linux-aarch_64.zip",
+      "etag": "0x8D9B964F4E68928",
       "checksum": "55dba3d64d45fc79e4c93d376b2e578dfec913eaa2b6f071beb2460956a17db6"
     }
   },
   "3.9.1": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.9.1/protoc-3.9.1-linux-x86_64.zip",
+      "etag": "0x8D9B9650F9CA294",
       "checksum": "77410d08e9a3c1ebb68afc13ee0c0fb4272c01c20bfd289adfb51b1c622bab07"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.9.1/protoc-3.9.1-osx-x86_64.zip",
+      "etag": "0x8D9B964F78EFD9D",
       "checksum": "fd2e8a52b9b173bf90633f346901f4dcf3083769ea24f917809932d29ffa1410"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.9.1/protoc-3.9.1-win64.zip",
+      "etag": "0x8D9B964D34DB069",
       "checksum": "71bc2b1dfd69c9baf5a86d88de040a84dca43b78082c5cca11a3ad1f753e8587"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.9.1/protoc-3.9.1-linux-aarch_64.zip",
+      "etag": "0x8D9B964DC049C8B",
       "checksum": "8558f398f1cc960d3a0ce7cded546ea5b5b749853ca688e8b91a2323939ac0a2"
     }
   },
   "3.9.0": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.9.0/protoc-3.9.0-linux-x86_64.zip",
+      "etag": "0x8D9B964FB9BFD95",
       "checksum": "15e395b648a1a6dda8fd66868824a396e9d3e89bc2c8648e3b9ab9801bea5d55"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.9.0/protoc-3.9.0-osx-x86_64.zip",
+      "etag": "0x8D9B9650F985D74",
       "checksum": "99729771ccb2f70621ac20f241f6ab1c70271f2c6bd2ea1ddbd9c2f7ae08d316"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.9.0/protoc-3.9.0-win64.zip",
+      "etag": "0x8D9B964E29B90F8",
       "checksum": "b278675fad5390cacd9704022c6ab94a0eec25bda33e4113411d367dc0720045"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.9.0/protoc-3.9.0-linux-aarch_64.zip",
+      "etag": "0x8D9B964F6EF2BBB",
       "checksum": "7877fee5793c3aafd704e290230de9348d24e8612036f1d784c8863bc790082e"
     }
   },
@@ -1761,18 +2141,22 @@
   "3.8.0": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.8.0/protoc-3.8.0-linux-x86_64.zip",
+      "etag": "0x8D9B964EEFBC0DC",
       "checksum": "717903f32653f07cd895cfe89ca18ff4ca35f825afa7fe17bcb5cb13bf628be0"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.8.0/protoc-3.8.0-osx-x86_64.zip",
+      "etag": "0x8D9B964FC8F135C",
       "checksum": "8093a79ca6f22bd9b178cc457a3cf44945c088f162e237b075584f6851ca316c"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.8.0/protoc-3.8.0-win64.zip",
+      "etag": "0x8D9B964D2D3625A",
       "checksum": "ac07cd66824f93026a796482dc85fa89deaf5be1b0e459de9100cff2992e6905"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.8.0/protoc-3.8.0-linux-aarch_64.zip",
+      "etag": "0x8D9B964E1DA5948",
       "checksum": "fab7465ceee64e189db4676ab8f6f441c320fa848620fe50e2e1026d7483f7c6"
     }
   },
@@ -1782,36 +2166,44 @@
   "3.7.1": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.7.1/protoc-3.7.1-linux-x86_64.zip",
+      "etag": "0x8D9B964F7EEE9CA",
       "checksum": "24ea6924faaf94d4a0c5850fdb278290a326eff9a68f36ee5809654faccd0e10"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.7.1/protoc-3.7.1-osx-x86_64.zip",
+      "etag": "0x8D9B964FEB7472C",
       "checksum": "7aec6c05939dceeadea774d4f5578a5fdf42bc58ab344cb566ffd1ba1daa3341"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.7.1/protoc-3.7.1-win64.zip",
+      "etag": "0x8D9B964DA4EC8BB",
       "checksum": "a47badfff1a5e778694739c4ba7f362c268878b5e84592477e8468977b3f3139"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.7.1/protoc-3.7.1-linux-aarch_64.zip",
+      "etag": "0x8D9B964DBD492ED",
       "checksum": "020d82fd48c95b2da0daed250305390927237768523e22f8dd7fac534d8379b9"
     }
   },
   "3.7.0": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.7.0/protoc-3.7.0-linux-x86_64.zip",
+      "etag": "0x8D9B96505D24C3D",
       "checksum": "a1b8ed22d6dc53c5b8680a6f1760a305b33ef471bece482e92728f00ba2a2969"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.7.0/protoc-3.7.0-osx-x86_64.zip",
+      "etag": "0x8D9B964E13A6057",
       "checksum": "7968d10232994470b6065e9a6fe961c28a0190caf96787f6edc75ca4abaf192b"
     },
     "x86_64_windows": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.7.0/protoc-3.7.0-win64.zip",
+      "etag": "0x8D9B964F3319F92",
       "checksum": "45942faf78ebaa6f28240148fd498291586bce60eb18914902600275ef4fa2d3"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.7.0/protoc-3.7.0-linux-aarch_64.zip",
+      "etag": "0x8D9B964F28684B2",
       "checksum": "e1b5a2bf02bb6512859fc08600a1a212fb6b7bbbc461e155803d4a2bea399fde"
     }
   },
@@ -1821,28 +2213,34 @@
   "3.6.1": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.6.1/protoc-3.6.1-linux-x86_64.zip",
+      "etag": "0x8D9B964F8F1DBBA",
       "checksum": "6003de742ea3fcf703cfec1cd4a3380fd143081a2eb0e559065563496af27807"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.6.1/protoc-3.6.1-osx-x86_64.zip",
+      "etag": "0x8D9B964CEAE2305",
       "checksum": "0decc6ce5beed07f8c20361ddeb5ac7666f09cf34572cca530e16814093f9c0c"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.6.1/protoc-3.6.1-linux-aarch_64.zip",
+      "etag": "0x8D9B964ECBF6BC6",
       "checksum": "af8e5aaaf39ddec62ec8dd2be1b8d9602c6da66564883a16393ade5f71170922"
     }
   },
   "3.6.0": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.6.0/protoc-3.6.0-linux-x86_64.zip",
+      "etag": "0x8D9B964D611BF22",
       "checksum": "84e29b25de6896c6c4b22067fb79472dac13cf54240a7a210ef1cac623f5231d"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.6.0/protoc-3.6.0-osx-x86_64.zip",
+      "etag": "0x8D9B9650FAAAA47",
       "checksum": "768a42032718accd12e056447b0d93d42ffcdc27d1b0f21fc1e30a900da94842"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.6.0/protoc-3.6.0-linux-aarch_64.zip",
+      "etag": "0x8D9B964EBF116A6",
       "checksum": "32d5947de9cf84e62499f7a4c0f2652d2adf3c2a51a6e330b62e22fc6288b751"
     }
   },
@@ -1852,28 +2250,34 @@
   "3.5.1": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip",
+      "etag": "0x8D9B964E75CF943",
       "checksum": "cd40f10bcdaff36429ec4652210f2bb8d6c7349e7b78f3a38ef42168401d7285"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.5.1/protoc-3.5.1-osx-x86_64.zip",
+      "etag": "0x8D9B964D6EB362A",
       "checksum": "fb356461d27e39c50a81b62cf28c2a9c0b6f05155cff254674ddf288f275bc7d"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-aarch_64.zip",
+      "etag": "0x8D9B964D785B1AB",
       "checksum": "ccf6896a00f1737d63e59826bc2c0a348b44a1cd4281e1593fd29ddca9fb0485"
     }
   },
   "3.5.0": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.5.0/protoc-3.5.0-linux-x86_64.zip",
+      "etag": "0x8D9B964D7F37E7A",
       "checksum": "49aa98db1877dcb69e89c7d217bb70cb1678d2266c3172f817348f2b5aab1d6a"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.5.0/protoc-3.5.0-osx-x86_64.zip",
+      "etag": "0x8D9B964DCAAFD28",
       "checksum": "ed2c1674d5ede031bed01f45e9c0a1c044470b99846b7fef444c864efc1d4f5d"
     },
     "aarch64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.5.0/protoc-3.5.0-linux-aarch_64.zip",
+      "etag": "0x8D9B965080A8343",
       "checksum": "99e7834fb35e03f99bcd9fbadfe808ceaac75351d4f79bec4fbf0b8105521ddc"
     }
   },
@@ -1883,10 +2287,12 @@
   "3.4.0": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.4.0/protoc-3.4.0-linux-x86_64.zip",
+      "etag": "0x8D9B96507C7DEC8",
       "checksum": "e4b51de1b75813e62d6ecdde582efa798586e09b5beaebfb866ae7c9eaadace4"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.4.0/protoc-3.4.0-osx-x86_64.zip",
+      "etag": "0x8D9B964D4A8A06F",
       "checksum": "8df109526ad6588f204fdeb7bc4843eb5f3246390c2f21b563473d43cb70e890"
     }
   },
@@ -1896,10 +2302,12 @@
   "3.3.0": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.3.0/protoc-3.3.0-linux-x86_64.zip",
+      "etag": "0x8D9B964E5030E5E",
       "checksum": "feb112bbc11ea4e2f7ef89a359b5e1c04428ba6cfa5ee628c410eccbfe0b64c3"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.3.0/protoc-3.3.0-osx-x86_64.zip",
+      "etag": "0x8D9B964F77CB0D0",
       "checksum": "d752ba0ea67239e327a48b2f23da0e673928a9ff06ee530319fc62200c0aff89"
     }
   },
@@ -1909,10 +2317,12 @@
   "3.2.0": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.2.0/protoc-3.2.0-linux-x86_64.zip",
+      "etag": "0x8D9B964E94F30EE",
       "checksum": "9cf9a8661d649b8477fe0ad32a8b28d351a170a62e210bf848d90a29f1f4df9d"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.2.0/protoc-3.2.0-osx-x86_64.zip",
+      "etag": "0x8D9B964D82D98B7",
       "checksum": "69fbd04599c53af7826f9a6cf2a34f15aec6e0800c24cd572f4f5ba9e156a2cb"
     }
   },
@@ -1922,10 +2332,12 @@
   "3.1.0": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.1.0/protoc-3.1.0-linux-x86_64.zip",
+      "etag": "0x8D9B964FAA9F91E",
       "checksum": "7c98f9e8a3d77e49a072861b7a9b18ffb22c98e37d2a80650264661bfaad5b3a"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.1.0/protoc-3.1.0-osx-x86_64.zip",
+      "etag": "0x8D9B964F37EF0D7",
       "checksum": "2cea7b1acb86671362f7aa554a21b907d18de70b15ad1f68e72ad2b50502920e"
     }
   },
@@ -1935,20 +2347,24 @@
   "3.0.2": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.0.2/protoc-3.0.2-linux-x86_64.zip",
+      "etag": "0x8D9B964CF8C2D43",
       "checksum": "e194ef8f1f3baf518bf3cba2e1c2657e5dea84a76a780f8ebb3b65ed29b271af"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.0.2/protoc-3.0.2-osx-x86_64.zip",
+      "etag": "0x8D9B964FE28B0C4",
       "checksum": "06f7401ffe5211340692b0a16dc53f3d8f9dc8ef3c1f74378110ee222e36436d"
     }
   },
   "3.0.0": {
     "x86_64_linux_gnu": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.0.0/protoc-3.0.0-linux-x86_64.zip",
+      "etag": "0x8D9B964D5BE2D3C",
       "checksum": "56e3f685ffe3c9516c5ed1da0aefd3f41010a051e8b36f1b538ac23298fccb30"
     },
     "x86_64_macos": {
       "url": "https://github.com/protocolbuffers/protobuf/releases/download/v3.0.0/protoc-3.0.0-osx-x86_64.zip",
+      "etag": "0x8D9B964FA0C97D5",
       "checksum": "7ea1a482e84319bedb28d72ab3e85779b4ecff95995875fc935a26419dbdeb4b"
     }
   }

--- a/manifests/rclone.json
+++ b/manifests/rclone.json
@@ -38,21 +38,27 @@
   },
   "1.67.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC8C924B53D8F4",
       "checksum": "07c23d21a94d70113d949253478e13261c54d14d72023bb14d96a8da5f3e7722"
     },
     "x86_64_macos": {
+      "etag": "0x8DC8C92FD0B9A8F",
       "checksum": "1a1a3b080393b721ba5f38597305be2dbac3b654b43dfac3ebe4630b4e6406c3"
     },
     "x86_64_windows": {
+      "etag": "0x8DC8C932E695D13",
       "checksum": "117b99441024607d6043e274c7fcbed64d07ad87347d17dd0a717bdc1c59716b"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC8C925FC96FFF",
       "checksum": "2b44981a1a7d1f432c53c0f2f0b6bcdd410f6491c47dc55428fdac0b85c763f1"
     },
     "aarch64_macos": {
+      "etag": "0x8DC8C930490BB8B",
       "checksum": "4dc6142aea78bb86f1236fe38e570b715990503c09733418c0cd2300e45651e4"
     },
     "aarch64_windows": {
+      "etag": "0x8DC8C933535742D",
       "checksum": "54f263712d02bf2345eb5a3444aa4f07b990f5b4c6d02f1de892d1ff8028b50c"
     }
   },
@@ -61,21 +67,27 @@
   },
   "1.66.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC40FA9FDB6F84",
       "checksum": "b4d304b1dc76001b1d3bb820ae8d1ae60a072afbd3296be904a3ee00b3d4fab9"
     },
     "x86_64_macos": {
+      "etag": "0x8DC40FB3AC878E4",
       "checksum": "5adb4c5fe0675627461000a63156001301ec7cade966c55c8c4ebcfaeb62c5ae"
     },
     "x86_64_windows": {
+      "etag": "0x8DC40FB7F362248",
       "checksum": "8e8bb13fb0d7beb316487ecde8ead5426784cdcdbf8b4d8dd381c6fe8c7d92a0"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC40FAA9EB15B7",
       "checksum": "c50a3ab93082f21788f9244393b19f2426edeeb896eec2e3e05ffb2e8727e075"
     },
     "aarch64_macos": {
+      "etag": "0x8DC40FB425E4E30",
       "checksum": "b5f4c4d06ff3d426aee99870ad437276c9ddaad55442f2df6a58b918115fe4cf"
     },
     "aarch64_windows": {
+      "etag": "0x8DC40FB805CB4A9",
       "checksum": "4e815350382249ffb6d9520262bbce81f45f63126134a0c365eb648a4d27e6ea"
     }
   }

--- a/manifests/sccache.json
+++ b/manifests/sccache.json
@@ -31,35 +31,45 @@
   },
   "0.8.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC7C430EE67474",
       "checksum": "e0ee621fb16b6940666cd770b091c62cadafd3e062dd12e3a49d9caaff3b795f"
     },
     "x86_64_macos": {
+      "etag": "0x8DC7C430DC5F5EB",
       "checksum": "4306fb21606b14e2ce1266b25c40e55c090ea68c2cb54e1c39bfb9b81ea3e342"
     },
     "x86_64_windows": {
+      "etag": "0x8DC7C430E55D3F2",
       "checksum": "44249088926f52d1fee76cd1dcd1c061e2152a7feedb7ba43d4a4f50be805608"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC7C430BF4C8BC",
       "checksum": "452cef732b24415493a7c6bca6e13536eb9464593fa87c753b6b7cb4733e9c50"
     },
     "aarch64_macos": {
+      "etag": "0x8DC7C430B6C0E8D",
       "checksum": "b4029ae790e29333ebcf52faa5bc0559945011d5fdbc7cc15812bc45fc6ea5d4"
     }
   },
   "0.8.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC620286B074A2",
       "checksum": "2e0e7df61bc7dcf61fd65c1b345d05cd1f832598a15c6f42e7e21f86b8d39b1f"
     },
     "x86_64_macos": {
+      "etag": "0x8DC6202857C842F",
       "checksum": "d1b871daf7f96f8d01c50746e588d50e2c54559c0de508257db3cb55b7fb8ec0"
     },
     "x86_64_windows": {
+      "etag": "0x8DC6202860CD6CE",
       "checksum": "a58bee25f1042477e6a2f9e0e1aae505172d0e85dddedc75b667cccdb3563ed8"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC620283AF7179",
       "checksum": "23d6920bf5a21a2269833ca5ef387e59c8dce69c03770b7aa44be4b130b07511"
     },
     "aarch64_macos": {
+      "etag": "0x8DC62028305E6EB",
       "checksum": "9439be7bd81ee86af6e8d866fd129150aefe24c78d857de9c99d57845187fc7e"
     }
   },
@@ -68,137 +78,177 @@
   },
   "0.7.7": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC27CBD162337D",
       "checksum": "ed0010b4dcaccce42b9dc8699257134a113d0ca16dfb7db890356135218322c9"
     },
     "x86_64_macos": {
+      "etag": "0x8DC27CBDF5E34A6",
       "checksum": "901b301e8108a3fae0425d478a9487fa145ec2fee4b4d311928d1d16b99a2c00"
     },
     "x86_64_windows": {
+      "etag": "0x8DC27CBD084B380",
       "checksum": "2f399cdde8ff54ca2388c3e22f97ae64b2c53a9e9ca95f35ce9fe88e9770b5f4"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC27CBCCE450B4",
       "checksum": "e7ecabac9a703e53a8b06e84b0058fcf242239d164050537bc399387160320fb"
     },
     "aarch64_macos": {
+      "etag": "0x8DC27CBCC0D5909",
       "checksum": "148c1bc64f95e91150e5d0f3ff9df461ecb47e326ff601ebe0bf1c90226acba4"
     }
   },
   "0.7.6": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC1B49D0DB686F",
       "checksum": "2902a5e44c3342132f07b62e70cca75d9b23252922faf3b924f449808cc1ae58"
     },
     "x86_64_macos": {
+      "etag": "0x8DC1B49CF166183",
       "checksum": "52dcd67b24c0ac9281b15563ec056ab1377f474024746488ce2147eafa7511d3"
     },
     "x86_64_windows": {
+      "etag": "0x8DC1B49CFC25AFB",
       "checksum": "582ba2a1a589de1fe995c2415b740ad445d2d7e94f87e7cb6850c6b7bc9a9820"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC1B49CDDFDAEC",
       "checksum": "be501f5dc946432b429108f40385de9cb58900be27963b98491b370ab585b565"
     },
     "aarch64_macos": {
+      "etag": "0x8DC1B49CC0BC9B9",
       "checksum": "dcbece714e08eb7e41bbd0951b0fc92d66bd5efc600a8b378f56b939e519863b"
     }
   },
   "0.7.5": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC12081B6854A2",
       "checksum": "ee224740012cccb85629eca11443baeaccf7114960faa9f48c1ca0034e00bfc3"
     },
     "x86_64_macos": {
+      "etag": "0x8DC1208199FD026",
       "checksum": "b51897aa0691a65b9c6d60f3cacf6b931addc5f71ee5fcdd29b1ce9e8685d3ca"
     },
     "x86_64_windows": {
+      "etag": "0x8DC12081A648C6B",
       "checksum": "f44bd3397a5444f16cdc45ea345f0964a8455c655c1fd2a7263926adda1f82c3"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC120816FEA88B",
       "checksum": "d129d9897d58ac385ac0695cbdbd7a28e2943c265d81fa25d701c0cce2b40d53"
     },
     "aarch64_macos": {
+      "etag": "0x8DC12081605A9A6",
       "checksum": "2a4ec79299d86a4dae3cb6eef7bd631ef24364e1f616fde181b6341113ca13a3"
     }
   },
   "0.7.4": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBEF3042283406",
       "checksum": "42612b161343e8b74d1feac6418c1286e036854983e7a16d567cfde3c74a8baf"
     },
     "x86_64_macos": {
+      "etag": "0x8DBEF30405B2069",
       "checksum": "5ef04e4a2dfec6467e611ac5e3dd94342342fb7fe6ca15c933e4fa48f78cac64"
     },
     "x86_64_windows": {
+      "etag": "0x8DBEF30417A6829",
       "checksum": "ca71810def1a522e8c676bc50ee270554772b72e8a5917f34a76de636431f3a0"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBEF303F8D467F",
       "checksum": "f491b6080da49547622d2a3ea388232293a1a0bb99acb53557dad7c34608b8d9"
     },
     "aarch64_macos": {
+      "etag": "0x8DBEF303EAD587D",
       "checksum": "c98acf172a7be239f8831523477c256c50aeab2cbcc1828dc5e4daafe5c8dbc4"
     }
   },
   "0.7.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBE9A3C5FBC962",
       "checksum": "2cc1ffc1c49eedf60eb0176a37de4af27ea33b6f46a3dfff17261626b745e094"
     },
     "x86_64_macos": {
+      "etag": "0x8DBE9A3C418AEC0",
       "checksum": "0aa633920d7ede4430c16d241449b0211c4228970bbe3d8d8ce6baf9276cdbbc"
     },
     "x86_64_windows": {
+      "etag": "0x8DBE9A3C507F4B6",
       "checksum": "0260b32893c5878df46a120d54050b56ce0d6228df17609ada95f81dd5835f33"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBE9A3C2EEC4C4",
       "checksum": "e1c739332532c1dd7a5af07bb183d8b36263da12fb12fcf06021ffd9e578ad3c"
     },
     "aarch64_macos": {
+      "etag": "0x8DBE9A3C3F28CFF",
       "checksum": "1eacdb65854a7b9c904a5f97fb2fdd6cef270aed171c2c6e97a59de68c872bb6"
     }
   },
   "0.7.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBE5C10A072700",
       "checksum": "5132f9ba985eba31baa9f8f6e8e67533e8d84c9b7039d090f8cddfda4427560a"
     },
     "x86_64_macos": {
+      "etag": "0x8DBE5C108640146",
       "checksum": "00c867ee62f2455244f3fa4c774babb56ce21b640cb98788d2046b1452e5b891"
     },
     "x86_64_windows": {
+      "etag": "0x8DBE5C109240825",
       "checksum": "deb00ee1545c569a71b90f7569f6d7b4771e2afbbe268bc4e0fe9ea89b4868bd"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBE5C107986EA7",
       "checksum": "5261cba78cdb013a9c5c14fdca2770c0b598b66d5a679aa47cc3dca5417f92db"
     },
     "aarch64_macos": {
+      "etag": "0x8DBE5C106D6E2DE",
       "checksum": "644f06cfdfa494f52f654bfc6f0d9f326beb8e38b9d151826660689b9f8d0f34"
     }
   },
   "0.7.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBDF97B390FEF5",
       "checksum": "610d2ffc994d2250b6e2105ed2be029f2906abead0425e0c947ba33b5903f129"
     },
     "x86_64_macos": {
+      "etag": "0x8DBDF97B358EFF5",
       "checksum": "9bc02331312d4c41e0c94814567c467eac7f55f4b120a2cdcd6190d28f578d33"
     },
     "x86_64_windows": {
+      "etag": "0x8DBDF97B2978AEB",
       "checksum": "1a65da887acf5a4cd67718e76453ecf3da1346ce6a0fb1859d7c79d551b8b059"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBDF97B0D3BB2F",
       "checksum": "8522f94b3c4b3e2835d9d3c3d4e824a62af5019ed33e84ad214f18c81056ccff"
     },
     "aarch64_macos": {
+      "etag": "0x8DBDF97B0120867",
       "checksum": "f375bcbf6eae1e70994b63cb1004c35fbdbc0a4ede97f4c4fa25834f963cb801"
     }
   },
   "0.7.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBDD76D4E76AAA",
       "checksum": "963391335d325c470a8f05df8575d4014bb3a7e76eef3dc5a91518db83989701"
     },
     "x86_64_macos": {
+      "etag": "0x8DBDD76D36148DE",
       "checksum": "08e3e303fd4ee3a65c7483b2f1f65032a5091936d8b86df153530ea50bc2374f"
     },
     "x86_64_windows": {
+      "etag": "0x8DBDD76D40B966F",
       "checksum": "484817b7c8beb64da2a3343290a48c8b50391e6946dde3bf544750bb2a8da1f9"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBDD76D2A3B018",
       "checksum": "65c0a50177d8c271623d2d4b7568ec99932570a7eca5e62ce535d5076996cfd2"
     },
     "aarch64_macos": {
+      "etag": "0x8DBDD76D1E46B80",
       "checksum": "55d310b384539639079a2b09ecdc55a7790124c836b1a2baeae786bba17c62e0"
     }
   },
@@ -207,15 +257,19 @@
   },
   "0.6.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBD7006899FACE",
       "checksum": "a0c7d5d072d7ce1cf3320cffdb7b7129fd86226d00f299f572898bb3940c10f5"
     },
     "x86_64_macos": {
+      "etag": "0x8DBD70066A90C79",
       "checksum": "974c053dfc76f4c210909b241ee34d3d34c4eb17fa34026015bac8a4d0a6b527"
     },
     "x86_64_windows": {
+      "etag": "0x8DBD700679AC0F7",
       "checksum": "0dc7bea1923b05736d027765a3816ca5c9e53d199d048e908b9a059dc5a0fd84"
     },
     "aarch64_macos": {
+      "etag": "0x8DBD70065B14446",
       "checksum": "f2dec6357f9d6efb0e3f925c90bc1f83b26442f3020bf377ea82c023c0d1a65a"
     }
   },
@@ -224,83 +278,107 @@
   },
   "0.5.4": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB76F32C8D0FB3",
       "checksum": "4bf3ce366aa02599019093584a5cbad4df783f8d6e3610548c2044daa595d40b"
     },
     "x86_64_macos": {
+      "etag": "0x8DB76F32B792C48",
       "checksum": "b404cf83dd20c2d7cc9f08ccea1fc593442d87f4112983ba44d9bcefebf15016"
     },
     "x86_64_windows": {
+      "etag": "0x8DB76F32BB7C3AE",
       "checksum": "0bdb1a4ebc2ffde765479b5689569b8e56f30452acbdcca0f0ef5d8c859ac93a"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB76F329F83495",
       "checksum": "85f0cfe9b3150e461801cf7453763080fc3604e255587e2a4886e55bb93e6b09"
     },
     "aarch64_macos": {
+      "etag": "0x8DB76F3291342C0",
       "checksum": "f2d9ccc40197e08b29f2a4d0fc16744235f62fb61e5c7cc539dabb609d4dbeb0"
     }
   },
   "0.5.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB64EAFCAB852E",
       "checksum": "56a61d8452a9274c92b33b3055ba371fa3e8ec9cfcac510581dbe8e27d099ae3"
     },
     "x86_64_macos": {
+      "etag": "0x8DB64EAFB11A3EF",
       "checksum": "31e7b81731220f892357c0de88bd85d9059d24a803ca754ec6d043a6d4c54540"
     },
     "x86_64_windows": {
+      "etag": "0x8DB64EAFBEDECBE",
       "checksum": "07e3aa012a9221d2831c04c7bd49a7a88ff90e45f7b19c1efcdef3693c6f2c6e"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB64EAFA49B6B4",
       "checksum": "a0545180d776aff944853d3cca211a9d4467fc711625fb1c6ed5d86b01447517"
     },
     "aarch64_macos": {
+      "etag": "0x8DB64EAF982D9B9",
       "checksum": "95b3bd1439397c861d4f09d4ab9c26249148392f359783f6e5a637010c825dfb"
     }
   },
   "0.5.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB6413909A89E3",
       "checksum": "75268b6f3e379d97140b24da4fda8c1b3b4778c7ca67a6b8b804999321ec8c48"
     },
     "x86_64_macos": {
+      "etag": "0x8DB64138EA816AC",
       "checksum": "4e6bed45d250aeb24e935928830730070e3a439243a42af893cdc3520463cad3"
     },
     "x86_64_windows": {
+      "etag": "0x8DB6413909BE7E9",
       "checksum": "205aab1d8a9eca61bc5d313551a0112705c5ae6502a25503ea51461cb043553e"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB64138D45F69F",
       "checksum": "1935833d29433cfe50e42091e3c9422a3f216c3358dd0c957b34df9f536fa28f"
     },
     "aarch64_macos": {
+      "etag": "0x8DB64138C59E14B",
       "checksum": "4b9a9075983cb619608de82015a4de2f0e511ef976e61254e8af5a72eff04f76"
     }
   },
   "0.5.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB6287F005FC4C",
       "checksum": "07699bdc132d6a346d985deab6c77a94f958c085a92779d1f533ec4c9ee6b7bf"
     },
     "x86_64_macos": {
+      "etag": "0x8DB6287EE58CEFC",
       "checksum": "57a091522b5498a943ef18d73701d0a3e5ce5e4f7566a5631c464a35faa9c362"
     },
     "x86_64_windows": {
+      "etag": "0x8DB6287EF124DD5",
       "checksum": "f78ca3787ab673261f5dcd2837136ad01575ad53e99008d236f5bffcec265381"
     },
     "aarch64_macos": {
+      "etag": "0x8DB6287ED70D335",
       "checksum": "dd9fcc0c735dfe6425802f73e061adb5d6a2484479f4395fcd81ac13c7d33157"
     }
   },
   "0.5.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB5B60CC09F6BB",
       "checksum": "9bc9318b94a4ac718b916eea0102aa520d73d098d86779767c1cb7562b705b0c"
     },
     "x86_64_macos": {
+      "etag": "0x8DB5B60CA599969",
       "checksum": "f5c69d0a39ebd8d44a70a92a513adfeff79915ad32b1568a170329f57d5aa218"
     },
     "x86_64_windows": {
+      "etag": "0x8DB5B60CE4B905B",
       "checksum": "72d035c20d207ee820c9196bb3e9161a764e91f7872aafd160cff50d230c9070"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB5B60C9740C44",
       "checksum": "6c9f466a70d37edb91924e8e2d437efc3b9dda3b452c0354e6d45f001a0d3c97"
     },
     "aarch64_macos": {
+      "etag": "0x8DB5B60CA742F6B",
       "checksum": "50498390b51b744119c62ead9828e43630861fa6e64fd9167bfaa4da52ddfcc5"
     }
   },
@@ -309,52 +387,67 @@
   },
   "0.4.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB44B07805B021",
       "checksum": "4cf08e75c2b311424eed2768dada6056569be4ac1d4cbed980e471bf1452d12c"
     },
     "x86_64_macos": {
+      "etag": "0x8DB44B0765C028C",
       "checksum": "5a2ce4b29b83f1315b63337c5aad2d9e7a0b4aec7b495895bc6a9a45212c7169"
     },
     "x86_64_windows": {
+      "etag": "0x8DB44B07738BFAC",
       "checksum": "d00dc1649df3527247dc9c0b5bb37f75754aaf809f24e478d9970f600b6cf301"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB44B0759A9DD9",
       "checksum": "91fd97473388f27a86d5442909ddeccb9963b05d25361f287cf05692bcdcec9f"
     },
     "aarch64_macos": {
+      "etag": "0x8DB44B074DE3C8F",
       "checksum": "48ac03656e821738537b19eebaf53d5b5164dc38b13e38ba8af4c74d9a0ba30d"
     }
   },
   "0.4.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB2EAE54667DEC",
       "checksum": "f077d92ca86d71bc55aebeeb6e8dc557fef481446ccc82504aeedf1fe6e1f657"
     },
     "x86_64_macos": {
+      "etag": "0x8DB2EAE54B5F1FF",
       "checksum": "a291f1d90c6b25726866f018ec6071fa4d20ca443ad91fe5dfb9740eb4ebc45a"
     },
     "x86_64_windows": {
+      "etag": "0x8DB2EAE5347C9CE",
       "checksum": "7508cfa20b045a891eba2f7298afb8faec886d40d10b844830160b096fe99874"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB2EAE50CC290E",
       "checksum": "263a43ba0cb211e5c1c10fe437c636d601bed7a47be0ca07beeba7973ba61461"
     },
     "aarch64_macos": {
+      "etag": "0x8DB2EAE4F7444CA",
       "checksum": "593c6c78796db712c29fe766caef4b8bd2e3d4a68ed5b2b8eca39e03ce2432df"
     }
   },
   "0.4.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB29F4648C0D31",
       "checksum": "8f5cf1079d3bb731671c96742eaeed2b45dbdd9add5f2d8b6fc9fe2fd4cf6a3c"
     },
     "x86_64_macos": {
+      "etag": "0x8DB29F461892A95",
       "checksum": "9f44dc58266cd455e69ec84a668627ca893e72a55cf0e4b0503c80ae727d9909"
     },
     "x86_64_windows": {
+      "etag": "0x8DB29F463400F5C",
       "checksum": "a8776e49862d1ea8eb9313f2efa943f4679670a777530f55e415977b9cae54d0"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB29F4607CEB6B",
       "checksum": "887397bafb2eabb3bf9d831da30a3db9faf8c92b0865af7a4619a24ee2d4b436"
     },
     "aarch64_macos": {
+      "etag": "0x8DB29F45F4BEBAD",
       "checksum": "51efe163fc30c6abc269f6bda9ef6e1af4262a5687579f756e96cb1cc1f6ed40"
     }
   },
@@ -363,49 +456,63 @@
   },
   "0.3.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAD9449389925B",
       "checksum": "427bd2151a1b01cd9b094d842e22c445b30f3c645f171a9a62ea55270f06bf23"
     },
     "x86_64_macos": {
+      "etag": "0x8DAD94491C086C4",
       "checksum": "e68aa0e2716e9cceff7912e09d8028df34cd63d8d60cae832a2d5f5c94da1828"
     },
     "x86_64_windows": {
+      "etag": "0x8DAD94493CF6AC8",
       "checksum": "b37b55b6e45737562450a98cd4e5c91e58540febdbbda5c575acf80314a2b3ea"
     },
     "aarch64_macos": {
+      "etag": "0x8DAD944905EE07F",
       "checksum": "751453b31048f8ba1e7d646be8d76d64ad0a16ecb17d17edb523b01eda25b7a8"
     }
   },
   "0.3.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAC5B10A0C0253",
       "checksum": "94ea33aac8dcb358753f8240cc87345963cf83cda7c6af0395dff31ffdc88df4"
     },
     "x86_64_macos": {
+      "etag": "0x8DAC5B108C3ACA9",
       "checksum": "d8ade8d98cef392e6b256d184690e1d722f263c9f0bd83938fdd524e839c9e58"
     },
     "x86_64_windows": {
+      "etag": "0x8DAC5B1094573EB",
       "checksum": "b8fc47e12dbc18a2a611dd5f037d0980f873c80a1adb26fa2f48cca0b0184adb"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DAC5B1082909DA",
       "checksum": "1bf58385dc27b66324bb9ee82084e65c4d2e60baa19e3d16d2ab4da6c1ae66b2"
     },
     "aarch64_macos": {
+      "etag": "0x8DAC5B107FFDCFD",
       "checksum": "303d8e905c44eb5401adc55561a4c44b36906516f3c1c0de386c4844d38151bc"
     }
   },
   "0.3.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA2EB4E80B0D79",
       "checksum": "e6cd8485f93d683a49c83796b9986f090901765aa4feb40d191b03ea770311d8"
     },
     "x86_64_macos": {
+      "etag": "0x8DA2EB4E66933A5",
       "checksum": "61c16fd36e32cdc923b66e4f95cb367494702f60f6d90659af1af84c3efb11eb"
     },
     "x86_64_windows": {
+      "etag": "0x8DA2EB4E73F76F5",
       "checksum": "f25e927584d79d0d5ad489e04ef01b058dad47ef2c1633a13d4c69dfb83ba2be"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DA2EB4E5C8EC92",
       "checksum": "9ae4e1056b3d51546fa42a4cbf8e95aa84a4b2b4c838f9114e01b7fef5c0abd0"
     },
     "aarch64_macos": {
+      "etag": "0x8DA2EB4E5056B29",
       "checksum": "65d0a04fac51eaeeadd72d3f7eee3fdc27409aaf23b97945ea537e92bd0b0f0d"
     }
   },
@@ -414,18 +521,23 @@
   },
   "0.2.15": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA0669E94430",
       "checksum": "e5d03a9aa3b9fac7e490391bbe22d4f42c840d31ef9eaf127a03101930cbb7ca"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA066AFFE291",
       "checksum": "908e939ea3513b52af03878753a58e7c09898991905b1ae3c137bb8f10fa1be2"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA0668011C5B",
       "checksum": "3dfecdbb85561c55e899d3ad039c671f806d283c49da0721c2ef5c1310d87965"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8D9BA06656ACCAE",
       "checksum": "90d91d21a767e3f558196dbd52395f6475c08de5c4951a4c8049575fa6894489"
     },
     "aarch64_macos": {
+      "etag": "0x8D9BA066A59A8C2",
       "checksum": "4120626b3a13b8e615e995b926db4166dc2b34274908b8f159ca65be4928b32a"
     }
   }

--- a/manifests/shellcheck.json
+++ b/manifests/shellcheck.json
@@ -27,15 +27,19 @@
   },
   "0.10.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC3F18BC4BC3A1",
       "checksum": "6c881ab0698e4e6ea235245f22832860544f17ba386442fe7e9d629f8cbedf87"
     },
     "x86_64_macos": {
+      "etag": "0x8DC3F18BC3E8C0D",
       "checksum": "ef27684f23279d112d8ad84e0823642e43f838993bbb8c0963db9b58a90464c2"
     },
     "x86_64_windows": {
+      "etag": "0x8DC3F18BC786DB7",
       "checksum": "eb6cd53a54ea97a56540e9d296ce7e2fa68715aa507ff23574646c1e12b2e143"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC3F18BC550818",
       "checksum": "324a7e89de8fa2aed0d0c28f3dab59cf84c6d74264022c00c22af665ed1a09bb"
     }
   },
@@ -44,15 +48,19 @@
   },
   "0.9.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DADCD52858B9A2",
       "checksum": "700324c6dd0ebea0117591c6cc9d7350d9c7c5c287acbad7630fa17b1d4d9e2f"
     },
     "x86_64_macos": {
+      "etag": "0x8DADCD528700EA3",
       "checksum": "7d3730694707605d6e60cec4efcb79a0632d61babc035aa16cda1b897536acf5"
     },
     "x86_64_windows": {
+      "etag": "0x8DADCD52851B5D1",
       "checksum": "ae58191b1ea4ffd9e5b15da9134146e636440302ce3e2f46863e8d71c8be1bbb"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DADCD52876EB66",
       "checksum": "179c579ef3481317d130adebede74a34dbbc2df961a70916dd4039ebf0735fae"
     }
   },
@@ -61,15 +69,19 @@
   },
   "0.8.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA0FACBC6651",
       "checksum": "ab6ee1b178f014d1b86d1e24da20d1139656c8b0ed34d2867fbb834dad02bf0a"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA0FABB5CBFF",
       "checksum": "e065d4afb2620cc8c1d420a9b3e6243c84ff1a693c1ff0e38f279c8f31e86634"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA0FB0570457",
       "checksum": "2a616cbb5b15aec8238f22c0d62dede1b6d155798adc45ff4d0206395a8a5833"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8D9BA0FBEA371BA",
       "checksum": "9f47bbff5624babfa712eb9d64ece14c6c46327122d0c54983f627ae3a30a4ac"
     }
   },
@@ -78,43 +90,55 @@
   },
   "0.7.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA0FBBA9B687",
       "checksum": "70423609f27b504d6c0c47e340f33652aea975e45f312324f2dbf91c95a3b188"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA0FB438D9F3",
       "checksum": "969bd7ef668e8167cfbba569fb9f4a0b2fc1c4021f87032b6a0b0e525fb77369"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA0FC38F3C80",
       "checksum": "1b80bbb525e6d64961afff09fb4a9199a62d5e22347a9c92c151a791131467bd"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8D9BA0FB2926E04",
       "checksum": "a12bdfe0f95811ad6c0a091006b919b2834b0619b460cfa596f557edd62e45ab"
     }
   },
   "0.7.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA0FA71B4969",
       "checksum": "64f17152d96d7ec261ad3086ed42d18232fcb65148b44571b564d688269d36c8"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA0FA65F6889",
       "checksum": "b080c3b659f7286e27004aa33759664d91e15ef2498ac709a452445d47e3ac23"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA0FC036CDAD",
       "checksum": "1763f8f4a639d39e341798c7787d360ed79c3d68a1cdbad0549c9c0767a75e98"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8D9BA0FC55FBF5C",
       "checksum": "b50cc31509b354ab5bbfc160bc0967567ed98cd9308fd43f38551b36cccc4446"
     }
   },
   "0.7.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA0FA906A33C",
       "checksum": "39c501aaca6aae3f3c7fc125b3c3af779ddbe4e67e4ebdc44c2ae5cba76c847f"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA0FB77D4E8E",
       "checksum": "c4edf1f04e53a35c39a7ef83598f2c50d36772e4cc942fb08a1114f9d48e5380"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA0FB6D937D9",
       "checksum": "02cfa14220c8154bb7c97909e80e74d3a7fe2cbb7d80ac32adcac7988a95e387"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8D9BA0FB8DA3955",
       "checksum": "012100d9778cfa7ea73bf42ab55b3e02cda7f75d65aab32c6445012398c89b54"
     }
   },
@@ -123,9 +147,11 @@
   },
   "0.6.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA0FB24AC16A",
       "checksum": "95c7d6e8320d285a9f026b5241f48f1c02d225a1b08908660e8b84e58e9c7dce"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA0FB14FBE10",
       "checksum": "25837b10b8387d3a7377f087ca3a27c6caa3765a41d993f25b816d65821c9a26"
     }
   },
@@ -134,9 +160,11 @@
   },
   "0.5.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA0FA6A40861",
       "checksum": "7d4c073a0342cf39bdb99c32b4749f1c022cf2cffdfb080c12c106aa9d341708"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA0FA9080293",
       "checksum": "cbfca919a03f058bc9b31b1d932450f63dbdb92dcfec1a30140e022f7db49bc0"
     }
   },
@@ -145,17 +173,21 @@
   },
   "0.4.7": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA0FBCDCD875",
       "checksum": "deeea92a4d3a9c5b16ba15210d9c1ab84a2e12e29bf856427700afd896bbdc93"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA0FC088D903",
       "checksum": "bbc260e15b42efdce628222d5649c0fa4cb3adaf2f71c958580b8928fe039e06"
     }
   },
   "0.4.6": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BA0FA8C02EE8",
       "checksum": "fe0a6e94d9cf24b5a46553265846480425067f95f2630317f8fd99bc60a13719"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA0FC25CB6BF",
       "checksum": "b15c547ac2dcae0e385869d4a2b3c899a9e47b639e8c8fa9ed0bdcdea22c1b09"
     }
   }

--- a/manifests/shfmt.json
+++ b/manifests/shfmt.json
@@ -29,18 +29,23 @@
   },
   "3.8.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC2AFF46EA9900",
       "checksum": "27b3c6f9d9592fc5b4856c341d1ff2c88856709b9e76469313642a1d7b558fe0"
     },
     "x86_64_macos": {
+      "etag": "0x8DC2AFF4736B5A1",
       "checksum": "c0218b47a0301bb006f49fad85d2c08de23df303472834faf5639d04121320f8"
     },
     "x86_64_windows": {
+      "etag": "0x8DC2AFF4662058C",
       "checksum": "91230a6d2d4dbb52e9c0bb134acba526f7880bfd3dfd1ffdde66e9f393d7a646"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC2AFF45C6E95F",
       "checksum": "27e1f69b0d57c584bcbf5c882b4c4f78ffcf945d0efef45c1fbfc6692213c7c3"
     },
     "aarch64_macos": {
+      "etag": "0x8DC2AFF46A57958",
       "checksum": "1481240d2a90d4f0b530688d76d4f9117d17a756b6027cfa42b96f0707317f83"
     }
   },
@@ -49,18 +54,23 @@
   },
   "3.7.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB6FF08114131D",
       "checksum": "0264c424278b18e22453fe523ec01a19805ce3b8ebf18eaf3aadc1edc23f42e3"
     },
     "x86_64_macos": {
+      "etag": "0x8DB6FF07E52B625",
       "checksum": "ae1d1ab961c113fb3dc2ff1150f33c3548983550d91da889b3171a5bcfaab14f"
     },
     "x86_64_windows": {
+      "etag": "0x8DB6FF07A38A47F",
       "checksum": "2807b4af91fbbd961b68716de06c044f1b4f897457fc89fba216e5e2e351c64f"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB6FF07C4C8369",
       "checksum": "111612560d15bd53d8e8f8f85731176ce12f3b418ec473d39a40ed6bbec772de"
     },
     "aarch64_macos": {
+      "etag": "0x8DB6FF07D54DA88",
       "checksum": "ad7ff6f666adba3d801eb17365a15539f07296718d39fb62cc2fde6b527178aa"
     }
   },
@@ -69,18 +79,23 @@
   },
   "3.6.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DADC2423314A5E",
       "checksum": "5741a02a641de7e56b8da170e71a97e58050d66a3cf485fb268d6a5a8bb74afb"
     },
     "x86_64_macos": {
+      "etag": "0x8DADC242107688F",
       "checksum": "b8c9c025b498e2816b62f0b717f6032e9ab49e725a45b8205f52f66318f17185"
     },
     "x86_64_windows": {
+      "etag": "0x8DADC2422320129",
       "checksum": "18122d910ba434be366588f37c302c309cde4ca5403f93285254a3cf96839d01"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DADC24241C9955",
       "checksum": "fb1cf0af3dbe9aac7d98e38e3c7426765208ecfe23cb2da51037bb234776fd70"
     },
     "aarch64_macos": {
+      "etag": "0x8DADC241FF53664",
       "checksum": "633f242246ee0a866c5f5df25cbf61b6af0d5e143555aca32950059cf13d91e0"
     }
   },
@@ -89,35 +104,45 @@
   },
   "3.5.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA485B37A4E592",
       "checksum": "56099a689b68534f98e1f8f05d3df6750ab53e3db68f514ee45595bf5b79d158"
     },
     "x86_64_macos": {
+      "etag": "0x8DA485B34D31BFA",
       "checksum": "09bece33040785cae8c7ecac65ba76e6747c8e3547c8eb55426eb6177361b902"
     },
     "x86_64_windows": {
+      "etag": "0x8DA485B3B583BAF",
       "checksum": "f759493bc55a4ea181442eb7d79b527ff6c15d62ec567b8b86a5df6a086c9c46"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DA485B3962A83F",
       "checksum": "09d7902de04d52ebe0b332d84a9746d195f7e930806bdc2436f84d0de6a2d368"
     },
     "aarch64_macos": {
+      "etag": "0x8DA485B35AEB5FD",
       "checksum": "7acde1d2c35219b7f8bf8c15c9ee87d91af76b0ea15f65404b7e458991921d78"
     }
   },
   "3.5.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA334CAFED5C2D",
       "checksum": "8feea043364a725dfb69665432aee9e85b84c7f801a70668650e8b15452f6574"
     },
     "x86_64_macos": {
+      "etag": "0x8DA334CAE0CD3D1",
       "checksum": "a211d5d4a6acff19807a9625ca8e05a50827a91d242fef669f253b359b41fc28"
     },
     "x86_64_windows": {
+      "etag": "0x8DA334CA2055CB6",
       "checksum": "da079a17319d83d7935ca799a13da98e9c637d9d46f174b07dd948e0d7d5eb3a"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DA334CA9C4F369",
       "checksum": "2dec40f18622873dd3bf84fda17f43a0ae93b5305ead909dc0e91f6479d359c6"
     },
     "aarch64_macos": {
+      "etag": "0x8DA334CA5E03343",
       "checksum": "273d556ff3f3488db769011bea0f06ef1fcafb5c75d56a99804b55f0ca7f8c58"
     }
   },
@@ -126,69 +151,89 @@
   },
   "3.4.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9F3E7E6D92692",
       "checksum": "713ef49db9a60a00636814a507da851b58da6b4b98a3627188fba0a61b60f9a8"
     },
     "x86_64_macos": {
+      "etag": "0x8D9F3E7EB30BA24",
       "checksum": "22af685075e0448861c5db111e70cc399bdc95cdd7def943bc5adb6783f3e530"
     },
     "x86_64_windows": {
+      "etag": "0x8D9F3E7E4E9110F",
       "checksum": "a6c317a68dddf8efa9fd87d985a807cf7ab2423871d390aac4d3775691565835"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8D9F3E7ED205A93",
       "checksum": "b4f5d7b53012a1a7fdac5df8f13d829d82bc7ace53da4a09c532ac562589b106"
     },
     "aarch64_macos": {
+      "etag": "0x8D9F3E7E10B086A",
       "checksum": "4006b3910bdea1e3eb3b02021f5ab1ca23bd09776d042e11321df95023faae79"
     }
   },
   "3.4.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9C6F65FC36C1F",
       "checksum": "9cc743f058ab8896ca6fa94a7f2e570b95294e8a142600f09fe832e406a88f18"
     },
     "x86_64_macos": {
+      "etag": "0x8D9C6F65D971A9F",
       "checksum": "36ff40deeb856ab5df58b08b542fd972c3a2201660e09dcadd76f3b81f336364"
     },
     "x86_64_windows": {
+      "etag": "0x8D9C6F65A52A4DE",
       "checksum": "0d20cc45c8e149eefbebcbeb5cbb5e2a64ebfd17615b2b89bc63baaf57f6417f"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8D9C6F65EB35CF9",
       "checksum": "93852ee7d64389802a65c9e58840eebcae43c771d7dcd73d2e25b8b0b87e7966"
     },
     "aarch64_macos": {
+      "etag": "0x8D9C6F65C7C37A2",
       "checksum": "2c9dd3383d2c60b9a852a4a43b5ff990162bd2dc06113c6c169cd4cf474d2075"
     }
   },
   "3.4.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9FFAD74E736",
       "checksum": "0c321e80a97cee3ffbff0579ad9f79805f622b306b507d674da00e3caedb8714"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9FFA9132361",
       "checksum": "388ed2c576a0169287efc2eefabed6ca5733bd269ac7804b8f1fcc8b4b88d615"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9FFA0124DEB",
       "checksum": "0d0cb61d85192725eb6140457ea29a3ba07d07ef339f638c9f095045aad44136"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8D9B9FF9C6FEC2F",
       "checksum": "dc8e0524ab9fc11bca3a363fef62dd8ffd3c2b3f04d780e46b349b7917a8f187"
     },
     "aarch64_macos": {
+      "etag": "0x8D9B9FFABC1AD88",
       "checksum": "4c97f4447acf05795bd5f25977c55e56247bcb7e6ad2068ba631c00d05bd1eec"
     }
   },
   "3.4.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9FFA61C0295",
       "checksum": "5cd7a2b57a0592f919ca2e4249bd567ae3426801a28ae94d0b26f8f2c4ce17f9"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9FFAB124E88",
       "checksum": "5f79d7e026892c483300c4a3d02129fccb06134660d32d715734b9167c104cfa"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9FFAFC385CB",
       "checksum": "c735bb0099cc215c2f859179dcabc8be63672ab4a577c2f610142379bdd7396d"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8D9B9FFAA054D80",
       "checksum": "c7a0fcd70f69ad136bee7352b42e0b52060c46bc547baf6e06926fcb0509c37e"
     },
     "aarch64_macos": {
+      "etag": "0x8D9B9FFB1FE513D",
       "checksum": "d7610e752061d3d6fa7aa68289a1be761ab930784023556a7fbf65576522b34b"
     }
   },
@@ -197,35 +242,45 @@
   },
   "3.3.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9FFAAD59CF6",
       "checksum": "0f73bf27219571bca7c5ef7d740d6ae72227e3995ffd88c7cb2b5712751538e2"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9FFAF7D11B1",
       "checksum": "ade755f37fd470e176536593a72394bbf543c80e0256eb937c3c09d1f4b2a55d"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9FFAF8C0387",
       "checksum": "aa116e5437a7e03c137bea0331177a91f98735094ef0ca2ffcfd6be2a3d61765"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8D9B9FFB095D0BB",
       "checksum": "65d09815bb0d5c5b3c49f4e815c4785bdbaf339f4bcd607cabfd9cd2868b5849"
     },
     "aarch64_macos": {
+      "etag": "0x8D9B9FF9D950564",
       "checksum": "a00c023c65e57e5c8b941c73187d7df3ac1d58207025c4a998564fbd9a5e68d8"
     }
   },
   "3.3.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9FFA4E49CAA",
       "checksum": "9ad8751cea92e0ffbfd6bb72208434f3a86e7319fd10b56def204c24ee1d9fde"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9FFA9FAEED7",
       "checksum": "a9eb2deafb693c8220f5bcdbf1e9a548bfc4e20ceb02bb64bccb35e19fdbcd37"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9FFA7364802",
       "checksum": "f964e42e17dfc1d93d27835f6b445d203ce7f9a1df4b062bd7ab84b8fc8bcb3c"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8D9B9FFAE6849AA",
       "checksum": "abf9bbc7027f5f5ba691bc48a55a2fc531c05ea88245ede989d67199687cadb5"
     },
     "aarch64_macos": {
+      "etag": "0x8D9B9FFA76E8D74",
       "checksum": "ced3a49fdc4e3177c22a56b0e706461e4638a7f43c77f3df21388fdf672a10ec"
     }
   },
@@ -234,60 +289,77 @@
   },
   "3.2.4": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9FFA6D01BC7",
       "checksum": "3f5a47f8fec27fae3e06d611559a2063f5d27e4b9501171dde9959b8c60a3538"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9FF9DA41E46",
       "checksum": "43a0461a1b54070ddc04fbbf1b78f7861ee39a65a61f5466d15a39c4aba4f917"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9FFA67C1538",
       "checksum": "95f8bdd19c7a94672b2cf1f93d12ffe7fd2873d4ee13fa857ac7a41d21fe4152"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8D9B9FFA8C758F3",
       "checksum": "6474d9cc08a1c9fe2ef4be7a004951998e3067d46cf55a011ddd5ff7bfab3de6"
     },
     "aarch64_macos": {
+      "etag": "0x8D9B9FFB18B7CC5",
       "checksum": "e70fc42e69debe3e400347d4f918630cdf4bf2537277d672bbc43490387508ec"
     }
   },
   "3.2.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9FFA3079A41",
       "checksum": "3a32a69286a19491a81fcd854154f0d886c379ff28d99e32d5594490b8bbef4b"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9FFA394A973",
       "checksum": "03f2eb5cd18d56b3242a3e0213f67c471cdba17eb30318967df9f76e9d667fa0"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9FFA46435B9",
       "checksum": "a0a2bdb9db57fcbf1905fbe709d86dbbfb6106f760ae6d6fe70b27d8834d9b4e"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8D9B9FFAEF7064C",
       "checksum": "5ff7c4250558678a091e428b2f57b8ab9c7a90e369383ebc9332aada4af02f59"
     }
   },
   "3.2.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9FFA53FCE13",
       "checksum": "43439b996942b53dfafa9b6ff084f394555d049c98fb7ec37978f7668b43e1be"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9FF9FE07020",
       "checksum": "4a79184afbbce72f3d24a75e2b1e7909185ff9e83369c5acffd127fd1a9eed7c"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9FFAFD2C5AE",
       "checksum": "f782bfe01cbd43d5e520869edb2d368ce9fd6cebb29b40c93db5ce3fa78e509b"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8D9B9FFA1CF9830",
       "checksum": "1cb7fc0ace531b907977827a0fe31f6e2595afcafe554e6d7f9d6f4470e37336"
     }
   },
   "3.2.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9FFB1EE4E21",
       "checksum": "84cf01d220bfb606d52af983e1afdbf6e25aff4a8aff6d5cf053dad29a1740f1"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9FFADA78834",
       "checksum": "1162c076557a3428cbe1b6f9f06b3f2d6bc3e0d9a12618715a4224db199d9bd7"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9FFA8AD6C42",
       "checksum": "d850200fde7861512a9c7d289e093d7cba54f7d95535b02a7ff352a1904e060f"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8D9B9FFA4256196",
       "checksum": "58a1254620b11e0499b9a4b315894aa75186d1dc951d706679d7f5262c3a64df"
     }
   },
@@ -296,34 +368,43 @@
   },
   "3.1.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9FFA7161ACD",
       "checksum": "c5794c1ac081f0028d60317454fe388068ab5af7740a83e393515170a7157dce"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9FF9F311121",
       "checksum": "284674897e4f708a8b2e4b549af60ac01da648b9581dc7510c586ce41096edaa"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9FFA2C08A06",
       "checksum": "5cafe309be761c092cea69221c9b25c68d13a9f89d12ad20601c9d5cc4b84457"
     }
   },
   "3.1.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9FFA0DFDEAE",
       "checksum": "3e519c372749174a09383fdd81030630e3755d654adf93839faf334c025289e8"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9FFA227E3D8",
       "checksum": "9c388336e9b8307eae460ef87e53613b5113237bc8c8953e2dd3b449a447b6c0"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9FF9CA3C57B",
       "checksum": "5f7d9eb9506274d54a5418ace06cda64442b8f8c29fda14fce1df7c593fcb19f"
     }
   },
   "3.1.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9FF9D57909E",
       "checksum": "cb91ea08a075a2f96b5230f09b4e211b7c108b1c97603caceb48d117d2ac5508"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9FFA698E79D",
       "checksum": "af297315fe2fe51a870448423ed1753aa49b7d6ec2d77e4232797d5b2f607916"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9FFA5BE1276",
       "checksum": "1ed3513f1a9c55bcbe088aa710b53740cb3f6769dcd2e2dddd10275bc859fb6e"
     }
   },
@@ -332,34 +413,43 @@
   },
   "3.0.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9FFA36367DA",
       "checksum": "95331ee5c29567720a882a64bdafd500411374b7835c0d30e48e0b41642d6255"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9FFABB0721E",
       "checksum": "494780beed75b77360118706c4ac662c12af748c5610413c1735cdf7f6a4d826"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9FF9D728E93",
       "checksum": "d40e893a0fe2bd6f43b62a33883296f8e7d207a09e3c080b7f0fc47e1c64d9da"
     }
   },
   "3.0.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9FF9C901970",
       "checksum": "86892020280d923976ecaaad1e7db372d37dce3cfaad44a7de986f7eb728eae7"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9FFADA9AAC1",
       "checksum": "e470d216818a107078fbaf34807079c4857cb98610d67c96bf4dece43a56b66c"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9FFA340C9ED",
       "checksum": "bd5c851044c724592ac68b63f121ccd8ed7700998ac7d2ad4014ebb4808d650d"
     }
   },
   "3.0.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9FFAC5DFCA4",
       "checksum": "b7c9088741242dde26082be3a006693bd252b3fd1966b8b23aaee4d54ed2a470"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9FFA71DE1C5",
       "checksum": "bd61cf50841ebb3155b8821a3b5ba1b0d00764948b8b286845502e008319a550"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9FFA314DEAC",
       "checksum": "47d95ab4bdb70416c52c356da125505c9acb872e133cb1d9563822edf3f5753b"
     }
   },
@@ -371,56 +461,71 @@
   },
   "2.6.4": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9FF9CB1A60A",
       "checksum": "2fbf21300150a14cf908c2e3cfd85a54ba8fcc1eba4349a9aad67aaa07d73e86"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9FFADA9F8D6",
       "checksum": "7dc5e45e9ebed836099322bedbd06639497f9711da259f4c8f0ffe9cadbfa5ae"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9FF9FC376B2",
       "checksum": "cc670f693f13c3ef4009d89a946d130ba6e0f8d19f910f9e7b51347521e84fa0"
     }
   },
   "2.6.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9FFA995ACDC",
       "checksum": "adb6022679f230270c87fd447de0eca08e694189a18bcc9490cd3971917fbcb4"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9FFA0A77235",
       "checksum": "5e1659999df29f06ec90e533670aff336957b43ce434c31d5bbc3e268a85dfae"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9FFA8B72EC3",
       "checksum": "bf7a7fef53117732a3d7b2647c342aa0aea85f13aba3dbbfa5fc417178eb950a"
     }
   },
   "2.6.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9FFAE4B0228",
       "checksum": "bdf8e832a903a80806b93a9ad80d8f95a70966fbec3258a565ed5edc2ae5bcdc"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9FF9E028385",
       "checksum": "aaaa7d639acb30853e2f5008f56526c8dd54a366219ebdc5fa7f13a15277dd0b"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9FFA3230D4C",
       "checksum": "ef32236eeb217edd141a03c8f2e0b6fb5c46f73acc374fbf1e24c47576f311d5"
     }
   },
   "2.6.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9FFA46D3506",
       "checksum": "edb1ddbfacd43ff7448deac4ce0b4a5adb2b5700c506621ee8c15171115b4d52"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9FFAF832B46",
       "checksum": "94aaabdeefed3e26806a393dd64ac5c84753dae45fa8ad8ac733ce28f50dafdc"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9FFA9AD4FEE",
       "checksum": "f9eae9e9f461e6edf8c81271b1a97c38a85d900238037c7cdd1319074dc2da18"
     }
   },
   "2.6.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9FFA0270B3F",
       "checksum": "e582c3417f1b773598c219683a98cc1ce444ca04aef1fa8457c378ad00316b29"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9FFAAFCF50C",
       "checksum": "e3a2777f339dc49488c3634510814ff3227ff1c4f8543c72d54c94966f14eff4"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9FFAFC3D3DA",
       "checksum": "b82fcd9f724a7785a0ab76486cdb22e3ea13bb8e0f7aa17a3619c456aff37820"
     }
   },
@@ -429,23 +534,29 @@
   },
   "2.5.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9FFAC8D90E1",
       "checksum": "37fd1f66d7bf9c48130bbc50a3747750c6e3b202c404ca4a5941f81b9efd9b97"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9FFA3A178BF",
       "checksum": "8b68cf463a92beb2139bcfdf4b21766f22406fc1ed8a88c006b79a0421964a5a"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9FFAF9AF55C",
       "checksum": "c8b409c8337eb6c6e8e9d63bf12347610d2b3823e0cd39bbfd9de98b3edbe936"
     }
   },
   "2.5.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9FFAA95DE99",
       "checksum": "fce24cfa408362e6802f1cec9b2b9f92fb865eb8ae1233ee2874b5d0c66b2f91"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9FFAC833235",
       "checksum": "9f416db4c63c3b294725ea2413b3eb99c7eb016fe6963869cefdeb333d8b3184"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9FFAD82EED1",
       "checksum": "10ea27378ded31aa99fe5ddaa869af2d1b2b7817b280274d4ef8deeed1826ba3"
     }
   },
@@ -454,12 +565,15 @@
   },
   "2.4.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9FFA6D412CB",
       "checksum": "abc78150f5d3afa10afe0dd8fef2c431729e14fdc77fde2bab6a3d869f551599"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9FFAD2BB46F",
       "checksum": "27cb4deba3bc04dab6171954a83520cf4889bd9e8dbf8b6c6f03bf39f9b02196"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9FFA22329A6",
       "checksum": "8da409729fd49a0163f3c42ecb0d1a12755e2fa97b6ee5b1aeb231bec9fe8850"
     }
   },
@@ -468,12 +582,15 @@
   },
   "2.3.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9FFAFD70AC7",
       "checksum": "eef540565962cf1f5432c7e3cf212c333e096f9f481d6d441197c1cf878746d0"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9FF9E210352",
       "checksum": "8aaabb6bc85ec4d000884e12b0266fef3b82d02b152299d87c96b743a5eb288d"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9FF9FD8D02F",
       "checksum": "3e2bbb05189c1686d7a7e281277034c9a2e35af2d065d6b916a5ab5b7cf0629b"
     }
   },
@@ -482,23 +599,29 @@
   },
   "2.2.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9FFAF88CFB4",
       "checksum": "2797065829b9e10b8a24cb7d85c4df95f55ba7c478f185a372fbd032bb2b268c"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9FFA30E28F0",
       "checksum": "8789f8ce1cf7d3ea072a77378d32fd5bb135eeae8882763dcb0b3a654dc90ae1"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9FFB12FAF39",
       "checksum": "a7e492705eb5d8d991d9f51fa22a98a236e10a0e1bb6d56528c9a0d2226c1c12"
     }
   },
   "2.2.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9FF9EE76939",
       "checksum": "8c07956ad54a914c587eac1a17d45b25e7b54a60d1539aa9a468091d4370e7e1"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9FF9FF728F5",
       "checksum": "abd34b4933c1c1e364297cac6c384ab6b593882bbcd1f34e5fdd61d4b4eaa2f3"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9FFAA9F7A1B",
       "checksum": "4ee5e736c32a0372c327d30dc569ac580710b6cdc010f7571a30f37228bc9630"
     }
   },
@@ -507,12 +630,15 @@
   },
   "2.1.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9FFAFCAD7A6",
       "checksum": "178e083c353a3c31a5b7cd1e07718ce6cb253e991300acf1ef2266033d681c43"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9FFB005B4C1",
       "checksum": "85d9cc85fe3b6392a365b423bcbb3800552b4240a3fc0aa5d6f348b36089c39a"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9FFADA3B839",
       "checksum": "e7eb265950c0f00d2be3826e57c8803790d1f695bce3dd858322fde0152145a7"
     }
   },
@@ -521,12 +647,15 @@
   },
   "2.0.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9FFB17FE5CE",
       "checksum": "f21ec3c37b9ece776a737629650adcb79f7b529026b967432a8a2c2b40dcabe0"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9FFA1123196",
       "checksum": "73373e146c9df4081a133cc18b12d14c23c3464f4116e66e1cc17798ea7c11b3"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9FFA5056617",
       "checksum": "c9a67bcb29b1649aeb656e85a55a3f95ae4847f814ff521717424b6bf005c5fa"
     }
   },
@@ -538,23 +667,29 @@
   },
   "1.3.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9FFA40E5AAC",
       "checksum": "4cdb7b24f5de623ad5d691f826ada61b4390a1c0c7dc1ef8414a5e9c1755f7c7"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9FFAB295570",
       "checksum": "fff31d437fc6153de3915df85a69a27c79b79965a94f59f06c1c2de08d7cc86e"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9FF9D804811",
       "checksum": "511d67f602f4c40340e30c6e02f7528341a38cbd1a029c051bd5543316b2fcb0"
     }
   },
   "1.3.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9FFA1A97866",
       "checksum": "b1925c2c405458811f0c227266402cf1868b4de529f114722c2e3a5af4ac7bb2"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9FFAC9FDD90",
       "checksum": "9fffa1726854e51323699baae3d2e292f067a57e19c1079852ff68e712105a29"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9FFA390D978",
       "checksum": "08049e80e9282d5c7d58656ac0a419dcba810a0bfe39479cab3ebef528eb39b6"
     }
   },
@@ -563,12 +698,15 @@
   },
   "1.2.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9FFB101C870",
       "checksum": "0f3b896945b02ed5706ae773408291884d87b457c9b09ddb6fe922e47714988a"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9FFAE015A47",
       "checksum": "59f9b62f256639eb4e8c2c011c6bc70d57b294fcb360b1a66ffb75a46ccd4671"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9FFAF70B785",
       "checksum": "9f05f75ddbc3421c5672a49a227f1595a32a8dc21e7da5ffa993c7d1a05d1cc7"
     }
   },
@@ -577,12 +715,15 @@
   },
   "1.1.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9FFA41DC1A1",
       "checksum": "84ba3e130bf32449f0e30aa77485e8acd41469f0fae6663a0ec81ab1e098d1b7"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9FFAEC21BBB",
       "checksum": "d3254df70c431d044126c028b328ce1d3b2c79f6ac26869bbe2247867e094ac7"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9FFADAF763E",
       "checksum": "d9d206d12a04b56821d523fb49eb8030b27a02a43ee6950fc9734aadd84f0e7d"
     }
   },
@@ -591,12 +732,15 @@
   },
   "1.0.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B9FFAFCF43C8",
       "checksum": "172d2cf2d7d71191b7b0cd0d7169d703475825cdd270a6982899a349dcd98588"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B9FFABF1B6DB",
       "checksum": "a80c196aa92b5e50a6b8c7c2ef7120fb04420c122025db95fb32021d4450aa74"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B9FFA0B997DC",
       "checksum": "ee3361b6acf5c72ca82a917aeceacd06fdcd46c527ad9747408159afd9227a29"
     }
   }

--- a/manifests/syft.json
+++ b/manifests/syft.json
@@ -34,18 +34,23 @@
   },
   "1.7.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC8CABD543B8B6",
       "checksum": "2d36ba261e94f93bbb9538a975a63a494cc9b4440dcd2ee43e68b4a70a506916"
     },
     "x86_64_macos": {
+      "etag": "0x8DC8CABD5E3FF74",
       "checksum": "e7a9ed735c2436f4a00bec80ec431788e008021e2af1ddce7747b3ae9a10b012"
     },
     "x86_64_windows": {
+      "etag": "0x8DC8CABD5F026CB",
       "checksum": "3c7908b5838a2a24ea4fa26425ee2690e1ada5e9763f7493a99d8efb1d9a08a8"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC8CABD54C3AA4",
       "checksum": "cf43f1702ee063071be929f5561b093f58aa08d4dc5e19016e5d25e1453d81fe"
     },
     "aarch64_macos": {
+      "etag": "0x8DC8CABFAE833B6",
       "checksum": "a076de1eb324b96a00e6b8546cbb77eb2ca34f0a38a008e4c10708778df4741c"
     }
   },
@@ -54,18 +59,23 @@
   },
   "1.6.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC8964A8DD28E8",
       "checksum": "35c8f0912aeb31b36a0621d98e48d0b2761cc896d18d541ed3982721cf2e8f9c"
     },
     "x86_64_macos": {
+      "etag": "0x8DC8964A9E9730A",
       "checksum": "93062feafa5c7684b1360e03cf6e3ec64f6b720f329743a00e917cf0a29bacb8"
     },
     "x86_64_windows": {
+      "etag": "0x8DC8964A9E8D765",
       "checksum": "6e100901226bf818455f9f138288037b2560e692df3119dd2af74e3959f1d286"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC8964A8D08CEF",
       "checksum": "82fa0d244f84d805589cfbdbe420fbf75ff92574eb85fcfef7de3b0c7f4ef4f8"
     },
     "aarch64_macos": {
+      "etag": "0x8DC8964A9D73807",
       "checksum": "d7d2aa97b08a66281a6137ed0bdef7d08c3613efbc413eee5f8e2fade699cbcc"
     }
   },
@@ -74,18 +84,23 @@
   },
   "1.5.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC7F298E8583C0",
       "checksum": "3d10023d46dfaf0fe75288df207b478b43597f7d2fff553f58430817166bd478"
     },
     "x86_64_macos": {
+      "etag": "0x8DC7F298FB250B1",
       "checksum": "605322e3e7043a4f2f3d6e37f75a71389d38f6f290bff2e54bb2aaebbbf4829b"
     },
     "x86_64_windows": {
+      "etag": "0x8DC7F298FBF3A6A",
       "checksum": "5079c6a88e130f8677d0701cb2689f9eae2088022ecf5fa2b9f341b96d9983d2"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC7F298E708CBD",
       "checksum": "ee2b1289a1e4b0de9409c3a78867949ca42788a5f50072b8a6e6e04e6a269f9c"
     },
     "aarch64_macos": {
+      "etag": "0x8DC7F298FA34667",
       "checksum": "fe02d072e7ec9a8eb4ac866ba973396a8beae79829ee870acaadd4d862e5e65a"
     }
   },
@@ -94,35 +109,45 @@
   },
   "1.4.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC70618AD38680",
       "checksum": "5e4c6a0d1ca28d25e060a29c7cca0aedc50d951bfb270b45bc9a71e86ac6fbe2"
     },
     "x86_64_macos": {
+      "etag": "0x8DC70618B750411",
       "checksum": "c25872b4ddd6f0d06d8454cce6351469b51ee5c04939b5d4ea86c6048c9021e9"
     },
     "x86_64_windows": {
+      "etag": "0x8DC70618B823BA4",
       "checksum": "ac97125b56b21987d35bcb6b5d300a686bc241272b0b91a12a3c6c743a0567a9"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC70618AC58C7A",
       "checksum": "a28d63bb2bca96092a1a42cd5afdd0787633ae05998935a5e6e2aac8f2e2ec44"
     },
     "aarch64_macos": {
+      "etag": "0x8DC70618B74DD2B",
       "checksum": "9e23ce6ab8e36c9fc102f21a47d0ae5cd39362f21ff58f33b09a58f456f36c03"
     }
   },
   "1.4.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC7054BF00F74D",
       "checksum": "b6c940a0ebc79840d1dd4049d481e0d7b7ea8b70a70ff9b4d10408ea226da9e9"
     },
     "x86_64_macos": {
+      "etag": "0x8DC7054BFAB44A1",
       "checksum": "235ec3197f15fb4f3cb509ef519b7281de7a1f4a5e43f9ade691791b31a6c44d"
     },
     "x86_64_windows": {
+      "etag": "0x8DC7054BFAA822C",
       "checksum": "49742d3ba007a1c477f6c1b15ba19aed7592697d321eee2ef37902001b3dd5e6"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC7054BF066F65",
       "checksum": "7cb482f7d7fc3fe8bc4d25673f17d5e4b81ac43a73e746f1862085276f523931"
     },
     "aarch64_macos": {
+      "etag": "0x8DC7054BFA2E997",
       "checksum": "ecf2aa6c922fba65c9ecd9b5774770468e9bf083a4759fdc87e3a68733f1b677"
     }
   },
@@ -131,18 +156,23 @@
   },
   "1.3.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC6602B19F0A10",
       "checksum": "9124b3e75b7d0beebcf9dbfd12d9e13e92a1951c7a9fb74100db08f379e49ea4"
     },
     "x86_64_macos": {
+      "etag": "0x8DC6602B25D3E6D",
       "checksum": "9ca5945824ee610a6d2cbc034e518c48a956e175001f6747c5867afdc38d38f4"
     },
     "x86_64_windows": {
+      "etag": "0x8DC6602B26E692E",
       "checksum": "90c526c99f794a33d57a2d7ba379206a4382ddb877e061daacf7569ff19bc892"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC6602B19C9C09",
       "checksum": "2bdd6ddd32b4947cea7a4f1e90e769a27e8e0dd2ad6ef3b29e48b57fc43090c6"
     },
     "aarch64_macos": {
+      "etag": "0x8DC6602B26DA6B2",
       "checksum": "4e68515226429697e6475c9af6c10269edd597e603e8f86e942420da814b47bd"
     }
   },
@@ -151,18 +181,23 @@
   },
   "1.2.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC5B1FD7395256",
       "checksum": "f56d63f6be18b12b6aff1222f5c9bcfe739b7d167165ed784151bb38e6c49bb2"
     },
     "x86_64_macos": {
+      "etag": "0x8DC5B1FD806DEAC",
       "checksum": "8be9524c6b91304bbdddd183ff884b1cbdd805ba0d228b587ad3566ea0e66171"
     },
     "x86_64_windows": {
+      "etag": "0x8DC5B1FD812B832",
       "checksum": "aec5b0219d948be0c9489c30eda9f463d10d7bcc3edca7b5c3b0f6d76dbc0704"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC5B2006743448",
       "checksum": "5699156ca5e568dad326605e2cb8a24774cd87ab858ac8fc438b8028e13c9d89"
     },
     "aarch64_macos": {
+      "etag": "0x8DC5B1FD7D24E2C",
       "checksum": "efaf83c8af800cea03f78eed117dfc8c16bebc64e6bcb165e0287cdae195fd76"
     }
   },
@@ -171,35 +206,45 @@
   },
   "1.1.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC54B7F66F5517",
       "checksum": "e41c3b7b20cf134b52067edf826364d6040bd401a18ee17e5c4862e57ca7968e"
     },
     "x86_64_macos": {
+      "etag": "0x8DC54B7F088099C",
       "checksum": "1f899350c06c061086c72759d2d3255d936485882302cda47b613e4a72b9ec19"
     },
     "x86_64_windows": {
+      "etag": "0x8DC54B7F09B0704",
       "checksum": "ffb4847eb0787888497813db7d9c3dcc71ab190ff49672b0235ec12a6837c197"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC54B7EFE995DD",
       "checksum": "33067023147abab03b43dc6ce46af156bb4b917738c46a290694f4372d48b986"
     },
     "aarch64_macos": {
+      "etag": "0x8DC54B7F0854D84",
       "checksum": "c5b65ad9e2fb1d895f7f21996e2b8b51f28c1371bcb8f7e92a0973cea0573e72"
     }
   },
   "1.1.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC4D154E7BE965",
       "checksum": "ff13f54ffbddc2e1426f79e03ba622eefd37f9309050c846d2505c09042e079b"
     },
     "x86_64_macos": {
+      "etag": "0x8DC4D154F52B999",
       "checksum": "de1182094a6267c231ed4d126a7adcd02ec0b590785bd1f8feb143b2f0d4f489"
     },
     "x86_64_windows": {
+      "etag": "0x8DC4D154F3933E2",
       "checksum": "871f068d62fae178d65922ad5902101523d39701ee626646aedf9e4dc61fcc33"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC4D154E6F2688",
       "checksum": "4e3c5c0bd9c51cbe8e57f8eca77a1ac56e4c2ff3118746365bd1838cb49c39b1"
     },
     "aarch64_macos": {
+      "etag": "0x8DC4D154EF65BC0",
       "checksum": "f51ccc4f172e9ec70a924e892969562f8ad556cdb6b39925a5ee846bdc26c80d"
     }
   },
@@ -208,35 +253,45 @@
   },
   "1.0.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC3E17D4E1F4A6",
       "checksum": "420f90e57def27745e414efcb7a41384b2ccdccafca87c327096ca44621ab0ce"
     },
     "x86_64_macos": {
+      "etag": "0x8DC3E17D56F8B43",
       "checksum": "3730868e23a65c0c2b94bd1d3c7ce608176aa98b631bf98249f04bec1a035b12"
     },
     "x86_64_windows": {
+      "etag": "0x8DC3E17D573578F",
       "checksum": "95bc151e3a713a31f7ae7bfacbe0bda8c8d8e08e390038b0c2fc7220c1b9c49c"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC3E17D4970F3D",
       "checksum": "c8582aa0e1c92c84c4a751c739ac3d7ca48c88a54b5d1b884d0629d7df72a6f9"
     },
     "aarch64_macos": {
+      "etag": "0x8DC3E17D5B96066",
       "checksum": "5dc061290afb7e8249dc590fcf4a7e15966346e73948415559855e1154fc0f42"
     }
   },
   "1.0.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC3936F404F834",
       "checksum": "27dfeaca134cd8aeff6135ba349ff922109bd89b955755459601667d69fed88e"
     },
     "x86_64_macos": {
+      "etag": "0x8DC3936F4EDDCF9",
       "checksum": "3c191441fa355d9fad0be169c29b0b54f541a732b9094f29cda07d367b4d8147"
     },
     "x86_64_windows": {
+      "etag": "0x8DC3936F4E7C951",
       "checksum": "39780b81a860ec38e23389f7e7290cb4c1988f6df11e60183db69d221210881f"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC3936F388D9BC",
       "checksum": "1353dd45f207610c68048f6296f78e6164f0d7608b3bb09d27c7d385a0537f68"
     },
     "aarch64_macos": {
+      "etag": "0x8DC3936F4C3058E",
       "checksum": "95c5ec22913b72a10e90760b85901c4a6a166defda52ba181d7c0281eb7a80ed"
     }
   },
@@ -245,35 +300,45 @@
   },
   "0.105.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC36EC5B955F06",
       "checksum": "6a1b8a734a0939799239ba067895a7bc5ad57ac73c91bb197bed4d1d1705fbb1"
     },
     "x86_64_macos": {
+      "etag": "0x8DC36EC5A8B0EBA",
       "checksum": "c0d9a60a78545774fa0a52b67c825fa632ff7538c992b5a2a1f2ee8753aee765"
     },
     "x86_64_windows": {
+      "etag": "0x8DC36EC5AA556E7",
       "checksum": "d106f8bb994e86b53739076995322832278eb3ad61288c1793fe6b3b6c677f12"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC36EC59CB085F",
       "checksum": "eaf059dc2d816b1e994ab9ba98fcea2dcf0f261767c75757103ef1f51ec44889"
     },
     "aarch64_macos": {
+      "etag": "0x8DC36EC5D739C83",
       "checksum": "445020fb7a6cd2f93c2f6a4c03273495e026e68b59b2018dd44c42e378e12794"
     }
   },
   "0.105.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC2DA34275FD56",
       "checksum": "6f9b5d7047c33d40609fe00b181f2510049f1ca32f1cbaa4cd34b8a567e41f03"
     },
     "x86_64_macos": {
+      "etag": "0x8DC2DA3433AB9C4",
       "checksum": "2ac536bdca551055e24a2c381afc95a2a8b391aeceed0062f24a3d0a1e6c8fd3"
     },
     "x86_64_windows": {
+      "etag": "0x8DC2DA34348DABA",
       "checksum": "b661e8ad08a6d9fa69a356a38111d42e345bb93065998bb9016838e40c469f24"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC2DA342EAD0E1",
       "checksum": "c8bb8ad81d6f3e1c5e9d75111ae08158506d1fd1fa4b253a22f7280aef3bec01"
     },
     "aarch64_macos": {
+      "etag": "0x8DC2DA3438F7F38",
       "checksum": "bfb0ea27bff3f89135f9159765ee896a5cb4d562c2d2b0af5451e8ba7999d97a"
     }
   },
@@ -282,18 +347,23 @@
   },
   "0.104.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC281F8D423C6F",
       "checksum": "b988b2eacbabfaf95a2e47d149bbda94da1c9b7cfe990c262f4ccd6f26268d6a"
     },
     "x86_64_macos": {
+      "etag": "0x8DC281F8DFB6D0F",
       "checksum": "22d4c845d418fada99bc59e9941c1a7abebbcf95fd4c34f0cfa3b032c9472273"
     },
     "x86_64_windows": {
+      "etag": "0x8DC281F8DF9736F",
       "checksum": "b356067854b097ee366f390445615ba50c99ec612e59bcf1ec4596f4aed79d71"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC281F8D2D6C50",
       "checksum": "788fde49184c0a26003b23abb8ad95b6708110ffd833b8e0e59d66baca0566ab"
     },
     "aarch64_macos": {
+      "etag": "0x8DC281F8E03EEF5",
       "checksum": "a148c0de98f664af06c2dfdc0a3169f55f9432dc2c829fccaa268763dccc3081"
     }
   },
@@ -302,18 +372,23 @@
   },
   "0.103.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC228076EA21A5",
       "checksum": "d128c3fbd86816e8c6f69df436b18a780a2b5d19f020c47a508ec2a2e88bef0b"
     },
     "x86_64_macos": {
+      "etag": "0x8DC228078222C8B",
       "checksum": "5f0d8fdec61b2f81fa1974416b37bf80740bd1d83f06b55e7defca41558ee3f1"
     },
     "x86_64_windows": {
+      "etag": "0x8DC228077F975A7",
       "checksum": "fd2204b44cbadbc84af50740b0005341c269420ec8c234f51250ea4c0b1a02e9"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC228076F27CA6",
       "checksum": "4d424a5f3d9754e00fc1e374b493e22ee5da590ebcde29d02cef1013671cf28b"
     },
     "aarch64_macos": {
+      "etag": "0x8DC2280781569A7",
       "checksum": "462d637405ebb02d49b03dd888dd4a7bca6a3efd2e4cef73a43111b1e4cbdf8e"
     }
   },
@@ -322,18 +397,23 @@
   },
   "0.102.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC1E7D1FE4C985",
       "checksum": "35f52d22745fb9a60fd7023e9faf5088a9dd506de11a9e20bf8a73d9f8a2cadf"
     },
     "x86_64_macos": {
+      "etag": "0x8DC1E7D21725C43",
       "checksum": "0aa08966ff4d46becdc7cbeadac858e4a6787e6bcc22994fd489338094bdddf3"
     },
     "x86_64_windows": {
+      "etag": "0x8DC1E7D1F1CDC77",
       "checksum": "70391850bc8c6bf9ccea5d67d2437217eaaa2303bfb34c9cea3b32231cbdae46"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC1E7D1E027160",
       "checksum": "9e55e48c89fe122452e175f0b769318e29585e079567c518781dd25a2af9f51e"
     },
     "aarch64_macos": {
+      "etag": "0x8DC1E7D1EF6460E",
       "checksum": "16fcf55432dd04ab7bd553a32a04d73bccee9852fa3aecffe14012fe1a1f8764"
     }
   },
@@ -342,35 +422,45 @@
   },
   "0.101.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC193B3E460681",
       "checksum": "88ac3dcd752deba6d93d655bed1fee18ea9692ac48fd3ff2cb81dde70a5aac6c"
     },
     "x86_64_macos": {
+      "etag": "0x8DC193B440C326B",
       "checksum": "2ed9fe6c87b6acf64b51fed04dd27d78b7bbbd606079f1370674d7b423190f80"
     },
     "x86_64_windows": {
+      "etag": "0x8DC193B3EFE4D8E",
       "checksum": "828cc0a4eb96ef8646d4477acc6c93d97ec69a7ca2281a303cd99be21342c9d8"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC193B3E9A0959",
       "checksum": "dbdcbf7fe69d8e8594d4bfdca1d7699229b655c0d23285fc16ce6ba991d7c63a"
     },
     "aarch64_macos": {
+      "etag": "0x8DC193B465390D8",
       "checksum": "a81aaa50fc798d05ef20fb821f5be94bce33ace26d77ebca78c2a0c7bc2aa661"
     }
   },
   "0.101.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC179DD98E2836",
       "checksum": "6ab16fd950f218a2682c2c126371b19e13adf717860299f64924a8b147d08e47"
     },
     "x86_64_macos": {
+      "etag": "0x8DC179DDACDF22D",
       "checksum": "d59a14cc812f6cbf4021c3e63664da9d10ba5a51740f10803dd7dd552e3d3027"
     },
     "x86_64_windows": {
+      "etag": "0x8DC179DDADEF603",
       "checksum": "8a0facfee157b674ac27f58d7d9ec6fb985bb4bbb0c69610d275dce7fb507dae"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC179DD998F16E",
       "checksum": "09ba6780c170fee7a42bf86da6ca664879502bc3366afec49dc0d8f05de40a5d"
     },
     "aarch64_macos": {
+      "etag": "0x8DC179DDA8BB59F",
       "checksum": "f3409b0ce93305377ff55675b185ad0d15782061a5c9f3130d83901a0a47183f"
     }
   },
@@ -379,18 +469,23 @@
   },
   "0.100.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC0E370A793477",
       "checksum": "0b9db5e79568dfe846abec744ff3f3e4d6aeef1a2e8c84a5cfe355c4d05e2b4a"
     },
     "x86_64_macos": {
+      "etag": "0x8DC0E370B8A820A",
       "checksum": "2a8ae723034874fb2a45cc9b8b3fc371d60d7ef1aeefdce28c4b22856595b7c9"
     },
     "x86_64_windows": {
+      "etag": "0x8DC0E370BBCF1FE",
       "checksum": "4490bf39e4432823a54166b6245f4255030d193eb05230c166f8589d48a736ca"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC0E3723176DE6",
       "checksum": "697d039c6d31d551d77472c498370605b2b666c3cfdfc8f961d448de3039bef7"
     },
     "aarch64_macos": {
+      "etag": "0x8DC0E370B764D80",
       "checksum": "67cac58c26f9b701583feca5d9a2b0f07d5dee73465f7610f7ccad02aa924feb"
     }
   },
@@ -399,18 +494,23 @@
   },
   "0.99.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC0241717C9720",
       "checksum": "e18580d1d55370431503a6dc17082e53ce0195cec498d025c09e3a201f492911"
     },
     "x86_64_macos": {
+      "etag": "0x8DC024172641D70",
       "checksum": "ab38b1f15f5503777961494fa2d027a1c47bfc9e83550ab07a3a4a6354db9dfa"
     },
     "x86_64_windows": {
+      "etag": "0x8DC024172D6A975",
       "checksum": "39adaae48cf1158c1181c3948bd4823e3fdd84f3411fb3cf0e466a29a1355732"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC0241726664CE",
       "checksum": "f198faf502e9fd6161a4236c365ff5f95e23f0b26d5e18fd6b245a5e2a1cb94c"
     },
     "aarch64_macos": {
+      "etag": "0x8DC0241728D48F9",
       "checksum": "43a4267e540766a4a9205802b69713b0dd76e08e4c6828b0b7b51363a72ba498"
     }
   },
@@ -419,18 +519,23 @@
   },
   "0.98.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBF0EBCF4B4552",
       "checksum": "2340210ba861481f269fcebf910cb4ea888d6ffc44a93758db227d6f1e555977"
     },
     "x86_64_macos": {
+      "etag": "0x8DBF0EBD068E131",
       "checksum": "91253de44621b040a0c8224256d30eab629dc74e3e683bbd69e1c96d839fe794"
     },
     "x86_64_windows": {
+      "etag": "0x8DBF0EBD063DDC7",
       "checksum": "120a76468bf91aeadcc8275105723f1c2c2600b765c302bf9ec4a228a1fecf2d"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBF0EBCFA278F7",
       "checksum": "fa800c59670aa34193a2d5634470cf10a5458306e1c062a9053ce72a4ef4d54f"
     },
     "aarch64_macos": {
+      "etag": "0x8DBF0EBD5C5A04A",
       "checksum": "9838f0aa8ef461a8090460e2dbefe459ddab033e063abb07c16e83de05cff374"
     }
   },
@@ -439,35 +544,45 @@
   },
   "0.97.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBE7B19D7388CC",
       "checksum": "592e642bb795bb0f6d9c35f4da58774f9b40d1f8ece3ea0367c2dea27dced470"
     },
     "x86_64_macos": {
+      "etag": "0x8DBE7B19E75CC3C",
       "checksum": "d86c2c80ef47179229bdd857508411424cf612760f13b8dc394de2f2a65d7ca6"
     },
     "x86_64_windows": {
+      "etag": "0x8DBE7B19E7D8BB2",
       "checksum": "aac9e63d219f27a75751e74d09d36c2ddfc02d1d623f8f8234e6b377f525ed2d"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBE7B19D669F1A",
       "checksum": "039003a7bc551f298d16ed770a1e5d0a51ea5fb1d86e021623a0435f69203c64"
     },
     "aarch64_macos": {
+      "etag": "0x8DBE7B19E55E503",
       "checksum": "7f62a2a6b5d56d065703e313d1a74893e9579396d75f022eedc8dab723ab0a8e"
     }
   },
   "0.97.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBE6F82B09C199",
       "checksum": "c17c905a2b687c1dac3fb96d7d30bcd6fbec1bdb5662372d0d9e2f8536b7ce04"
     },
     "x86_64_macos": {
+      "etag": "0x8DBE6F82BF51467",
       "checksum": "46636177f41e8fe01941b786141a9cabd34453da2b245068925e0f8a56797a54"
     },
     "x86_64_windows": {
+      "etag": "0x8DBE6F82BFDE41A",
       "checksum": "250cc21ad1538c575fa74d51230c20c7517af79d36b5271788ca4ebf038e4a26"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBE6F82AF1E7A2",
       "checksum": "8cce25f7180c385de094936c40306f5efacf1ec5dc9e150076aa1b8a4844ff35"
     },
     "aarch64_macos": {
+      "etag": "0x8DBE6F82BC56084",
       "checksum": "6bb8c10704c2d0de82e3e6dfd845391343c6d13737b71576f4c5d586b0eefbe1"
     }
   },
@@ -476,18 +591,23 @@
   },
   "0.96.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBE12DD2F4740F",
       "checksum": "abc1b66ba07241eaa667a78900dabab4a4e7a96a1776b39628a4de3b61dfa30d"
     },
     "x86_64_macos": {
+      "etag": "0x8DBE12DD3CB1DA5",
       "checksum": "08e8b68e4f59fac5320a44738c6352c70f7b70e55823447736c4188d9a39f479"
     },
     "x86_64_windows": {
+      "etag": "0x8DBE12DD41F209C",
       "checksum": "6e459a69302a181a62e2e85566e94ecce4850a908af648850467a4d2d426823e"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBE12DD2D0C095",
       "checksum": "d43bd1a221f4393b1e6ddb1d03d381b6dde837d2b35c121eeec16f360e399592"
     },
     "aarch64_macos": {
+      "etag": "0x8DBE12DD38EA6DC",
       "checksum": "ab4c4a3b09c0fa6b0b6f00596bd13fe177bf1510ba6cea6bbcd6af3b846bc4a7"
     }
   },
@@ -496,18 +616,23 @@
   },
   "0.95.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBDFB1931617C6",
       "checksum": "437ce8e8f23176a88f8ad05a6252dc417081a4569c921ddbe6241c9873da8cba"
     },
     "x86_64_macos": {
+      "etag": "0x8DBDFB1936AB64E",
       "checksum": "6d46dc6a5565a5296a3ca606345d249796248f334c438f3ec59419227357f3ec"
     },
     "x86_64_windows": {
+      "etag": "0x8DBDFB190C48AFD",
       "checksum": "aff4d28a825e59e799610463cdce3ff89fc41532b2cadfa7067a8e2295bcd315"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBDFB18F932F3F",
       "checksum": "8fc9b37e861ebc9fdddf09dc3b1089cdab6a7f2eb4f18c0d57e1716cdd1c8d25"
     },
     "aarch64_macos": {
+      "etag": "0x8DBDFB190609480",
       "checksum": "bcc97342151b95dfa4fbe06c25de4508b6e703f3780b1ad4a2be67ec15844e66"
     }
   },
@@ -516,18 +641,23 @@
   },
   "0.94.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBD19266AE0181",
       "checksum": "a18f10ba6add219b2680687450869db3c6a8b71e68ca6ae3925f9e53964cacbd"
     },
     "x86_64_macos": {
+      "etag": "0x8DBD192689316A7",
       "checksum": "6057745c6618ec69f5a7a0d517c230b4ad55ec5ea33ab51ec928b364cac6b3a8"
     },
     "x86_64_windows": {
+      "etag": "0x8DBD192696DB3CB",
       "checksum": "be675b28d282f0be75868cea4766369325e58ede7d4fcf76ce97d0a1004d413a"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBD19266AE762E",
       "checksum": "7a6dc03e02565e1008d93c6083181b1699cde3da15ab975e21ef7ae7c3e5caa1"
     },
     "aarch64_macos": {
+      "etag": "0x8DBD1926867CA88",
       "checksum": "0109b3015e618ec54f7d431aef37c610db5864435d71990874b1f884373da936"
     }
   },
@@ -536,18 +666,23 @@
   },
   "0.93.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBC9B7B3C5C79C",
       "checksum": "5fb0eb70c0f618e9a8b93d68b59da4b5758164b1aacc062e2150341baf7acc73"
     },
     "x86_64_macos": {
+      "etag": "0x8DBC9B7B3FF826C",
       "checksum": "fbf8d99ff614221bdb78dc608dd4430b0fd04a56939a779818c7b296dfd470f1"
     },
     "x86_64_windows": {
+      "etag": "0x8DBC9B7B4B3AFAF",
       "checksum": "78da6446129fa3ae65114ddf8a56b7d581e21796fd7db8c0724d9ae8f8e3eeb4"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBC9B7B2CC0610",
       "checksum": "f2f8889305350ee3a53a012246acfa10b59b7aee67e9b6a2e811f05b67f74588"
     },
     "aarch64_macos": {
+      "etag": "0x8DBC9B7B4263FB9",
       "checksum": "169da07ce4cbe5f59ae3cc6a65b7b7b539ed07b987905e526d5fc4491ea0024e"
     }
   },
@@ -556,18 +691,23 @@
   },
   "0.92.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBBF71CF9D7E0E",
       "checksum": "42159b11660fba22a12f8acad87022987337c0725b99d9cf645b690163d5bfce"
     },
     "x86_64_macos": {
+      "etag": "0x8DBBF71D0DEF495",
       "checksum": "ac6097010cbba3e0300672868d54670ff514458c6784683172680c47ba1696de"
     },
     "x86_64_windows": {
+      "etag": "0x8DBBF71D831F3FE",
       "checksum": "071135f3ddff00edd7c21663a08d8c8e1a9d199f55bb0f3cd36aaeb1e186875d"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBBF71CFEFD545",
       "checksum": "33f6636e54eb1731b137c43257d8de8025282ca3570f307f3249ba7d5757ce10"
     },
     "aarch64_macos": {
+      "etag": "0x8DBBF71D0E2C0DA",
       "checksum": "8518d8682b5fe287caaabf3584331074220ab3f588ed3d47badf8428af87c320"
     }
   },
@@ -576,18 +716,23 @@
   },
   "0.91.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBBA122DAD3DC7",
       "checksum": "51188401eb2a2425db1155ba18cb64db8275491a1e1049690fe6e8a371ff222a"
     },
     "x86_64_macos": {
+      "etag": "0x8DBBA122E839962",
       "checksum": "724e6864a356834d8f3a40a3db2216884fc2c4cf69b67baa03cd08466e80fca9"
     },
     "x86_64_windows": {
+      "etag": "0x8DBBA122FD3F2B6",
       "checksum": "9189e2246b5b649f8f09eb6d7500ee5f698253e94ebb34fab06ea6910489bcdc"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBBA122D9DBEE8",
       "checksum": "e9d3eb8120438325b79a8bf2a994692a111e5a47c63bbdf7762f7e9fb5a12f4a"
     },
     "aarch64_macos": {
+      "etag": "0x8DBBA122EBC91A0",
       "checksum": "d53362e44322e81015c9fa17f2254f2fa3d55dc04f18c1e0bc8891705aaf4696"
     }
   },
@@ -596,18 +741,23 @@
   },
   "0.90.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBB30DC11C6FE2",
       "checksum": "7368d65830fe90ad96edac8a1d548193a36e18853f30e11b9f97772a573eae2a"
     },
     "x86_64_macos": {
+      "etag": "0x8DBB30DC2FD4386",
       "checksum": "5b2c36edf5a317eb45691484ad6eea6ffc2aee45fb97612492b93099a9407578"
     },
     "x86_64_windows": {
+      "etag": "0x8DBB30DC4189830",
       "checksum": "eaffd994f6c90ce39e7753f1cb48f5e61f7828b83dc8f27364490f02813d3645"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBB30DC11FEE73",
       "checksum": "06bc39ff9ff3a3a5ba7055a158eace7bf105c8baf9eecfa33fbb1387e9dab4ed"
     },
     "aarch64_macos": {
+      "etag": "0x8DBB30DC309B89E",
       "checksum": "9d596ab903becd9061cb9919e6e626835978246adaaf0392c871fdf34b974c38"
     }
   },
@@ -616,18 +766,23 @@
   },
   "0.89.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBAA38DF919C38",
       "checksum": "b7cc7c1fb588454947ca678df7ddd906620d399a05f92a550b1b2d312fb26764"
     },
     "x86_64_macos": {
+      "etag": "0x8DBAA38DF658DA9",
       "checksum": "fd8fc86772d44b4a93f6566a897f832923cc6aa3de9434772a4ac0966377f8be"
     },
     "x86_64_windows": {
+      "etag": "0x8DBAA38E03623D0",
       "checksum": "1a512c97b3fa504ad0b6c8c62660cfe980786a433a1582b460bd35005b36ceb2"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBAA38DF3C3B21",
       "checksum": "1c1c8e53d7157c3e861116e24eb494da0b660b3757ea69d6e05038c6ed76c50f"
     },
     "aarch64_macos": {
+      "etag": "0x8DBAA38DF7CA526",
       "checksum": "7d6d848c4375d10c2ebd019120a835f3d4527bb78250efc47fd2ba010a6798ba"
     }
   },
@@ -636,18 +791,23 @@
   },
   "0.88.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBA5AE72D8C44C",
       "checksum": "d22c5e840c1a9ba10aee264d8bd015aca9c745bfd23efdfe75fdd36eeaf75ea8"
     },
     "x86_64_macos": {
+      "etag": "0x8DBA5AE73CD0E1B",
       "checksum": "f27232e327bf7f533dcffb2275250d325f45b69f5a0bd723c33f40f733e89e15"
     },
     "x86_64_windows": {
+      "etag": "0x8DBA5AE74C3517E",
       "checksum": "3c4bbcfee4c885e2b344c0de3dc77987057b27079cccb1b15435fd2399f92cfa"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DBA5AE73181E21",
       "checksum": "2c5550833c9c958f29e0f0cd13fd962b1805b97c8775db73c44e274da42a7b39"
     },
     "aarch64_macos": {
+      "etag": "0x8DBA5AE7401030F",
       "checksum": "8e822e53eb3f779e446466a93863a75da9e78cefdbcf1fa575b0645a45dcc868"
     }
   },
@@ -656,35 +816,45 @@
   },
   "0.87.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB9F5503F40139",
       "checksum": "1f6f5aa0bb5682f8db74cb5adf00fac9bddec40f6fcde808b71c43d3593e3cf5"
     },
     "x86_64_macos": {
+      "etag": "0x8DB9F55055ECACA",
       "checksum": "c24990a01127bfe512351bb65694460629a6c83828e02aef9f8e7ece5d0b3c8a"
     },
     "x86_64_windows": {
+      "etag": "0x8DB9F5505F50AC0",
       "checksum": "ec89bf68571238a67b83c26a32371b67efa6daeaa819d67a9f281a69cb2e0cd0"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB9F550390F3CA",
       "checksum": "5570eb42a9a2b696d4d8398a9733f7f2dda0e4a243413960aeab44a1183a6f47"
     },
     "aarch64_macos": {
+      "etag": "0x8DB9F5505F6B692",
       "checksum": "eeae4d4ed97f9519697027d658deab72fcdc94a6f2c4d77354a82085fb8db1f4"
     }
   },
   "0.87.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB9CF10A1A9D16",
       "checksum": "9567007466ae6c5c893abd680258f8781b0709188fb0aab59eb1eb35c64ea6b6"
     },
     "x86_64_macos": {
+      "etag": "0x8DB9CF10AE67DDA",
       "checksum": "60137a14c6a1340e7405baa07876b5e442e756b208fd9b5b3cb2f9a14a410e19"
     },
     "x86_64_windows": {
+      "etag": "0x8DB9CF10BD6390D",
       "checksum": "2fe288c607b1d2febac30b5997b76aa83b40694b8af7af6690d9f64385212f3c"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB9CF109653854",
       "checksum": "14f5876c6543d084fa0f91ec928af8bd0dba7ea09f5848528c6402b20ff72041"
     },
     "aarch64_macos": {
+      "etag": "0x8DB9CF10AD7C15C",
       "checksum": "2b68cefc0b51781fdf2669ef3633904fe057740b6752d2704db34ba380238387"
     }
   },
@@ -693,35 +863,45 @@
   },
   "0.86.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB91ED868B2E41",
       "checksum": "6316bff6b9a40c893422ec4df12c7da6a200f7ca08842cccc39bf94cd69f28c8"
     },
     "x86_64_macos": {
+      "etag": "0x8DB91ED8806FA97",
       "checksum": "5e506e96ac2ae01e9d2598e66dcc9375d0d4018031e54725e25b26bc0ed9f177"
     },
     "x86_64_windows": {
+      "etag": "0x8DB91ED889BB53A",
       "checksum": "b0a8141b46de13ccf82dd12fd8eddb77888aef770ef210ee35f9c68a61122b93"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB91ED8679DCA3",
       "checksum": "ed143b563c231ab3acdf805ff4b68d808d4ccf2ed35ec829aa5c377de0cc02ee"
     },
     "aarch64_macos": {
+      "etag": "0x8DB91ED87E9CF7C",
       "checksum": "e538cc1881d9b2446d4d20ea19f650e567cb729c38ad05c268c712450bcf7ecf"
     }
   },
   "0.86.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB91E172A61D6B",
       "checksum": "f05da10cbf60cb5f9edcd8da79762bc5b4a495d828bad23b301632ffc18ddfb1"
     },
     "x86_64_macos": {
+      "etag": "0x8DB91E17413A20C",
       "checksum": "d8c7169086347427bc1317ce484d21049331f34c516f209e01335b6c4ba89648"
     },
     "x86_64_windows": {
+      "etag": "0x8DB91E174CE7E60",
       "checksum": "ffb447ca43ac4761796f9463b88b2bdca5f45169ac5ace86413c70394cefdc3e"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB91E1729EF979",
       "checksum": "c6aa2fe68101b349b8426c0fb119b98d24a361e3bdac0554f477c5a943bb288d"
     },
     "aarch64_macos": {
+      "etag": "0x8DB91E1741967DD",
       "checksum": "e083dbf018cfa5bffd2904a1c4c9277cface05bdfdd2ec6b46b171091c3e6a91"
     }
   },
@@ -730,18 +910,23 @@
   },
   "0.85.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB82FFC2A09302",
       "checksum": "2a92c69e1017e2bf3785886a8298ad2b94dda69f9f5623560999740986dd8420"
     },
     "x86_64_macos": {
+      "etag": "0x8DB82FFC35F62D0",
       "checksum": "8dc8a29466bc69f514b56d8e41801ff781253646d07044982122609cb48bc1da"
     },
     "x86_64_windows": {
+      "etag": "0x8DB82FFC42ACE74",
       "checksum": "ca38ceb73b3124e92e2717f269e826a5091f128ee9bade27c9d9481b45aca43e"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB82FFC1B9F5BB",
       "checksum": "fe96fc0c286feb554821ec1baf9367ad7122173998a8ca4ae2bcda844cd4a10a"
     },
     "aarch64_macos": {
+      "etag": "0x8DB82FFC379AAFA",
       "checksum": "0864e3b49ccf232bab7e171e4f8c03d1d6b291adc122ca009aa00218e9c74607"
     }
   },
@@ -750,35 +935,45 @@
   },
   "0.84.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB78C5B4A8164A",
       "checksum": "05ebad9167254f03447103efea175d636c3cd27d0da7f79972ca78adc7c442f9"
     },
     "x86_64_macos": {
+      "etag": "0x8DB78C5B52E623E",
       "checksum": "43af6c70dca85ea603fb807e78044879c549a7b9d053d00d071078cebbdf2c6d"
     },
     "x86_64_windows": {
+      "etag": "0x8DB78C5B5F64F60",
       "checksum": "03241b9de869df23634c34c28cc27a7f48af3571ef95b46318c834a56c42e519"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB78C5B3A3B26D",
       "checksum": "8b68b2cf046f8c3729753f7a414eb6546ac7b43bee3afd56f413601200cac3c2"
     },
     "aarch64_macos": {
+      "etag": "0x8DB78C5B566712D",
       "checksum": "b98b9817dc284a0eb5d7e559a574361fda49d79a3413710ae5c35bd5e986adcb"
     }
   },
   "0.84.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB71B9DC553992",
       "checksum": "cca9c05614667fe6d5de6362417754c522aeccadcb2ccfb9302f3dd7e82bdddc"
     },
     "x86_64_macos": {
+      "etag": "0x8DB71B9DD7DECC1",
       "checksum": "f981df10be75e86fc82ba59cc338f982c5b6b07a5a2e3c104c983fca975fe1ac"
     },
     "x86_64_windows": {
+      "etag": "0x8DB71B9DE330380",
       "checksum": "39f90587629f32681ba22a03de6c996d4c4c94f3266e09ae6a472fd127176e07"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB71B9DC219276",
       "checksum": "33924f053526b6c2178f7c362bb7d19483406d59664cdf3528d92262cbfa213d"
     },
     "aarch64_macos": {
+      "etag": "0x8DB71B9DDCB4098",
       "checksum": "65972738458a3255011808f46919a2fd6c1a559565be67da2a2a8f314f25638e"
     }
   },
@@ -787,35 +982,45 @@
   },
   "0.83.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB6D014C23000E",
       "checksum": "59b761dc495dd56e32e744cb4403bfcca6a9c0aed810b618664e36530a01f253"
     },
     "x86_64_macos": {
+      "etag": "0x8DB6D014C871D65",
       "checksum": "fa51fe155bc19f047663a6dbd2cc82fd35533a1601be55abb39c50ecff1e461a"
     },
     "x86_64_windows": {
+      "etag": "0x8DB6D014D4FCCBE",
       "checksum": "035fdcc70f38479de7a3d67525f5154e2acd9748e92fe37ef1814766f478b59b"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB6D014B232B25",
       "checksum": "1df595ac70f29be7683857f585a4cdf583245b36f98b362a4da8276f08dcb640"
     },
     "aarch64_macos": {
+      "etag": "0x8DB6D014C8DCCA1",
       "checksum": "8a7ec7450a7f6d0f894bcad946e06ce70d455269191dc706ca671b3d698d6a1d"
     }
   },
   "0.83.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB65FB24D62554",
       "checksum": "694e97a454327403fb440544c41fefd83d37f88f43c4f9ae0b0d67a3562bd25c"
     },
     "x86_64_macos": {
+      "etag": "0x8DB65FB2688F06F",
       "checksum": "211f34f2e52e842d3248bc3a72c07e534d0d7a8e40babaa7a2034a41a077b70e"
     },
     "x86_64_windows": {
+      "etag": "0x8DB65FB273FD9AF",
       "checksum": "9131f458fdbbc88fe1bd8df666721ecb95ff751d0ca3e2cffecfd5e021c65e97"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB65FB24D90841",
       "checksum": "388fbea52598e44f8529e3432555c53e6e161211a83020d2b749c5d160baf593"
     },
     "aarch64_macos": {
+      "etag": "0x8DB65FB2671644A",
       "checksum": "4b93cf316aa30bddb53d2dcd82f4c9d0353b337677cbdf8a470749f9e98eec82"
     }
   }

--- a/manifests/typos.json
+++ b/manifests/typos.json
@@ -26,107 +26,137 @@
   },
   "1.22.7": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC8AF7A10A1A14",
       "checksum": "a706a74f970f660e8aa24c6b3a46b8e213974d4317dc163b03d5e05c20e561a8"
     },
     "x86_64_macos": {
+      "etag": "0x8DC8AF77CC0694A",
       "checksum": "28f40f958f37cab2b24308142f404dba22d0e18757b511e0a16100fb4fd41547"
     },
     "x86_64_windows": {
+      "etag": "0x8DC8AF7A6AFCDAC",
       "checksum": "912951a701c2c55dac499f908775126735aa2b59b41c488da18093e2b2d3aa69"
     },
     "aarch64_macos": {
+      "etag": "0x8DC8AF7772E993C",
       "checksum": "c5857dec27e38ed996e76b2d8c4545006905ea750ab015ab72bd66cadb00b376"
     }
   },
   "1.22.6": {
     "x86_64_macos": {
+      "etag": "0x8DC8AF57EB4DB8B",
       "checksum": "ba16199129ddd81e1c720d39fb35c41369a9c78c15b2e39126e8b02e875e11f7"
     },
     "x86_64_windows": {
+      "etag": "0x8DC8AF5E0D1637C",
       "checksum": "aae44abc76ba77556cfc7d576ced87a716f420b09fa357cebbdf0a9a040a2492"
     },
     "aarch64_macos": {
+      "etag": "0x8DC8AF58830DFF5",
       "checksum": "31a335e695fc9749ddd95bc9154616ccb07c94df77bcc9156acc41d258219f64"
     }
   },
   "1.22.5": {
     "x86_64_macos": {
+      "etag": "0x8DC8AF0DB37C168",
       "checksum": "1023d1323b98103d45ffd293515a2515c14493c57c5035c76106ec344aab6a4b"
     },
     "x86_64_windows": {
+      "etag": "0x8DC8AF0FD2C382C",
       "checksum": "b727570571472fbab9029d4bcc09a1cbcafece02907fa7a25a46d6feb426bb5a"
     },
     "aarch64_macos": {
+      "etag": "0x8DC8AF0DDC29603",
       "checksum": "96024e189bce99b25bbc2a4165a76832637c231f1163d57581a080bbb5bfbd22"
     }
   },
   "1.22.4": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC89994D5C7E90",
       "checksum": "aa4be101267b74c7ba0a8d506362c8b5ed75351afe35c86e2de3b2dfad1092b7"
     },
     "x86_64_macos": {
+      "etag": "0x8DC899949D33436",
       "checksum": "3761bc4c3bbc0367fbb691e600d09f92a2b641f98158b13c78b469c36afa6a67"
     },
     "x86_64_windows": {
+      "etag": "0x8DC899997F7AF9F",
       "checksum": "94473d6765f59ea970deb2377e5a42c6d4bf7a37441fab52a2a6eb1ee6d49f77"
     },
     "aarch64_macos": {
+      "etag": "0x8DC89994B8EF607",
       "checksum": "5328764dc79e25e65615698236ff8842bb4a1bfd95e2d4e84171d7df5b216489"
     }
   },
   "1.22.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC8704B5D665D4",
       "checksum": "712206018c601b93557e42aeffd486af2e6fb0a6b017d0d51e6dad587bd65097"
     },
     "x86_64_macos": {
+      "etag": "0x8DC8704C925B535",
       "checksum": "21cae80f0ff7ebf39e36cba72c230f78d728168e127e21480d9398cccd862fdd"
     },
     "x86_64_windows": {
+      "etag": "0x8DC8705094F17CB",
       "checksum": "2d1cfa926d0f0dd8c972334b6e6c127243dbf8e354f3e31ed5018e30f531fe43"
     },
     "aarch64_macos": {
+      "etag": "0x8DC870525B05643",
       "checksum": "5ffd546b0335480af0c9f384d58db07b72e822864466055b2d2079114a279324"
     }
   },
   "1.22.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC86F211D1C0DA",
       "checksum": "ff5123e4f309c3f013a4126fbfc8c998b018408d250d170295683b567c1b7ffe"
     },
     "x86_64_macos": {
+      "etag": "0x8DC86F2124FD8AC",
       "checksum": "b85e65bf834304c71f7cce7311e99d950761d23e87bbfb2c86a37d9d52a9cb84"
     },
     "x86_64_windows": {
+      "etag": "0x8DC86F24891B47B",
       "checksum": "6e7ecedbb3aab7bc00d1818680abe90ed3faa071113f12e6e7d197986ba9565d"
     },
     "aarch64_macos": {
+      "etag": "0x8DC86F1FB6577CD",
       "checksum": "dc1939d39b55a08900f57dc077f9e69f275365abcee6a45d32b04514f1f6a8a8"
     }
   },
   "1.22.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC8597C46F2E87",
       "checksum": "24afc3b444e2abfa2b09af337b8ebb07e27856dd9a685bf62d967c212f509cbd"
     },
     "x86_64_macos": {
+      "etag": "0x8DC8597BBA7FD61",
       "checksum": "5ff717943be650006cf56f20d2e7dacb93bb206efae544955fbe3bc0897a831e"
     },
     "x86_64_windows": {
+      "etag": "0x8DC85980F2C345E",
       "checksum": "7185b46acb4735b57cea4932657a29f5a55050becf02814b0057143e7fe5c94d"
     },
     "aarch64_macos": {
+      "etag": "0x8DC8597A0E09FD4",
       "checksum": "19234d0f9e90895ab1ffbbc21b46d0f4fe403cf8add8d9a66b5491ecf19a253d"
     }
   },
   "1.22.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC83DFFFA46D4F",
       "checksum": "bfa037cb884797da229768751642191128a8096f34a77c2c2aab81f4ea4add5e"
     },
     "x86_64_macos": {
+      "etag": "0x8DC83E02F0CA5F5",
       "checksum": "5cede24a0c7e7fa826372346ae8a1eb7264741412cf830acb7bd6ba9d261e610"
     },
     "x86_64_windows": {
+      "etag": "0x8DC83E0A4884053",
       "checksum": "cded62aca581b5610a8a8ac88d26c84bbbf02cd988fca64be50da6beb7d6ad85"
     },
     "aarch64_macos": {
+      "etag": "0x8DC83E03EB13D58",
       "checksum": "e747252644b76cca8b7c4bf3a36835186773500a2d1964ffe7341bd33ffdfbe2"
     }
   },
@@ -135,15 +165,19 @@
   },
   "1.21.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC694DCEBA71DA",
       "checksum": "e28b75a55460b18245edf18a3f4da28b0c9271c9c19edb1c32fe4301db573e7f"
     },
     "x86_64_macos": {
+      "etag": "0x8DC694DA92B2F6D",
       "checksum": "b808f5598249e7e8f6a7dc9e58a6591c62de1d273c04baba50ea248cad01f8b5"
     },
     "x86_64_windows": {
+      "etag": "0x8DC694E008C8073",
       "checksum": "caa1c4c83e6a7ab2e6432d6412f826da94f3967dc5f5cd80d6df845c0ef4f6bd"
     },
     "aarch64_macos": {
+      "etag": "0x8DC694DC63006AC",
       "checksum": "f6d2088ac6af68a02f68e12c4cc5e37278c702f3e1b7fc7da99f925435a9a5c5"
     }
   },
@@ -152,155 +186,199 @@
   },
   "1.20.10": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC63D170A3D2A5",
       "checksum": "2f0758620492b6f0fb3f1c3b916a6e7741c171d814e1204cbc923481c85e0867"
     },
     "x86_64_macos": {
+      "etag": "0x8DC63D1B2C2CEB7",
       "checksum": "e0fdd6fa3838f0d538655a8c205b8e34add56e4803b133af13879cce7f7dbb0b"
     },
     "x86_64_windows": {
+      "etag": "0x8DC63D1C5764431",
       "checksum": "60bbd4bb97b7e622d43e7353764de055f7e62ef0e6db4f22e1fe42f3543997ff"
     },
     "aarch64_macos": {
+      "etag": "0x8DC63D1A6718CFD",
       "checksum": "80f170e22bdb635d2424fa03eeb021d3efcbd11bbafa428671e36fd435f6a000"
     }
   },
   "1.20.9": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC5E36B7B9D386",
       "checksum": "3f36e675f9b463b0c385af92653f249f663d09ce1496cc1534f4a848a34cfc04"
     },
     "x86_64_macos": {
+      "etag": "0x8DC5E36FA3A6200",
       "checksum": "16591f4c39d31e9cb082cfcdb00d4b296a7254f0fa4f6446f27278d43863cb75"
     },
     "x86_64_windows": {
+      "etag": "0x8DC5E36DDC81F23",
       "checksum": "0acb7374014653b93c34301b2e2c5a7e47a74a88124173b4d6269866d1856687"
     },
     "aarch64_macos": {
+      "etag": "0x8DC5E36FE2A3774",
       "checksum": "489ec947b024bdce526157e48540aa020c2c7079729c49f7d89d26d29fe4bc72"
     }
   },
   "1.20.8": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC5B343B75AF06",
       "checksum": "681a132089eae4d7c08b9bd9e0fb4bd40eb2418658130c91dcadaaa190cb0334"
     },
     "x86_64_macos": {
+      "etag": "0x8DC5B348311CF99",
       "checksum": "3f321104f7d5fe7f7d773d888ef0b235aad6c64889486b1d0858335c8f7075b7"
     },
     "x86_64_windows": {
+      "etag": "0x8DC5B347888C300",
       "checksum": "bdd479b600d84b423b36811140b7617c6dd541df46e9d8729a837b5431351463"
     },
     "aarch64_macos": {
+      "etag": "0x8DC5B34D633108B",
       "checksum": "50b0c0392c0d49f4617daa30035d632c9dbe1c6ad0facca73395d7be50163b7e"
     }
   },
   "1.20.7": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC58D40FEF8496",
       "checksum": "90ec15ee370cabe01111e8fb488e9b96382c6e27e3444d285df49387fedb5c52"
     },
     "x86_64_macos": {
+      "etag": "0x8DC58D437BC33E2",
       "checksum": "5f93dda37eedfbfc9e9513c23402432d7e4a99dcf926cad69a2e24ae3c2c9f1c"
     },
     "x86_64_windows": {
+      "etag": "0x8DC58D461BC19F2",
       "checksum": "9d12e8b464d29be93b53da2bf8dbd727fc8dd51ce25d40b67edd62209d40297e"
     },
     "aarch64_macos": {
+      "etag": "0x8DC58D46C920502",
       "checksum": "23ffc31c0beea9b2cd832cec5e77e3d516c9f6c0ae3aa92d160b5f2447569be3"
     }
   },
   "1.20.6": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC58B5C9DED1C1",
       "checksum": "bceb5e6a9bde42e8147809bb894835aad65563fc90ac8f0c512ec750b5fb0ed7"
     },
     "x86_64_macos": {
+      "etag": "0x8DC58B60E8C3ADC",
       "checksum": "309554fd276f5ef670c95e92e698b5fdf866fd863b686df185e5e677353044b9"
     },
     "x86_64_windows": {
+      "etag": "0x8DC58B641884D24",
       "checksum": "bcc6718c7dfba565223b67308f52d4fde521fb96be9c7865112191fd571eeac1"
     },
     "aarch64_macos": {
+      "etag": "0x8DC58B677E11E6D",
       "checksum": "b963887ffb9c59829c5cc6316396222391d2783aac91e500bca872e1aeeaf956"
     }
   },
   "1.20.5": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC583719923E3A",
       "checksum": "dd638fcde5e955bb801b9be28e912977dba6c857603ca14c212c71fc6cd871b0"
     },
     "x86_64_macos": {
+      "etag": "0x8DC5837EB3412C2",
       "checksum": "55cd7b30f2a081e6cda222df753da265daf816fe379d6307ba14de7f0c6a493f"
     },
     "x86_64_windows": {
+      "etag": "0x8DC58374B79CF5F",
       "checksum": "b98a51f9b41c606d7f431e2902e2929daba17ee8841f4b197b1459ee1b66b6eb"
     },
     "aarch64_macos": {
+      "etag": "0x8DC5837CD13FA10",
       "checksum": "d35a6e13fab8b967ae07acb23416c8ed2fb9deb8d57fc0e0f7403606a968e110"
     }
   },
   "1.20.4": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC54B32B2C2973",
       "checksum": "d7df369303db357ccbc3b0b0f7c0dbb8ba3b4c9767db5aca8b19b33b64fe00e8"
     },
     "x86_64_macos": {
+      "etag": "0x8DC54B338AC57E3",
       "checksum": "ef356c0424cce3ce7f9665941c829541b372e0e8f8a88f87a47ef90d415fde6d"
     },
     "x86_64_windows": {
+      "etag": "0x8DC54B354B1DD46",
       "checksum": "c7d2db44d00675783c54a31245f3b1d73cb921b1f13a816f6710511ab2260f0a"
     },
     "aarch64_macos": {
+      "etag": "0x8DC54B3718085F5",
       "checksum": "c89ff96b4ec56ab2e6554fa94c9ddfff6b19162dc85316bd36ccba0e4b8850b6"
     }
   },
   "1.20.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC532C8EF597EB",
       "checksum": "1d4d372ede016bf0a4a630c7f14a42ed23187a144fda3540204f23d03ca136ca"
     },
     "x86_64_macos": {
+      "etag": "0x8DC532C9EC252B1",
       "checksum": "3b9f2fa808b042e82024387f7792a593371d6fafe73f53daf0671b16be0e0d19"
     },
     "x86_64_windows": {
+      "etag": "0x8DC532CCA310ED2",
       "checksum": "b1cc90fecd0527b14af278b24d24e6b35d359ed8b3c88413887ad762fbcc3cb9"
     },
     "aarch64_macos": {
+      "etag": "0x8DC532C9DAD862E",
       "checksum": "474eadb97cb2cc35d2b1ab6cf80337c7f2bb22f7ad0761d6d94697cac5016048"
     }
   },
   "1.20.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC532A8E08AE41",
       "checksum": "baf0c3fd847e951e4ed24bd3dd59fd98434071a7ee373b085bc2a5b1098325c8"
     },
     "x86_64_macos": {
+      "etag": "0x8DC532A9C29E5B6",
       "checksum": "4967973cf7bd29e30391f290f434de4f39a634c1b4ba6ef9d98e3ff8cd446b68"
     },
     "x86_64_windows": {
+      "etag": "0x8DC532AB82D46FF",
       "checksum": "d55c2a70a4a6f36b6ff60896a2542ec7e2508e096270c30e939930eedf84c2a4"
     },
     "aarch64_macos": {
+      "etag": "0x8DC532A9C317E46",
       "checksum": "788359f64f6b1f0e889c7b9039b1ae86f1d15b0e10436ffe923d29c8c7297ace"
     }
   },
   "1.20.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC5294BCCFE761",
       "checksum": "1796a65b930ed00c895fbf08d7e5b163649ebddbd1046cf568b8d26833059148"
     },
     "x86_64_macos": {
+      "etag": "0x8DC52954D85C845",
       "checksum": "5d9c57f672e041312026d6bc8249e88dc8517b61b4ac15745bc164b5c4f37226"
     },
     "x86_64_windows": {
+      "etag": "0x8DC52952B58A097",
       "checksum": "1f89912a7fd370c336f7ad0a08d637a37f2e34aa6e25c73286aaa5d09d9e48c5"
     },
     "aarch64_macos": {
+      "etag": "0x8DC52956BBFC38C",
       "checksum": "3455e6f1241df06ba4c09fdd596879fc499fa882ce95319f2185f1611a218f0a"
     }
   },
   "1.20.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC527C36C62961",
       "checksum": "6b73ccf2f08d0905c84c1a10a4b7440106998f2014d87a28fcd65112c63ecffb"
     },
     "x86_64_macos": {
+      "etag": "0x8DC527C9A0E7D32",
       "checksum": "5c919a07d770ee4aacf3d1ff0025fe5f3ff67b58d95531c582a99f82dcb39a4d"
     },
     "x86_64_windows": {
+      "etag": "0x8DC527CA408D93B",
       "checksum": "2fa637603b752494259aa43dd22584d850d47d1dbb28fcf025e1865f0230eaf4"
     },
     "aarch64_macos": {
+      "etag": "0x8DC527CACB7E014",
       "checksum": "5ff1468178786040008f9348f5f27b31e2f5c937f2772145e09d3adc0ce14bc3"
     }
   },
@@ -309,15 +387,19 @@
   },
   "1.19.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC3A0EDF258A54",
       "checksum": "76cc73adc1ff95975e4fbc27b3cadf17c82d276c8dcb9cd58de7e536bb287e1d"
     },
     "x86_64_macos": {
+      "etag": "0x8DC3A0F5F7EC4CC",
       "checksum": "c80a5ed91c1265e241162f93e1aee64c0603e09f68baff8ad1b465a3fbe355f4"
     },
     "x86_64_windows": {
+      "etag": "0x8DC3A0F687AAF11",
       "checksum": "8d87449c00dd5d95f7d8cadbb5749391257c147f6aa7067b44771879da45dd88"
     },
     "aarch64_macos": {
+      "etag": "0x8DC3A0F57FB9D74",
       "checksum": "1aceaa132e120d911a4ed5d6641940db83066b36b0e0113a9fbc7f3c5981461b"
     }
   },
@@ -326,43 +408,55 @@
   },
   "1.18.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC28AA0C763A73",
       "checksum": "6546fdec5f7d6af6b37e7a4d28bb546446b82026d280407eb0a1eed3b6e18ccd"
     },
     "x86_64_macos": {
+      "etag": "0x8DC28AA7CE684BA",
       "checksum": "5d31ff3c17f06660fe22ade7853861a95d107a3fc8d607fa63e13b5a00495751"
     },
     "x86_64_windows": {
+      "etag": "0x8DC28AA75DB1350",
       "checksum": "835ac32d7c2f59bb9b85f9035068ab2d7a03d3b416434af5d3308e2f3126319c"
     },
     "aarch64_macos": {
+      "etag": "0x8DC28AA6308EE7B",
       "checksum": "bb1fe44b36ee9f9a582588f43de48dd3942f74003b58a905965d4296a891d09e"
     }
   },
   "1.18.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC266150A6529E",
       "checksum": "fac30780d3f1e6dc57309c5821ec6241b5052867a70dc2edb7820161b3678de1"
     },
     "x86_64_macos": {
+      "etag": "0x8DC2661F65A0B76",
       "checksum": "8d2ee3058bdbb9fdabde3fac20006197941ba63c728b6a7c022a472bdb911d91"
     },
     "x86_64_windows": {
+      "etag": "0x8DC266194EEDC84",
       "checksum": "510033034d135e8cf863891139713ab4c311b01396f8b9b643d4598e9a8542ba"
     },
     "aarch64_macos": {
+      "etag": "0x8DC2661F5F3F44E",
       "checksum": "4d8c48a6f28c72527e7c6d081f9bed5d51b74f2ea44bbc05b96ff261b6189289"
     }
   },
   "1.18.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC2337AD83AADA",
       "checksum": "b6c0c0a5b097de77fa52b91f82ae2233da7c238044945447ae1ecbbc4a03f6e2"
     },
     "x86_64_macos": {
+      "etag": "0x8DC2337F58BD7F6",
       "checksum": "826d61d542d0a0434acd67c0b263d9d4deaff913aedfccd8390857456db5fc72"
     },
     "x86_64_windows": {
+      "etag": "0x8DC2337F4F7DF74",
       "checksum": "64f2756b5b3fe700b444843dee3cd4841cdf8f16feb1045327d7967c43bcb169"
     },
     "aarch64_macos": {
+      "etag": "0x8DC2338066E716F",
       "checksum": "9c39e0f59cd562c23c6072f86d7afcb9782cb82d31eb6d8a13f1626588918c35"
     }
   },
@@ -371,40 +465,51 @@
   },
   "1.17.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC190DE9468B7E",
       "checksum": "54b7092403a9ba85eed3f1f17c5952cdcd18545af0aa3d32a38a3a3b71ca8763"
     },
     "x86_64_macos": {
+      "etag": "0x8DC190E5E4E311B",
       "checksum": "c36ef165dd68bb8d94b2b93794b229e40e7dbe3010b421bdf44046bddd484fbe"
     },
     "x86_64_windows": {
+      "etag": "0x8DC190E1E50897A",
       "checksum": "50b2d57433999253979d9d2621b14450d6ec75edb063e35d5706ac7733d1e43e"
     },
     "aarch64_macos": {
+      "etag": "0x8DC190E04769AD5",
       "checksum": "25f8e64913e1c3338f925b517a68bae210149585f4de69601640f2bd65b12ff1"
     }
   },
   "1.17.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC13BA67787006",
       "checksum": "cf8744fbcace2a221fc141c4561b242ff2a2789f73c6741386b9451a62457845"
     },
     "x86_64_macos": {
+      "etag": "0x8DC13BABED3F265",
       "checksum": "5740e693e489f592cde54807f44d841fe190ac8307304a77e94437e83e5a293c"
     },
     "x86_64_windows": {
+      "etag": "0x8DC13BAC1564356",
       "checksum": "85ed4887d1518cce6e97434939048ef4dffc73452210ed1de546bf36901b2191"
     },
     "aarch64_macos": {
+      "etag": "0x8DC13BAC03135C7",
       "checksum": "166b3bd30b8b5d90bc79832da9677103e152d8e41c45a4707b05040bcdc8ab72"
     }
   },
   "1.17.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC0C0857815E4D",
       "checksum": "b7c3052a78467a38d48df6f495877964ec2ee920dc1543ae7b609553beaa6105"
     },
     "x86_64_macos": {
+      "etag": "0x8DC0C08809F7E77",
       "checksum": "7c5078c435e7eb76924d20431b26370d6f09eca3324c052d7ceec1daf6c89eef"
     },
     "x86_64_windows": {
+      "etag": "0x8DC0C0880B69603",
       "checksum": "ebe6749b2258ba264941dca0ecfb70a9757c80aeb6c305f2b698e304832f74d0"
     }
   },
@@ -413,298 +518,379 @@
   },
   "1.16.26": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC06FAE48B5C12",
       "checksum": "e5c6beffdd1f46d793b1d035e917724fa8e400efb0cc0bd5c83aa892a72a9ff6"
     },
     "x86_64_macos": {
+      "etag": "0x8DC06FB01EC455E",
       "checksum": "be70afbcfeda0ad7426c56307fa8ecc10e976016a82b58a203f92bc70f26336a"
     },
     "x86_64_windows": {
+      "etag": "0x8DC06FACB167B45",
       "checksum": "2080767701cd251fe283e35ec7259764a710d277baa055b7846a0c5a3eb50b52"
     }
   },
   "1.16.25": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBFBEB9FE5DE33",
       "checksum": "bf87976d6cb06275d6e0993113dbeddcec417ca442d8ed419cb93c0c39dddad0"
     },
     "x86_64_macos": {
+      "etag": "0x8DBFBEC0AD3C2E3",
       "checksum": "a617899118b0bc137718fb2463ec067b1ceaa76be614d8edc73df0a87764ddc3"
     },
     "x86_64_windows": {
+      "etag": "0x8DBFBEBDEEC4029",
       "checksum": "bf063ba9e73b63ac2e9c6c12b335ff9cac1f29be849ae82d6ec331c5ba45d81e"
     }
   },
   "1.16.24": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBF825CB0A84B5",
       "checksum": "2a6cde513daa86ff0e667584096a67807ae87f09fec3db9df150d58a3c539c16"
     },
     "x86_64_macos": {
+      "etag": "0x8DBF8263E08CF17",
       "checksum": "b367e9b7b642346ff4fdc00764df404a142c00022b462321b33cbc3bbe50a4b2"
     },
     "x86_64_windows": {
+      "etag": "0x8DBF825FBC59489",
       "checksum": "eae441d677876f717d2fa7bf3d30f068a2379d3078aecafa0045b63d11d4ce3e"
     }
   },
   "1.16.23": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBDEF2525C3983",
       "checksum": "1ac3dce7e92c52d247813d315bb15b2d1843623726128f5d09f3a1eab0e8cab1"
     },
     "x86_64_macos": {
+      "etag": "0x8DBDEF2D69A15DE",
       "checksum": "f5f55e9fa6ed044e91217ebf1efe441aef4899b47a1d2b1ce45163eea3d494bf"
     },
     "x86_64_windows": {
+      "etag": "0x8DBDEF2BC78B6E5",
       "checksum": "6d03906812c6604e0262bdf2c32821d631c4778d84991b846a8bc57229da7527"
     }
   },
   "1.16.22": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBDB0DC9BCB557",
       "checksum": "d0bb5ba46a835d51d5bb872453d8c3530b8bf9d6a2b0c48f2b8ef7aae0cf1bce"
     },
     "x86_64_macos": {
+      "etag": "0x8DBDB0DE7F09130",
       "checksum": "1e93d9a2c22da3b68924adb0dabfc2208c940c1630a9d41e6f30ffc7f15dd9ec"
     },
     "x86_64_windows": {
+      "etag": "0x8DBDB0DB5B42A33",
       "checksum": "a2f3bc46caed03f3a8e43ec9e7a586cbd009cd8c5ba4eeab162ec579def9fe54"
     }
   },
   "1.16.21": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBD6FF59BEFD4C",
       "checksum": "a9bc4f49617409ed4ae0f253dd319f5871c6d7a16c6f35bb5fe687572e0f071f"
     },
     "x86_64_macos": {
+      "etag": "0x8DBD6FFDF5BFAFA",
       "checksum": "da38a63a4594c84291a9ced1f902d55d69839081b11a2aadb884bc0f1ad1ec33"
     },
     "x86_64_windows": {
+      "etag": "0x8DBD6FFDF9174C8",
       "checksum": "ad9b97997f201cd3f4f4c6c04a2f3c96a7d7240abe0d313ded91b904c2821ce3"
     }
   },
   "1.16.20": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBCE7186CD4441",
       "checksum": "c60be908cd920b2dc8e4784de955910d4100b8340695a7e4606a1c947dc2f7dd"
     },
     "x86_64_macos": {
+      "etag": "0x8DBCE716F1E2E85",
       "checksum": "225300dc7ab8c738c753141c0fd447c3ffc8e297d464d1ea9679ec018e3328dd"
     },
     "x86_64_windows": {
+      "etag": "0x8DBCE71E0F93183",
       "checksum": "2180bccdfecef69f824688cbe329c8edeab98db507df75f349f02a9bc1257c69"
     }
   },
   "1.16.19": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBCAD2676A20FE",
       "checksum": "29e1c5e540d8bf3d39a7467122c49d798d3800fcf1c32b244e08a48c65204305"
     },
     "x86_64_macos": {
+      "etag": "0x8DBCAD1617147C8",
       "checksum": "1edc0c1689478027fcdbb399156b81290f9bebdf8caecd02b1b58eec99931b49"
     },
     "x86_64_windows": {
+      "etag": "0x8DBCAD15E423C08",
       "checksum": "6ed829ad60f64af8f77cc61f7f2c58f0ab6231265ef0538a9abbfb44cf2b60f3"
     }
   },
   "1.16.18": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBC907DA926F93",
       "checksum": "6b49334ab11aa7a1972412e85fe5477b6451c474a2c325928882762102ad1ed2"
     },
     "x86_64_macos": {
+      "etag": "0x8DBC907CEEF4CAE",
       "checksum": "8e6831efe3b1cf9ff95fc9d30830517ad6bb2d2b98065c05045c03db5261dd0e"
     },
     "x86_64_windows": {
+      "etag": "0x8DBC907F91DDE78",
       "checksum": "7e3836892f782f07d5a1517d1bdbd8dbe755b648377ae770e94b5c68b51e333a"
     }
   },
   "1.16.17": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBC389413E7478",
       "checksum": "9b6f8716c245d713bfa1f7492d52b676dcb44b5a5ba8cdaafb3e5ae390050e50"
     },
     "x86_64_macos": {
+      "etag": "0x8DBC38947C1F043",
       "checksum": "17a2c4451ef27707a074a7da928a6410a6d7c45aeeb2f2bcbd7acb456ea786fd"
     },
     "x86_64_windows": {
+      "etag": "0x8DBC3898AF8CCD9",
       "checksum": "e52121f3ae4a6823a03c6378b59325c4b99d33018f984438e8e20ebf9133574a"
     }
   },
   "1.16.16": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBC35CC4D6DC9B",
       "checksum": "0645ba7799529fe3edd9638e43b7dfc8021504e8f8d6e85c9bc39f4413218ca3"
     },
     "x86_64_macos": {
+      "etag": "0x8DBC35D3E44D8A5",
       "checksum": "9a7c13d2a94e9334fb43cb12095dd25fead4f0da3382bc256cee1cb6560c4305"
     },
     "x86_64_windows": {
+      "etag": "0x8DBC35D11A3E6C0",
       "checksum": "4951536fe8f4fa10fca10ea14f866b38c8f74113b6a8742f4b04a9e3c9a44fe3"
     }
   },
   "1.16.15": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBBF728D413216",
       "checksum": "aa8fa9bcf77ae1aa8f6f330c18e68b9ccf54de6e2a9be237889b7dfe8c860cf0"
     },
     "x86_64_macos": {
+      "etag": "0x8DBBF72B3D0AE64",
       "checksum": "d52574a88daaf1114a2101e6ae0b054a3c95f552bba4a8d6abe8add621070ee8"
     },
     "x86_64_windows": {
+      "etag": "0x8DBBF72F92D97BC",
       "checksum": "06241c68ca61bd84d5615eb013200893f73cc403d9d2784303a4ad68bf1d4473"
     }
   },
   "1.16.14": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBBDF3AA770D87",
       "checksum": "6b5a5335903132ef0514734e9a11d7b5a0450c83db9296854eb5f6315385c3bf"
     },
     "x86_64_macos": {
+      "etag": "0x8DBBDF40C81CBE7",
       "checksum": "99fca753e8003ade13122923c7168358f513118605b509a26863f3551f4005d6"
     },
     "x86_64_windows": {
+      "etag": "0x8DBBDF41DCBD094",
       "checksum": "e9fb8e4825a6d092b7b393e621265977bf877735a980095ad3fe97be617f61f6"
     }
   },
   "1.16.13": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBBBCC34C3E379",
       "checksum": "38176cec255069c8a2e6919d4172114023d72ea34303999b7091a0da94a7c823"
     },
     "x86_64_macos": {
+      "etag": "0x8DBBBCC5195DBDC",
       "checksum": "d5c3d9babb96e18f8ef5675ae5bd0e328b3783273c11ed18ff4b51b5c46ca1d8"
     },
     "x86_64_windows": {
+      "etag": "0x8DBBBCC803AE407",
       "checksum": "bd222a8abd392f2212daeba053b1051f886fe61595c94cde3f9b855a6cb87c7f"
     }
   },
   "1.16.12": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBB87B65744D33",
       "checksum": "885f12710f0e415fb7daa213619c02b0cf7a8df68e31be6a02b9ff96c2d8dbe4"
     },
     "x86_64_macos": {
+      "etag": "0x8DBB87BBF3FF7D5",
       "checksum": "78182280b6cbfb1cbacc20c85a6cd6b0ad07917f53fa091d75a53cf1a36a4581"
     },
     "x86_64_windows": {
+      "etag": "0x8DBB87BB6A5BF08",
       "checksum": "41a1e5ffff3553ca1245457f48c66891e0bea6d70eedfd9cd5b24cd0a8b17594"
     }
   },
   "1.16.11": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBAF1989B05E91",
       "checksum": "ffe3e07a797ef4ae6d992a10c9d59070004e864b1558fb1233a1baa4b45f396d"
     },
     "x86_64_macos": {
+      "etag": "0x8DBAF1A0B27EB79",
       "checksum": "310a25c9d9bb1f3706f0b9d865834c5dc885f8f33aa442e9e1dba5c43b42a564"
     },
     "x86_64_windows": {
+      "etag": "0x8DBAF1A6229F8D4",
       "checksum": "7d01f8f976b1e883b9349c70f43f398a763e0840efe4b1e32b4142314b7a3141"
     }
   },
   "1.16.10": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBAB32E519BB51",
       "checksum": "4fc2966a7d79d6ada15d9982613f97b0a891669a03fe142f5793ccce78794f3b"
     },
     "x86_64_macos": {
+      "etag": "0x8DBAB32F376AAB6",
       "checksum": "87b7b82fb3f078c0e2c1d0e1b92f45cc4900475c5af76e06b2eaddc3c364bfc7"
     },
     "x86_64_windows": {
+      "etag": "0x8DBAB332F7A3EB8",
       "checksum": "04d643f508ceaced83cb5619d1ec9638783723283ccebf4157e81fe0216ce5a4"
     }
   },
   "1.16.9": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBA97171709370",
       "checksum": "fbc3df32c12482c51ca93faf8582afef8d8df25afd87d4f4f3f792d4578e2a14"
     },
     "x86_64_macos": {
+      "etag": "0x8DBA97181C6A45F",
       "checksum": "2d10fd8bfed1141e92b03d0d61de4dbb0589a9482782d9572aa032f866a51397"
     },
     "x86_64_windows": {
+      "etag": "0x8DBA971A130B355",
       "checksum": "fb8f80fa3589f63f2fc1fbaa6401335622a10b95452665557c7b3a672bd421c4"
     }
   },
   "1.16.8": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBA2731DB0F200",
       "checksum": "f722e1b7c5b5a605b5ad75664d2abf8c3c885ea432c573faa44ac99b7e38b390"
     },
     "x86_64_macos": {
+      "etag": "0x8DBA27389BCA20D",
       "checksum": "f78303a62bfbd1e198188dd49a6f36419d95e8377c5c208cea019ebe564b6686"
     },
     "x86_64_windows": {
+      "etag": "0x8DBA273ACE47FEF",
       "checksum": "165bf0812fdd24ca8ff6079c069789a0888dd2c222b96c46ab80808a7625ddce"
     }
   },
   "1.16.7": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBA25D84C1055F",
       "checksum": "84af22acc590944df52b86b09b465ee4166dc4056bb1b633fbc0a4bb5e537fd4"
     },
     "x86_64_macos": {
+      "etag": "0x8DBA25DA89D81F9",
       "checksum": "53b2713bd753abac5bf585ca4a4fe6d9475616bc56c25447ef1bae21c5e67b8b"
     },
     "x86_64_windows": {
+      "etag": "0x8DBA25DF82A18E2",
       "checksum": "07e2b826016e15bd575f95d5c2f4daa17217217476153a8021976510fadeeaa4"
     }
   },
   "1.16.6": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBA035E9474001",
       "checksum": "1b5eca4bebb33a2d11671b45db056966de64375efdcd5779c0a45814bdf1495a"
     },
     "x86_64_macos": {
+      "etag": "0x8DBA036B6278B61",
       "checksum": "567af5c7a3ddde218a1b960b52efc80914e21d2731e777fbc1dd41359dc6680b"
     },
     "x86_64_windows": {
+      "etag": "0x8DBA0362B9954E6",
       "checksum": "0485b6f60864b45476c0fa23134e527df3ce43138dda3eeaca58f9aa66fc93c9"
     }
   },
   "1.16.5": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB9CD72DA5B207",
       "checksum": "b4c942b0a8362c571974775ea238bc04ce5a95a2673152322bf4cdada8d20523"
     },
     "x86_64_macos": {
+      "etag": "0x8DB9CD76EA01F64",
       "checksum": "9bdd866137209b9d8da4fdd8a13d3dc20a25c24a9513f747631b2a31320e4d73"
     },
     "x86_64_windows": {
+      "etag": "0x8DB9CD7D2DCFA5C",
       "checksum": "c0af21f649d02dc0865fe0583ab608cb5bf9037666a03dfd52404ed1bb6affca"
     }
   },
   "1.16.4": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB9AD471294806",
       "checksum": "d39ce68b6ee23a47af96d9fbd06a23e0f128fdb503a33c3f97965e87953f46f2"
     },
     "x86_64_macos": {
+      "etag": "0x8DB9AD4ADDCF747",
       "checksum": "3c1fefc12d3a1a6de2112b6e9df4ca7082a7f82ab1325bffd23a635ee33aa6f9"
     },
     "x86_64_windows": {
+      "etag": "0x8DB9AD4DB07AA57",
       "checksum": "e718adb4ab32b1a59dea0caa3c7b337d3d53afc3eb17556a34598b6ffe3bd0a5"
     }
   },
   "1.16.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB98DEAB59B860",
       "checksum": "db083ab85af96e4d913dc234c07d8bb84a8d82a654d8dde120cdbac45ede8f41"
     },
     "x86_64_macos": {
+      "etag": "0x8DB98DEFB1AFA69",
       "checksum": "4d711113d949205494c07faf206755687e280e769d71134ff752dc1977db0bfd"
     },
     "x86_64_windows": {
+      "etag": "0x8DB98DEFC7E2B56",
       "checksum": "23755bd2231cd7822742dbd5025ec52881a4e16c9c593065db9ff17f8f7132d0"
     }
   },
   "1.16.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB92A748DCF1A9",
       "checksum": "b0c24323e0bdda88026295643ca627679a9eb768ee820b54aa688bc376b72b3d"
     },
     "x86_64_macos": {
+      "etag": "0x8DB92A747DF641F",
       "checksum": "97c5fdce9039ae00349ba109112478b39dffc78078477476ba402f8550e8047a"
     },
     "x86_64_windows": {
+      "etag": "0x8DB92A7B4475802",
       "checksum": "a0748dfe0a7b4691bdb4b13fe46c074af72564925106d479b9872bd27484dcdf"
     }
   },
   "1.16.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB84A0FD169AC2",
       "checksum": "fb8871605b0fb5bf9c71c91b43d2741b3f3554991bcc9b868489a3615ab8ba6d"
     },
     "x86_64_macos": {
+      "etag": "0x8DB84A13340AE80",
       "checksum": "14a10d936d616037e6acaebd9a51f8c1f133c6ee449717190bec094444354e9a"
     },
     "x86_64_windows": {
+      "etag": "0x8DB84A0E586D2A9",
       "checksum": "1b7a83f751515139ae46299cc85caf6cf4d1e4fc252cee32dd89bacecbdda95c"
     }
   },
   "1.16.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB8157927BAFC6",
       "checksum": "c128933b6fe42af9cdffe068b3f9ddc7810ff511e5cbda349f006c1c7a4b3670"
     },
     "x86_64_macos": {
+      "etag": "0x8DB8157A2D7A260",
       "checksum": "363d536316d9837a44515c7966b86872eef4b94225a391bcbdf66179d3b1f889"
     },
     "x86_64_windows": {
+      "etag": "0x8DB8157D512321A",
       "checksum": "56486f9ff231467f67d88d71e14a92e03ec6e9afac95dfd13751895409b0e95f"
     }
   },
@@ -713,122 +899,155 @@
   },
   "1.15.10": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB7BD39CED5B47",
       "checksum": "cca547bffbb064476a9b8eb277d9af8f1e07cebc4ed65dd30d6a9eeb5ef6ce16"
     },
     "x86_64_macos": {
+      "etag": "0x8DB7BD3E3C97B9B",
       "checksum": "82ebb2cd105489d9aa3850a2be8860c7f9fa7b2b0595cde51ac059180b97b1cf"
     },
     "x86_64_windows": {
+      "etag": "0x8DB7BD3E79749C3",
       "checksum": "1cb66b4779066ece860248043b41c891d9fbb15b17bbae48bac7f8c5b4d2d8fd"
     }
   },
   "1.15.9": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB79795048A334",
       "checksum": "72612f8c108b778ac47e0b83c9c2786cf0ec2f389bd88a16dacc40664f2543bb"
     },
     "x86_64_macos": {
+      "etag": "0x8DB79799F1D51EC",
       "checksum": "b9f1b18993f1f636a5db94e5421c7788d845c7bc62c0fe15e791c43ce09c3b6d"
     },
     "x86_64_windows": {
+      "etag": "0x8DB7979CC7A8A87",
       "checksum": "eaa9ba176f512650ba675da82b3be6a4c038a82c9227a6197ec3a7f81766aaa6"
     }
   },
   "1.15.8": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB78BCDDFACA44",
       "checksum": "92401ba4cb694fbc4062e4de7e118452856f107bcbdc384192ca1fa3b62e3aca"
     },
     "x86_64_macos": {
+      "etag": "0x8DB78BD119B4E4A",
       "checksum": "ec8222eab90114ed251aceec9ab4ba55604496c31df689b3b9233d0b7c2dc277"
     },
     "x86_64_windows": {
+      "etag": "0x8DB78BCEF8FC0AB",
       "checksum": "c4135edd467b87597cd9c7fcb0b6daf9a4b195182397edfeb1d64bdf154cfb69"
     }
   },
   "1.15.7": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB76871D7A69B8",
       "checksum": "c9530c641d685ee0564d69a78c3b349a66e81f2b2f97a265a2c4df0e88f302ab"
     },
     "x86_64_macos": {
+      "etag": "0x8DB7687367EA2A2",
       "checksum": "ed9a5ab015e84a13aa0d4ae23bf3fe6ccf5a0aa1b0843c6494208811ac150402"
     },
     "x86_64_windows": {
+      "etag": "0x8DB76874A9FF234",
       "checksum": "47807f62de3f557a306b342d44b10ae3a5e2d5aca57302c2a9e0d47a7f1dd250"
     }
   },
   "1.15.6": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB764F37423105",
       "checksum": "56e3ce2da3e9134eb5d14effa08f1efce1ef999fef57d0467dfdbca322ece9b7"
     },
     "x86_64_macos": {
+      "etag": "0x8DB764FCA30D4EF",
       "checksum": "53379d7e6926f5e42e9116f7f9b2958938a3cdcd4a5baa2c52d21c85573378f2"
     },
     "x86_64_windows": {
+      "etag": "0x8DB765002561311",
       "checksum": "979aeb4ae53607456a1fea2705ef68adc92b6200d8caed6a2baddafb2bc1f600"
     }
   },
   "1.15.5": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB7347B746DC06",
       "checksum": "9a7caa97835658aa8b538e69c1339ae9a35ab931e75cb32bc46b2f47c6daf0b6"
     },
     "x86_64_macos": {
+      "etag": "0x8DB73480257CC7D",
       "checksum": "31204863b75471e307db3304647aa87cd26a3909e18b8f7a024598e480cc227d"
     },
     "x86_64_windows": {
+      "etag": "0x8DB73482698A698",
       "checksum": "6558b566197eaa3c2182ade92bf90522d22b183d4bd1dfad74f1914a22ed280f"
     }
   },
   "1.15.4": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB73346F99D7E9",
       "checksum": "92612ac191643d03dec4b1557a1611dee7ac4cbc273e44e985cf2f0299b3e773"
     },
     "x86_64_macos": {
+      "etag": "0x8DB733465A22DC3",
       "checksum": "25c72846244613a90b818e94ad3a669930630a3c0e9dbbf389587b8734e227be"
     },
     "x86_64_windows": {
+      "etag": "0x8DB7334C17B9841",
       "checksum": "a91ec0a021761be47ddf6889fe87a4bf25be04fd99f76a66b0b187bb90b1656f"
     }
   },
   "1.15.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB7291D2B64CBD",
       "checksum": "9c2ada9c1dbaf443e992f955c3d3c276a31171464047e69454cfff11bf3ca935"
     },
     "x86_64_macos": {
+      "etag": "0x8DB72921280228E",
       "checksum": "3c66254cf6ee8bae1f8a47bf2aa8b1eb9976a248fdd1e5d9a57bf6dce0f1ccc5"
     },
     "x86_64_windows": {
+      "etag": "0x8DB72922AA06CFA",
       "checksum": "73a7924c1df5a2a4dd85bde1da4cb9a1967000236778c42d9b666459ad09e501"
     }
   },
   "1.15.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB719AE75A6283",
       "checksum": "f9183a149fdbad516fe27dbe0211a5eb71d8b265099ea47addd7fa50c4bc06cb"
     },
     "x86_64_macos": {
+      "etag": "0x8DB719BAB95A3DA",
       "checksum": "b9a3bd44227c0d7dc3b05cf248c32daf7d01bc52ff547cd916cfad74bbf947e0"
     },
     "x86_64_windows": {
+      "etag": "0x8DB719B13891886",
       "checksum": "01560f0f26c758819a37d79d505ccbb2e698c742f3331c77d3d302268fcaa057"
     }
   },
   "1.15.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB70DB430C8498",
       "checksum": "c28b3768afbec3b22621d6b6270c31ca937f4749c2104bd57c513775361f5a15"
     },
     "x86_64_macos": {
+      "etag": "0x8DB70DB9B36C24F",
       "checksum": "ca849a9102e22a4e40eb1be686f01e58e615e9f44f3541a4a29f179c83f0349c"
     },
     "x86_64_windows": {
+      "etag": "0x8DB70DB9D59D245",
       "checksum": "ffd2d523cef1bcc3757e7f9c8a423b00cd3c26e1c31f51679c1618cad3c1bfdb"
     }
   },
   "1.15.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB6835C63E20A3",
       "checksum": "5349378a7e431563b1f6e12f85a5dcd4400ef94343f3008b274f5eb294bb7381"
     },
     "x86_64_macos": {
+      "etag": "0x8DB68374EF1A1C8",
       "checksum": "a793a6d542be73c677223f0e4ae994c14b2b667295d61de5804e29e053054af5"
     },
     "x86_64_windows": {
+      "etag": "0x8DB6835C9CCE2B5",
       "checksum": "d53ceb6e0dd436996dfcfa8332425ba84ac9d5e60afbbafd211c385b42aaa088"
     }
   },
@@ -837,144 +1056,183 @@
   },
   "1.14.12": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB63041552C367",
       "checksum": "c8b4da00fd559a06efd187284117088974206f399c2c6a44cd8a041b55ea629d"
     },
     "x86_64_macos": {
+      "etag": "0x8DB630481832C6B",
       "checksum": "5670ed5f3ae98af8277ff78ba9245adcef35af0d2dd5984bbf962ec240ff65ae"
     },
     "x86_64_windows": {
+      "etag": "0x8DB63046ACE8EA4",
       "checksum": "cf667f72aa34522e4916a0aaa3e586db48b4d8e0f5de561d3e59e77a15954861"
     }
   },
   "1.14.11": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB5B0274591F93",
       "checksum": "a4f78208a6f4c592b0742e3b854950339140695dc9339471f58baa1d7fcad788"
     },
     "x86_64_macos": {
+      "etag": "0x8DB5B02FC070A28",
       "checksum": "1ff4dedf1ed88f3ddae4a89fa056a10747afa627aea0c4f33f563c96cc3bb5b6"
     },
     "x86_64_windows": {
+      "etag": "0x8DB5B02DB144AA3",
       "checksum": "b05114c370179d613a993873543ab1058268a16c96ed616fa8d1d56ff49f0abc"
     }
   },
   "1.14.10": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB58720D7CAFA7",
       "checksum": "300964645e5980efe736e3838445d701520e6a4b59ab09765fcdc593ceaeda88"
     },
     "x86_64_macos": {
+      "etag": "0x8DB5872722FF787",
       "checksum": "11ac23f5451a2627de601086704e0d9a974d7d20e7873d8f0155a66eba211ab3"
     },
     "x86_64_windows": {
+      "etag": "0x8DB5871C6154EED",
       "checksum": "60c2fc4eae4af969e7be85749d648d7ac0c19d285f15d8964ec894ed4052c302"
     }
   },
   "1.14.9": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB4BDF9E01EC9F",
       "checksum": "146dbc2793a8cf4094f404cf37c58e62892da24819d335478c1e1b8c06578282"
     },
     "x86_64_macos": {
+      "etag": "0x8DB4BE01FE6F25E",
       "checksum": "160e247c922c897c466a5b758d075f2f5d9d2dba89f009346fbb25203038318f"
     },
     "x86_64_windows": {
+      "etag": "0x8DB4BE07A3EED22",
       "checksum": "617388136b8a8233ac9472c9834658a9f1730c3b4815f11c1e403adf6893e0cf"
     }
   },
   "1.14.8": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB40E661DF7BB9",
       "checksum": "1f0338c64b324514a2bd5b745ffcc4be999b58c1393212d4e26fcc877ae00e6b"
     },
     "x86_64_macos": {
+      "etag": "0x8DB40E675B12D3A",
       "checksum": "724b8197f1e0f82b3ee1ec83297b6b144319c15abc91719a0672bd089eab272a"
     },
     "x86_64_windows": {
+      "etag": "0x8DB40E66FFC75E2",
       "checksum": "ad3b0551e74b2215415d5519704f4fffe61aba7c3395f183f24dde6126b02ae6"
     }
   },
   "1.14.7": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB40DBCB0F3027",
       "checksum": "d368934a8e65ee56a552c68dc3bb34c51e2e968986870fcf418721b4a4e2e63a"
     },
     "x86_64_macos": {
+      "etag": "0x8DB40DC3295E000",
       "checksum": "48e5fc2eb64d18e30c1f6e1e47ec80292886df16af76cfe517af18368a239147"
     },
     "x86_64_windows": {
+      "etag": "0x8DB40DC2FEDE1D7",
       "checksum": "e5b33b92078abcc1e6a5886e067a20cfcd6d1db25e43fa9ca81f428c9526863d"
     }
   },
   "1.14.6": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB3C3D99548F6B",
       "checksum": "27ce43632f09d5dbeb2231fe6bbd7e99eef4ed06a9149cd843d35f70a798058c"
     },
     "x86_64_macos": {
+      "etag": "0x8DB3C3E340994BA",
       "checksum": "a6f4844dc0f5a585d2f3fb99aa67f67193c70351440e58a07997fbbb96375b38"
     },
     "x86_64_windows": {
+      "etag": "0x8DB3C3E5360EEB6",
       "checksum": "b467715ddcd9d6d35edd6bfd441be6790ab3f9b9faa817a20595644e390c3426"
     }
   },
   "1.14.5": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB3519AC578C99",
       "checksum": "f2de58d4ce7efab743863d193043d79377eb94766271c1768ed44be8398165f7"
     },
     "x86_64_macos": {
+      "etag": "0x8DB3519D130A011",
       "checksum": "25dc8e811379a270297c39c6def9f3af9fd6b8c4b5c9a5d5ac42ffad40b12cfe"
     },
     "x86_64_windows": {
+      "etag": "0x8DB351A0FBFC774",
       "checksum": "68a447dbd742d144bd106551d1ceb848c0c20d1e14abeaa1289d3259883e9065"
     }
   },
   "1.14.4": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB345A8AD17824",
       "checksum": "91de0b9d37ac5c3615b20a93e1cc55813f0501f935a9eabf711a8a350326512e"
     },
     "x86_64_macos": {
+      "etag": "0x8DB345ADA3FEE8F",
       "checksum": "4f2c7184629bbbbeaa4de889d1866e1fc6509073593e378a67d7944d0d5a704d"
     },
     "x86_64_windows": {
+      "etag": "0x8DB345ABBF55268",
       "checksum": "6a54b553fe400d33ba08045c41861d72f4c1ea29102880b6a196d619ea9189f7"
     }
   },
   "1.14.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB2B3B6EE5289A",
       "checksum": "8883f651b95c4f042ace10d599375b1874a8ff2dab6eb0be9f79a14cca3eb3d9"
     },
     "x86_64_macos": {
+      "etag": "0x8DB2B3C41F2CBBE",
       "checksum": "c73bb3dbeaf4412fb48899252a82597655fd411cea0abf6b63e065b71bec7a80"
     },
     "x86_64_windows": {
+      "etag": "0x8DB2B3C1524E8E5",
       "checksum": "88a82e2ea53beb8e39eb3029de6117a7f1f1ad12309321be6a0545b3abd90ae1"
     }
   },
   "1.14.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB2B19395EAB0D",
       "checksum": "f44867d451692164d75efd98a712d6a8193fd3a2b7d0fda54acfb0bc3179c9d0"
     },
     "x86_64_macos": {
+      "etag": "0x8DB2B1976C114E0",
       "checksum": "70765c69624804fef4a8d846258c36c688fd99a4c46a09f6fce2656173c960dc"
     },
     "x86_64_windows": {
+      "etag": "0x8DB2B19A8D52DE3",
       "checksum": "dd0037d46209502ef4021ccfaad621111685c2d6301cddce4f6de4e10dadb7fb"
     }
   },
   "1.14.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB2B06D9CAD906",
       "checksum": "67ef274bfa81bb3ceea64bf4bda2646ed3f80c6a6138254c0cf66290c4d16b51"
     },
     "x86_64_macos": {
+      "etag": "0x8DB2B077C2B9680",
       "checksum": "3372e1c5476f3aa664476daded13a75b32d4eb7787fe340b703fea8dccd914e8"
     },
     "x86_64_windows": {
+      "etag": "0x8DB2B0706DB0D5B",
       "checksum": "89fd5b1a9e9a08dff21f30702fd4a6c06e295db43e0e5255fdcf40b20fab87fc"
     }
   },
   "1.14.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB2AF5EB86F18B",
       "checksum": "9c668df0e6b7e506552a736d9d12c67e8ff64edf028f9912a94fc8741e8ec54b"
     },
     "x86_64_macos": {
+      "etag": "0x8DB2AF7CD8BA2C9",
       "checksum": "65c4a77c48ecf8f8a54954401cd7247775cb2e40032cd726b00fbb7d323db9c3"
     },
     "x86_64_windows": {
+      "etag": "0x8DB2AF6817AF706",
       "checksum": "0d03941d3b6b0c1eed2bb92e85ff0983b8d4cf65b8d4071a133c39682539c4c0"
     }
   },
@@ -983,273 +1241,347 @@
   },
   "1.13.26": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB2635DB532D00",
       "checksum": "4e627e72790b647f3c835350a4e299a9a865efbb3605a0d1e1768b461b1a57c0"
     },
     "x86_64_macos": {
+      "etag": "0x8DB2635FFABE594",
       "checksum": "34070278f96ad75325194d2574fd0852b5d2134df8d579771c2cb0951a671de0"
     },
     "x86_64_windows": {
+      "etag": "0x8DB2635858021B9",
       "checksum": "e4aaaa3bd30f50bb89490a752280f38323e3070dbb73186deea6316b22cbbd34"
     }
   },
   "1.13.25": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB261E747D60FB",
       "checksum": "d0985d1472af8b52ddd06a982c6c98a6d3dcfd563017fac93dc62e4445d550a1"
     },
     "x86_64_macos": {
+      "etag": "0x8DB261EB6947B91",
       "checksum": "09ab81d506b40d0030a26d8ee62c94b9e8bfb4ba6f8f76195c9715cd8c883618"
     },
     "x86_64_windows": {
+      "etag": "0x8DB261F369562FE",
       "checksum": "e40852663d6737f0ebfaa8f6ce1b9b49c8d842281df97aafa674f4736c2102ca"
     }
   },
   "1.13.24": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB2561AEAE2BB5",
       "checksum": "99a9bffe322034284fad397c2a511edc75503803549e4a4b28317064f344026a"
     },
     "x86_64_macos": {
+      "etag": "0x8DB2562DB2ABF02",
       "checksum": "4ed9572539521632809ed9306b62dee2cb2d038b5a68d981afc7f69e3cc57563"
     },
     "x86_64_windows": {
+      "etag": "0x8DB2562B69D47DB",
       "checksum": "370845521fd37c00d3a885c0e9b91c794346f4a1d0349b0ad2189ffd6973087b"
     }
   },
   "1.13.23": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB24A58B7FD5E3",
       "checksum": "9704ce98e03c909c4e09239fefa0360e3d17ca0737436d8281a00e5b21337864"
     },
     "x86_64_macos": {
+      "etag": "0x8DB24A591F64D2C",
       "checksum": "f155060e980d7ce4244ede74f3efcb6dc93d9b78ca087a8316dabeda96b96f52"
     },
     "x86_64_windows": {
+      "etag": "0x8DB24A59D9DCCBA",
       "checksum": "4387e21bd8c99095c1950282747857e67311f0c553a63b87b5aad030f4724070"
     }
   },
   "1.13.22": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB23EAEE329C51",
       "checksum": "25fc68ffe700dec3330b2a924babf11b2d2e311e01861c13f132352eac1d3d31"
     },
     "x86_64_macos": {
+      "etag": "0x8DB23EBA45E4CC5",
       "checksum": "ffaa5ac80db1f51f5a38f838e8cbaa76939ed1ac39604381c581c43c234f3061"
     },
     "x86_64_windows": {
+      "etag": "0x8DB23EB5A2A364F",
       "checksum": "b9e767987fd2f443163c3450b0e21f012aa28d9dcea7f2817bc9de95e11f9d22"
     }
   },
   "1.13.21": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB23E574BF22A9",
       "checksum": "64551f025a79727403c19ece7c21e4839fbc6c7148e62ca7cfdae91d598dc26c"
     },
     "x86_64_macos": {
+      "etag": "0x8DB23E5A3163757",
       "checksum": "c07261a78a382855dcc413948f3a7a12829e220737e0a142380339218ef710db"
     },
     "x86_64_windows": {
+      "etag": "0x8DB23E596052456",
       "checksum": "58b180039c4d9b34c97316f115d85abff27d0c0e8b1108e3b90583fac9f4eea5"
     }
   },
   "1.13.20": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB20B3ABA1D21D",
       "checksum": "b3ef130fd88b49ea6c79a78ea678ee10a0ea43ff73611aac9a08decf1366a589"
     },
     "x86_64_macos": {
+      "etag": "0x8DB20B3AF398D18",
       "checksum": "222a0d0d74aa1d65ad10d6698e9a1d631413a8f962a115a1023c430da79a54b9"
     },
     "x86_64_windows": {
+      "etag": "0x8DB20B3C9CCC002",
       "checksum": "65da012bfe04ce5c3f00ec5cb2517a5830be991e6c1ce5a043d91cd941bc60c7"
     }
   },
   "1.13.19": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB204D9E204893",
       "checksum": "32647825a6038723702ccb12259c8477d7a750b691adf8ebf3f0f3a4d37b6ccc"
     },
     "x86_64_macos": {
+      "etag": "0x8DB204E4036BE61",
       "checksum": "a2f19846a52f17b1254a7927592da003cd58e6779108230c2683b75517f5c5a4"
     },
     "x86_64_windows": {
+      "etag": "0x8DB204DC025EC94",
       "checksum": "d28c1e138da8c0827e5020279c7458c92768f7b62ead848f5a41249bb7f6c208"
     }
   },
   "1.13.18": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB1E58D3AD2C09",
       "checksum": "e200fd300b302fab5d7890e5bfca274175f29b7f5368b2a3bd7f9dba98d5567b"
     },
     "x86_64_macos": {
+      "etag": "0x8DB1E58EDD48122",
       "checksum": "a4cf0bb833962d6258f51fcb1e4b6bdfe2f4d0f0eb3223eb8f27bd0274401700"
     },
     "x86_64_windows": {
+      "etag": "0x8DB1E590A93D6B9",
       "checksum": "e6be53a84c9eb14474bd52911814889ca7473536dbdb3a2e694742258364c6bc"
     }
   },
   "1.13.17": {
     "x86_64_macos": {
+      "etag": "0x8DB1E56AFD9132C",
       "checksum": "782b62a30a3798662e8941b70861deb5dec366662e01e4ce944edfbecdbc0305"
     },
     "x86_64_windows": {
+      "etag": "0x8DB1E5680011CA6",
       "checksum": "555c71fb703f5f00672b24322e03fe4b9d2d4b8bd82db7ff5c98c3012a8f67f7"
     }
   },
   "1.13.16": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB1ACBBA3B478D",
       "checksum": "62a20f6cc2063d971b94b03b3658b5271b9d627c52e70b81b181bbb0e49aefc4"
     },
     "x86_64_macos": {
+      "etag": "0x8DB1ACB91C34562",
       "checksum": "544e524d92d1cae1b2d4b3c6c1fdfadca5b498af9e58fba3de9cde9c6c6b1ebe"
     },
     "x86_64_windows": {
+      "etag": "0x8DB1ACBA2F81124",
       "checksum": "be1823ccd736f1ddfe8fe64dc4ba7479597c08543a013c3d613ed24443efc3c3"
     }
   },
   "1.13.14": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB19BB7FBA05C2",
       "checksum": "079dc5783bd1ab99fd6ea803e74d92cb618fda79c7eaf1e651c1e085d9405d68"
     },
     "x86_64_macos": {
+      "etag": "0x8DB19BBC88B3F5F",
       "checksum": "6a9976871b275719124625ea8e9730cccd00e762b599a897fccd9bef21dda2e7"
     },
     "x86_64_windows": {
+      "etag": "0x8DB19BBED252C85",
       "checksum": "9fa01401e2deb422b9efa1c316145b8f2f5d86b79f42b25dbdde8bc825cdd8ed"
     }
   },
   "1.13.13": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB19B5BBB22ECA",
       "checksum": "7c861f869f8a92e37067e92271a9599ae71a5529d87ade1c50eb005bbc36a9e7"
     },
     "x86_64_macos": {
+      "etag": "0x8DB19B6549A8948",
       "checksum": "479bef1ddd02f46f75af5973f80feb6ca7b6bbdda74a5d8248b9ccb71ccef389"
     },
     "x86_64_windows": {
+      "etag": "0x8DB19B61A1725B1",
       "checksum": "1c93cd3b5b9c6b66aca86b85c148e8c488587a8c04fe6b038a5bb4215670e304"
     }
   },
   "1.13.12": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB15D22DF2D295",
       "checksum": "4342d15e1be4f0013cac952bdc1fabda7c7962c6ed64caf717a99c944c87dd86"
     },
     "x86_64_macos": {
+      "etag": "0x8DB15D2B8E0EFA1",
       "checksum": "c71dac9fb51af310ff302de03b5106e6f65c74e6e0fc230b8e47e276ccf1289f"
     },
     "x86_64_windows": {
+      "etag": "0x8DB15D288869441",
       "checksum": "9740bf30776cfa279ba0c3acb6ea0f75b906378a541c99a21ddfc322f5fb1e2a"
     }
   },
   "1.13.11": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB15BDD54E80B4",
       "checksum": "3cfa2143192eb66acb3dcddb8c35a4ba06dc29adc3223d8435c9242d972a6f7b"
     },
     "x86_64_macos": {
+      "etag": "0x8DB15BE0AEE7A38",
       "checksum": "3e86c2c45cccb036ff1a6e4a0975c41b5a8157e96eeb53d556652d66e952413d"
     },
     "x86_64_windows": {
+      "etag": "0x8DB15BE44707378",
       "checksum": "f586efa78fcb280c0ec5fc3a755108242ce13be6ab68973c63da697e28af3771"
     }
   },
   "1.13.10": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB046F546347C1",
       "checksum": "ac5a8fa50030a2fd52c08b828998edbeddab568fc99bd36ff73843b75c3380b1"
     },
     "x86_64_macos": {
+      "etag": "0x8DB046F843DDF78",
       "checksum": "941d6724932a7ed69d67b3a6613b5c38c33f8aab240b271e399722e9eea21c21"
     },
     "x86_64_windows": {
+      "etag": "0x8DB046F9C5939E1",
       "checksum": "80a399a4aa5c85fd3624c175c9078f9e0299196541c3f37152ceecdc57e9ebf9"
     }
   },
   "1.13.9": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAFEF2469D5722",
       "checksum": "b21e5ac2a973eff32c4c764f6a39dafe372d5c67a2842962014ba529e84c8a78"
     },
     "x86_64_macos": {
+      "etag": "0x8DAFEF275ED7A0A",
       "checksum": "9c700139136f7ac5c5d03f94afc2445c99b7f82c3df15bac1c24cbc2b7a3f7b9"
     },
     "x86_64_windows": {
+      "etag": "0x8DAFEF2A6B7A8EA",
       "checksum": "55ac42260bf44f4826ce330992883760a154a0c494ccf2135c3da3e625e395f1"
     }
   },
   "1.13.8": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAF7D0B8A7D4B8",
       "checksum": "a98e12c42251d07f1f3f649cb0a94d8cd4a890c5f88b594485e471675579c9a5"
     },
     "x86_64_macos": {
+      "etag": "0x8DAF7D0D0C21ED4",
       "checksum": "aef083b5f74d0307c9a457cd2a181c3eaa18c865b29bd49500f554a62ba7384b"
     },
     "x86_64_windows": {
+      "etag": "0x8DAF7D0D0E83ED4",
       "checksum": "46dd67c0cd563ba0b3f51d1c92e2794fffca82b3a4f97606accc061349b7d5ff"
     }
   },
   "1.13.7": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAF5DE951FD61B",
       "checksum": "305cc50a52b8ed7b0368d26d4d7849f3e4b557032076a9dbbfa471042d1daa41"
     },
     "x86_64_macos": {
+      "etag": "0x8DAF5DEFEA1DDA5",
       "checksum": "c05bd5934a832abac759228f9345cd6360b0a24d50a26a2e1c8e20f60c0d002b"
     },
     "x86_64_windows": {
+      "etag": "0x8DAF5DECE61AC7E",
       "checksum": "8dfabd58615727fb373fdb890885f2645ae16c99d090c1e0eaa4e999ba7c271f"
     }
   },
   "1.13.6": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAE2CAE84A6AF1",
       "checksum": "51d712cdada5aaf7496243551a2d600493198a75a14d35cdcfedd7913808f9b5"
     },
     "x86_64_macos": {
+      "etag": "0x8DAE2CAFB1A1306",
       "checksum": "7fd9407df825fda64a9ab77850996170311aef61af4583c10d18556e0f6a93b1"
     },
     "x86_64_windows": {
+      "etag": "0x8DAE2CB317DA6BA",
       "checksum": "b4659afb75f846c7c9e391ea148cf3f5b24139f9abf1f91f876003ae51a1c311"
     }
   },
   "1.13.5": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAE1D09A76FE50",
       "checksum": "2da74a3c46a432398f6f4c7f92b52fe75bba6827be912c3cce767ef29a3198b9"
     },
     "x86_64_macos": {
+      "etag": "0x8DAE1D0F930FECE",
       "checksum": "e875814eef75f8d62aa569c19065fac8c3568717f09acdf6406fe7aa8935f64a"
     },
     "x86_64_windows": {
+      "etag": "0x8DAE1D0F0881548",
       "checksum": "aad26447e57a0773385ca29f355ba2139c768fb50560bf137d9148a459c8f0c1"
     }
   },
   "1.13.4": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAD7C471B99AF6",
       "checksum": "65e46ca35755c223e00eb2d457d7ceaa46610f4eed13c3d4e810974b5f7e1d69"
     },
     "x86_64_macos": {
+      "etag": "0x8DAD7C55E1796C1",
       "checksum": "c8e7fb115cbb132976b756e16caab36ae0fe1986262afc74e7c0ee4bf79479c8"
     },
     "x86_64_windows": {
+      "etag": "0x8DAD7C4B493A0A1",
       "checksum": "4a453c59734525fe5fa23a14b47c57502de5cfdd9fb49d98e93a5403923a0116"
     }
   },
   "1.13.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAD40D2C06EF1B",
       "checksum": "9bc99b5b1146e880664531ac90b5de782a24932c8cc636ab72ca6e632abb4a6c"
     },
     "x86_64_macos": {
+      "etag": "0x8DAD40D7EB8D3B3",
       "checksum": "64af0f3968760cc2b778fc04c9c4c60a4afb6b5e1383841a0e77997ac5b34004"
     },
     "x86_64_windows": {
+      "etag": "0x8DAD40D824CBB58",
       "checksum": "de6e3e4d2318ea55ad068c44852d53c98ec04f4732d0c3b5cd7f78a6549cf383"
     }
   },
   "1.13.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAD29093B3F39F",
       "checksum": "ff066bb7d1bd1d7a5f909fefa32fae09fb296d1eaaa3382669ab8a20d01caa9a"
     },
     "x86_64_macos": {
+      "etag": "0x8DAD2909156FCDC",
       "checksum": "a59f2790608224af47fd65c30710fa8af93c2bb7ae9d36dc45246a6abee2eb90"
     },
     "x86_64_windows": {
+      "etag": "0x8DAD290CD50E6AA",
       "checksum": "9994a9f72991341b04cd0ea00e0ec2b8a59bba6ff50c40e2238cd50eca2c128b"
     }
   },
   "1.13.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DACC425B95691C",
       "checksum": "aa323534728a7ed201a265a05ef078d43339760771e761824fb2f563a09e5c9d"
     },
     "x86_64_macos": {
+      "etag": "0x8DACC42EAE8A9D8",
       "checksum": "b2c9625d09bb5cbbb0bbd37e68132c5d1ff3d9bd162aa12d6e269741a24f5862"
     },
     "x86_64_windows": {
+      "etag": "0x8DACC42D1B5634A",
       "checksum": "024a922f475683cd4871909e6168e5525fd15d4b4f7cf574be7bb55b6f1e4439"
     }
   },
@@ -1258,144 +1590,183 @@
   },
   "1.12.14": {
     "x86_64_linux_musl": {
+      "etag": "0x8DABE74DC1362C5",
       "checksum": "847f387f0f9c1227642bd4417f43f90044d445a406a8d34a3cea3bf573b8ed27"
     },
     "x86_64_macos": {
+      "etag": "0x8DABE7555103FE1",
       "checksum": "f82daabfed35fc4d027301c2b7c8b985cf178953748f1dd57f7cffaac772eb66"
     },
     "x86_64_windows": {
+      "etag": "0x8DABE754E506B0B",
       "checksum": "1334b1ad015e205a5cba38b5ffbbbad0f3892250abd4bb91553e0f1a6f95c606"
     }
   },
   "1.12.12": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAB682DCF02B7E",
       "checksum": "bc3bfaa0587274b522542b5660b2083414ebc17e041f283e6fce990139e8e829"
     },
     "x86_64_macos": {
+      "etag": "0x8DAB6839452311C",
       "checksum": "1af1db7a9587c065bf08b7b332e6c6d9013b7ab83b14d80fea7b649484fe404a"
     },
     "x86_64_windows": {
+      "etag": "0x8DAB683187A5541",
       "checksum": "2f4c1b8c9eb3f16dde14283b9dbf08e9ebae96888b0d225df544c2f87418eb27"
     }
   },
   "1.12.11": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAB2948D0CD6E6",
       "checksum": "0896434d3d57e3d98978eae3ceff0ed31951e1c525f040286d15079fb378c193"
     },
     "x86_64_macos": {
+      "etag": "0x8DAB294C0C67747",
       "checksum": "b2ebcea09407f860d5b66ce15da0098021942c1f3ac59ac5f2cdfc98dcbd21fa"
     },
     "x86_64_windows": {
+      "etag": "0x8DAB294CA336E1F",
       "checksum": "39860dcf2b147078d4b97c2488178b28c021c805271d57eea3d671e49d8bfa93"
     }
   },
   "1.12.10": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAAB984A9491D0",
       "checksum": "f600aecc9e73c664cd0592ae718ce59b8f6802e534b470bc0979be5206cfa3e5"
     },
     "x86_64_macos": {
+      "etag": "0x8DAAB98794B8267",
       "checksum": "2a8849cbee1bd3b85583a4d6eab7b7ca5e6473112d8e4c969337bf24b9faae88"
     },
     "x86_64_windows": {
+      "etag": "0x8DAAB989459EE63",
       "checksum": "3402db1d5b0d54f9fb0f87640aea81fcb7c62e7eec8dbd17f7fe67a4a4b9bc9f"
     }
   },
   "1.12.8": {
     "x86_64_linux_musl": {
+      "etag": "0x8DAA19722AF0D71",
       "checksum": "2aa15a5573d1cc22e1d04fbe44ebf7c04f52151c916856cb0a96ed12ac65857f"
     },
     "x86_64_macos": {
+      "etag": "0x8DAA197899F2BFF",
       "checksum": "ce664fb452efda44698382a3f8d9ae1b7b9973bc2e18ac765d6a665532c4b0c8"
     },
     "x86_64_windows": {
+      "etag": "0x8DAA1978964C39A",
       "checksum": "07b7162dde6a1cb9acb394183ad0a261d3537e6c7d3aafeae52934482335f0be"
     }
   },
   "1.12.7": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA9CCA48D3443B",
       "checksum": "84977e8c4c905d4cb7635163ebf7b02f86457647aa304037ca4b591046da04a9"
     },
     "x86_64_macos": {
+      "etag": "0x8DA9CCAA1F576B4",
       "checksum": "88f4b1d5a4418f1b0a24449400bdb4fa5d5e8b0f0c215cd5f1826cf25080f8aa"
     },
     "x86_64_windows": {
+      "etag": "0x8DA9CCAA4B4076A",
       "checksum": "ea96d6ba3cc1e9ff015be8fcd318eb415269f805a57b835a6ecfb6bddf61f16b"
     }
   },
   "1.12.6": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA9C33D650532D",
       "checksum": "4729ec6b2a13a1dbbbde4072a069cb2726419ac416bb3b91966343f490bb7bc6"
     },
     "x86_64_macos": {
+      "etag": "0x8DA9C342E1E242F",
       "checksum": "c9b7e61a46d6cf00f12acabc93345f858d1a59cfc066c66e8dc622f9f21c7ab0"
     },
     "x86_64_windows": {
+      "etag": "0x8DA9C342A191325",
       "checksum": "92809e58a6f99803098b8fd9642ca53071bf5bbbf51ad598afc13aeddb5d5ba4"
     }
   },
   "1.12.5": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA9722840EC8CA",
       "checksum": "331f456b354d0249b58be78d5528ff33e64a2913d793283ed46a9c2562977c25"
     },
     "x86_64_macos": {
+      "etag": "0x8DA9721424D6398",
       "checksum": "f879a87f9c0a95756cec1553553b154a9ddae65faadbcf7acedd0dbcbf4844d3"
     },
     "x86_64_windows": {
+      "etag": "0x8DA972132863821",
       "checksum": "23ac24c3dcd875fe21989fdda36608de3fb751f8cbdd3a47f4c73a00ed2b9613"
     }
   },
   "1.12.4": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA91BAC68E335A",
       "checksum": "820f9d0387ef32125f1c7a6338b5aea6b7d4c8de0a741556470298f7a7936f53"
     },
     "x86_64_macos": {
+      "etag": "0x8DA91BB1DAE359F",
       "checksum": "e60c1e6aae962f31b0198856910b7d34dcfa4ccec9a810c0826c07ea9afbad6a"
     },
     "x86_64_windows": {
+      "etag": "0x8DA91BB24F266DF",
       "checksum": "c0791fbde8cd27de7ba01fec0e801ed5dc7071f3331693db114f171e919ebd0f"
     }
   },
   "1.12.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA9014692EFFBE",
       "checksum": "6a702c703fe35ceddb732005c1a301cc035a839f1fd7a1eb967ebf5269e77c82"
     },
     "x86_64_macos": {
+      "etag": "0x8DA9014C6F2876A",
       "checksum": "6d0b486f11fc316dbaf83cd4c7197b98e0b46ace3a56dc27bd4452fa52a2109b"
     },
     "x86_64_windows": {
+      "etag": "0x8DA9014CBFC893C",
       "checksum": "320d0d3ad60921b2428e55b000c0a6cd1a98053b8c7001dbed30227fccaa5f43"
     }
   },
   "1.12.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA8C319A7CAEC1",
       "checksum": "e73bc8696dc7f8bc782c501fec6861edb1a6e4e106ed24ca27a243dfbc480f6b"
     },
     "x86_64_macos": {
+      "etag": "0x8DA8C31D4DC6D46",
       "checksum": "16be00eb1ae65ea0615d00cdc363ad988b6abe5290303831d240e9268d4433e6"
     },
     "x86_64_windows": {
+      "etag": "0x8DA8C31E833396C",
       "checksum": "988a468b1e0250f03ff8265025fc4a61228cb74b478df7b6cc357f263bf7e406"
     }
   },
   "1.12.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA8C2A254EBD04",
       "checksum": "7aece27cc8f8e8ecbeb45805d13db052ca73a2b2df9d69c201f8e63b60ee0ec3"
     },
     "x86_64_macos": {
+      "etag": "0x8DA8C2A48753718",
       "checksum": "a635a3f8824854c0109e5abaed777dd015d219d53adc0fac52debee5a526ca6d"
     },
     "x86_64_windows": {
+      "etag": "0x8DA8C2A877211A8",
       "checksum": "01a2af00bd2a1a05a7eca542ebecb54f9683e7c1b66d0ae1829459039a62308e"
     }
   },
   "1.12.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA8A94B276BEC0",
       "checksum": "615b7c926b99c3215233971bab26fdb28a841191fb6988930c78894061313ce7"
     },
     "x86_64_macos": {
+      "etag": "0x8DA8A958857B099",
       "checksum": "8fbf5cde18a94fed375592a313638bc73d83d7984d0f8961cf404139f547964c"
     },
     "x86_64_windows": {
+      "etag": "0x8DA8A953D44DFB3",
       "checksum": "da182bd7ab9e8bf31fde3e39aeb6041b5427f8054247ae9f3657fffbc7626898"
     }
   },
@@ -1404,67 +1775,85 @@
   },
   "1.11.5": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA8A03DD143DCD",
       "checksum": "124c186db4b9b5271135015dd59c16fc5acab9ee20cedb8582359e82c6bf1c45"
     },
     "x86_64_macos": {
+      "etag": "0x8DA8A03F5FDB122",
       "checksum": "ba43b5e8e45c1f27c9339c584b5f60f49997c4c732a4422e97d6569414bd3a9c"
     },
     "x86_64_windows": {
+      "etag": "0x8DA8A03FFC17DF6",
       "checksum": "bd923a0e9fe1bd73c91f8469dda77077ee4e8f2af16d5678d53ad4027ae84bf8"
     }
   },
   "1.11.4": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA86E11B6E6607",
       "checksum": "cab61fe026d13b00d2de407990696b1d2e3967f84c3bd59d4491189c39127e4d"
     },
     "x86_64_macos": {
+      "etag": "0x8DA86E1488E368A",
       "checksum": "e698e36290b72db3ada59e53a2483fc9c469d805638eee6d27e61833704a9ebc"
     },
     "x86_64_windows": {
+      "etag": "0x8DA86E148AE8AF9",
       "checksum": "6ff2b9f4fc8cb855cccdd26a658e7ba45864850ed14571cee307f917a12b00aa"
     }
   },
   "1.11.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA868EE55CE687",
       "checksum": "3871918a5afe182595f6d2cedaf1798a2cf16c7445fe1ac65dc020ff95635950"
     },
     "x86_64_macos": {
+      "etag": "0x8DA868FA516841C",
       "checksum": "8ac05d7bfd4d9b7a68b128e1c32057d08d26e95c0beb3d70b0116fb5d390dbfd"
     },
     "x86_64_windows": {
+      "etag": "0x8DA868F541C3714",
       "checksum": "9766474d1a594cf17d1a6122c36fdb342ea4b37e9d427efb06de3cf3d1c6561c"
     }
   },
   "1.11.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA85140B897838",
       "checksum": "fc18d2ff0475e89cc7e111be02080911d4d07bdcd8a584067da9b03b675a5cc0"
     },
     "x86_64_macos": {
+      "etag": "0x8DA85142037571C",
       "checksum": "4d250b0dd048bbed593cb55ffcff9cd0238b20d12e1181f40df9c4e8ff0a202c"
     },
     "x86_64_windows": {
+      "etag": "0x8DA85145641303C",
       "checksum": "ba0ab7ef240cbb8de068541f74356d8f6d0c55006cd031b40689784092b741c7"
     }
   },
   "1.11.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA7F8660FF3E9E",
       "checksum": "ece5d320df31a6046852b3344f14ce6bba38a80fbb0a94c317231d153a5ebc4c"
     },
     "x86_64_macos": {
+      "etag": "0x8DA7F86B4250A1A",
       "checksum": "cda28ed1cf360ecca85f303412d6c3829a8050d8b34238e5b204c6bab3074fe9"
     },
     "x86_64_windows": {
+      "etag": "0x8DA7F86CFBB0FD1",
       "checksum": "38a3ab99b161c9aab479814ab9b63f1ced4943d0da3e3b791877a434ad86d291"
     }
   },
   "1.11.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA7D4EDD11DE25",
       "checksum": "265e9a6d30ad190802ec10db78897212b784c92b640a35269ddb850475e0a482"
     },
     "x86_64_macos": {
+      "etag": "0x8DA7D4F0E8BEF4E",
       "checksum": "362a821447cacdddd25d8487ed9995559ddd5167455bd311320ed5b08a60d1ea"
     },
     "x86_64_windows": {
+      "etag": "0x8DA7D4F274CC7F8",
       "checksum": "ce0f5208ac1a862bffd5a12a1e77d5c1b12ee49b1cdb2b7e7970e3593a449f8c"
     }
   },
@@ -1473,45 +1862,57 @@
   },
   "1.10.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA6BFD2E586977",
       "checksum": "9d6d26b3ee3aa492867b3b6a6edd9b9bed14c9610da2dcca5c8562efcde59adb"
     },
     "x86_64_macos": {
+      "etag": "0x8DA6BFD821CC786",
       "checksum": "4f50e2ccb28ad87499485fe8674fa2e1c0826ddaadbb54942bb134605fde1c0e"
     },
     "x86_64_windows": {
+      "etag": "0x8DA6BFD7E5F19FC",
       "checksum": "ecb50296cd466928fafe8443a46ee8ac6ec938a98ba082e440e7b33515f2f7dc"
     }
   },
   "1.10.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA54755534CE5B",
       "checksum": "c8dfaff5085beb8acbc8ab315dde8a5a843865f7bab45691ef6433dea3ed372a"
     },
     "x86_64_macos": {
+      "etag": "0x8DA5475F2448F72",
       "checksum": "c66970ac14ffd3b11870b311ddcd600e4b437baaaed158c98401383c5231d4d2"
     },
     "x86_64_windows": {
+      "etag": "0x8DA5475DDE2BD12",
       "checksum": "a53972d93f8d0a801d678595b946ab78677c78b3be1c8bd44a6b627ed22aef95"
     }
   },
   "1.10.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA4FCCC9C9574E",
       "checksum": "ae7f36aee8fd2dc25a9d04f80fe7eb77b25597a9e673f50826837bf6ae8290cc"
     },
     "x86_64_macos": {
+      "etag": "0x8DA4FCD10E7A594",
       "checksum": "1a3b2137b26eada0859efbb9a9ac16e347d23fc8b52f2077e85bf44c47220344"
     },
     "x86_64_windows": {
+      "etag": "0x8DA4FCD30D21CD1",
       "checksum": "f454c1e63112a81e252893fb215f0d30a027cbf5a1137c2cd4ba4a5bc663039f"
     }
   },
   "1.10.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA4FCA1049CFF9",
       "checksum": "778502fdf227e18b5141a15cc6ef64515d066a44fac26ab8c5fc49312800ba4b"
     },
     "x86_64_macos": {
+      "etag": "0x8DA4FCA0CC7E515",
       "checksum": "b808fb26867f3912d0d468ac24f3dbbd1976cc251559eb589291e49562bfda29"
     },
     "x86_64_windows": {
+      "etag": "0x8DA4FCA5B3ADE3B",
       "checksum": "773dadd0b8d2f598c2ecebc7e4cf6eefca1761f348b024fcc671d09edfb2695c"
     }
   },
@@ -1520,12 +1921,15 @@
   },
   "1.9.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA4F14C7ABA3F0",
       "checksum": "5b2ef7aafcb9a3d4dba0dc258338a074c239f9f5fd23702ce00e915b204b0e36"
     },
     "x86_64_macos": {
+      "etag": "0x8DA4F14D94A6BC9",
       "checksum": "92372ea7741205b2bb9da3b39941cb0e6c84bb82abdd14b2b7fbc93d531e2583"
     },
     "x86_64_windows": {
+      "etag": "0x8DA4F159C22684B",
       "checksum": "99527512d757412cced6098d451613efaa5226a6d7f2e746c5e8ef509fe8ea7b"
     }
   },
@@ -1534,23 +1938,29 @@
   },
   "1.8.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA3749F997B8D2",
       "checksum": "2044fbae38128dea67758d3bb147e47f74560218c6d7b3824eee857dfffaba45"
     },
     "x86_64_macos": {
+      "etag": "0x8DA3749E9AD8078",
       "checksum": "4f6aa82ad0be0fa03847010dbc52dc0c5275c4d76978f86977d3c634194a2ed5"
     },
     "x86_64_windows": {
+      "etag": "0x8DA374A80B893D3",
       "checksum": "d3a5156d664b2624d1ce271cf8f04d6a64352dc2d00feff52343c6ce676db8ca"
     }
   },
   "1.8.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA32BB836CDD78",
       "checksum": "56815dfef83944f11abd3f8dd51707cc5d92228a25884ed92a05e7887750c106"
     },
     "x86_64_macos": {
+      "etag": "0x8DA32BB8E0EAFA7",
       "checksum": "e8c0240717f53dec1b6a2c6c4ea45e41c12dd8800ce533974084949ab33a1349"
     },
     "x86_64_windows": {
+      "etag": "0x8DA32BC01A7F13E",
       "checksum": "ac2480f8f2a4c8ad2441b9c3edd538e4a111f1e05a6d91623175feb418e43f2a"
     }
   },
@@ -1559,45 +1969,57 @@
   },
   "1.7.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA2925AA394CBF",
       "checksum": "9abdfc4e1803d3361103e830f79df5aaead3ba4dc7cbfa2856e033774689c0c5"
     },
     "x86_64_macos": {
+      "etag": "0x8DA2925CD872093",
       "checksum": "4274b0d05151ff190a3ac7f0bf13082cbf5b20753f92089c15cffe31d0cd62c8"
     },
     "x86_64_windows": {
+      "etag": "0x8DA29262C046679",
       "checksum": "58eb750cb06ef547279d2c154ddf2298b6bd2d25c27e85fe3ab967ca1571d1cf"
     }
   },
   "1.7.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA28C371C98F76",
       "checksum": "e558298a401026e7a851eeb60d29c19c77a3d4c0c5f39002b26b295adebc6d03"
     },
     "x86_64_macos": {
+      "etag": "0x8DA28C3F2C82866",
       "checksum": "ab9348dc780a32048411fa9189828e82429e7b9cf81ce1e05819fb4b8acce84d"
     },
     "x86_64_windows": {
+      "etag": "0x8DA28C3D3604C00",
       "checksum": "3bdbd0f3899f36e6095357f759cfca5182a1dbfe9bc04bd62f226c28752ae536"
     }
   },
   "1.7.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA26DC5C400450",
       "checksum": "3f524e8c9c30c14370bf0760c4416c34766f597182850b29cc8023265b74ba84"
     },
     "x86_64_macos": {
+      "etag": "0x8DA26DD1E9273FF",
       "checksum": "38dc19e54854fc5f34a2c55337a382e0dfed9e2f250e998d21ea62f7dc5b7ddb"
     },
     "x86_64_windows": {
+      "etag": "0x8DA26DCE3A2DABC",
       "checksum": "c8b06d3978a48c791018dd44fa4bd2ae5bfc7b82399de1402446bd453b1596fe"
     }
   },
   "1.7.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA214A070D9032",
       "checksum": "4a462e8d17839c328d9da9b41617edddbd29554fd102dd74295fc46f889f5443"
     },
     "x86_64_macos": {
+      "etag": "0x8DA214A331BAA1E",
       "checksum": "4b9ca43f3bde293ae1b404980e48c295b377a2115db154173c0914b7c863cbfe"
     },
     "x86_64_windows": {
+      "etag": "0x8DA214A79173A0B",
       "checksum": "0f3a5d3e7b9d845b2dd95e054daed84439c089f0d84ec27c0ce9890f6c45ce89"
     }
   },
@@ -1606,12 +2028,15 @@
   },
   "1.6.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA17F6F0E2FBE3",
       "checksum": "78e88322d4f71faae133d11471e5088b870c4daca4046191097a43793a437dfc"
     },
     "x86_64_macos": {
+      "etag": "0x8DA17F71E5EE253",
       "checksum": "99ccf7ea17185b9a49ed277b4195f80a354115bfecd4e74d54022487ab02cf47"
     },
     "x86_64_windows": {
+      "etag": "0x8DA17F75A69E756",
       "checksum": "a57ad6f316e7c2b96b353f69cc1d5203367523d3d5c7031bad00e4fe8302b8bf"
     }
   },
@@ -1620,12 +2045,15 @@
   },
   "1.5.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA01DE5B9CE767",
       "checksum": "026c1e1c72f064d6a818070a7608574ca944f5dc23838215d3c238fbfa1655bb"
     },
     "x86_64_macos": {
+      "etag": "0x8DA01DE9BBC56AB",
       "checksum": "4bf4e93c6ae1bdcb365574c6cd7baa8f403c2f4b76f42dbb54261a3a6364a841"
     },
     "x86_64_windows": {
+      "etag": "0x8DA01DEB6C9603F",
       "checksum": "a4612c928b0bfe4897ae2e7dd473169358a6e09ffc1e6ed050230e378cfda00e"
     }
   },
@@ -1634,23 +2062,29 @@
   },
   "1.4.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9EFCC3975BA9D",
       "checksum": "efc5cd671eefa914bd9f70009df7a844323e7565864a8663fea77cc97d5f6d49"
     },
     "x86_64_macos": {
+      "etag": "0x8D9EFCC501EB24E",
       "checksum": "d068820a559af6f848e7f58698fb983dfdfdc5c8a32b5e30d07457c39c3a336d"
     },
     "x86_64_windows": {
+      "etag": "0x8D9EFCC8C3D0D10",
       "checksum": "ca4a6c9d3950053de1176cb0fd5200fe46abcd91b8a2cf1cad38da20d8ea10ec"
     }
   },
   "1.4.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9EB0580E0DA83",
       "checksum": "cc26618f6e0a865a206b573e28a10fa7aed4345580bd2ffe462919d156c1c201"
     },
     "x86_64_macos": {
+      "etag": "0x8D9EB05A5CB7A65",
       "checksum": "a31f14c85d78aa0276bfcdb7146d409ba9552b09bcc4f4ca7908ebfcc18556e3"
     },
     "x86_64_windows": {
+      "etag": "0x8D9EB05ECBEEDB5",
       "checksum": "7e4773e421b7b8d05f0bee8a5e06d730d6e2ddf799c29343b7e3eb7b31472618"
     }
   },
@@ -1659,111 +2093,141 @@
   },
   "1.3.9": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9E10E4023E1FE",
       "checksum": "58c7a4f0ec76f7481ba066708a4b92e4488720769e330006f2ea7f34d42ceafa"
     },
     "x86_64_macos": {
+      "etag": "0x8D9E10C8BA5D5B4",
       "checksum": "02b79bbb61420cbbb9553eb8bd26a83711ee7b931b2b009a3cba94b00b743062"
     },
     "x86_64_windows": {
+      "etag": "0x8D9E11172422724",
       "checksum": "3fff59903b7a0c1eb37ce4f12be9a1e46046bb26f50279dbc1ada72a790e7234"
     }
   },
   "1.3.8": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9E0EA234B3172",
       "checksum": "928d5d6b06e640b56491f3982a7fb42c2bf8ce4b819b2aaf5e46eef6f8a9fb58"
     },
     "x86_64_macos": {
+      "etag": "0x8D9E0E8DC618A30",
       "checksum": "bb2a50510ff5332882b070c5c52ca39247f7c191004f11725eefdbe548aa39c1"
     },
     "x86_64_windows": {
+      "etag": "0x8D9E0EA28F5A16C",
       "checksum": "e9ae4a4532b466779ef1cf6ac54656dcfd9a4c1595ac017c7f4c864c44e6f15a"
     }
   },
   "1.3.7": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9DFAFE5632D22",
       "checksum": "f0a11969dca740edf051c01dd39cb3c61ac5f0ec1988286b06d79504ac417d8e"
     },
     "x86_64_macos": {
+      "etag": "0x8D9DFACEB717EBB",
       "checksum": "549f621a1f3f16c5ca9346c86a6adcd6933773163cff1fd57b844197aa0ac86a"
     },
     "x86_64_windows": {
+      "etag": "0x8D9DFACD4914C31",
       "checksum": "438b5d62bbacaf45ec25aaa3dd2b82d297e0f342710617b7af6cb06453df51f1"
     }
   },
   "1.3.6": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9DF687AD05F47",
       "checksum": "4adb6cc0104bdf736e5520372a54f66a12b263c1018e64c05df9b8881ae513c6"
     },
     "x86_64_macos": {
+      "etag": "0x8D9DF689A52EB2F",
       "checksum": "db2048e7fd690cfeaaac91c303e168c40361cb204615b6f20d9d2931ca4752fe"
     },
     "x86_64_windows": {
+      "etag": "0x8D9DF68C87A666B",
       "checksum": "1942e74589824f204c2460624f918f4c565f9c6bed91c768b66e8d0e2a691747"
     }
   },
   "1.3.5": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9DCFD545D239D",
       "checksum": "b2d3681d4db209f511f20497f86d7f846782b7d7de7bb3d8fed63b7dad6fc965"
     },
     "x86_64_macos": {
+      "etag": "0x8D9DCFE2A89580C",
       "checksum": "336a2e1db56f4fc97623fbab5556b7f195808e76c4d4fa0cb6f1ff1b76393933"
     },
     "x86_64_windows": {
+      "etag": "0x8D9DCFDAA810266",
       "checksum": "faafaa30e36e8b84ad81659ce0492b45d1f7938e12964808112a75eca493ff46"
     }
   },
   "1.3.4": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9D69659AD0EEE",
       "checksum": "4b65e6ccd00232c0ba5110b6b5ff082af6fe4d33677dd11e114d3f1d30b1d0a1"
     },
     "x86_64_macos": {
+      "etag": "0x8D9D690E5716C6D",
       "checksum": "beb35d7d478a07864b13f7b9582e89a6578853938b6b07a49552d6cd1992a45b"
     },
     "x86_64_windows": {
+      "etag": "0x8D9D692E54609D3",
       "checksum": "0c9590be5423d3ebbacbdb022528e8be63fe7b774c5f272dbeeff098ac20f80c"
     }
   },
   "1.3.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9C28226D2D94B",
       "checksum": "30adbc9b50f675b1194e90bfe18f4721cd5d2b5a7993c838a2231db08e384b27"
     },
     "x86_64_macos": {
+      "etag": "0x8D9C2823C5A4AE5",
       "checksum": "69b288c36c764a2707629c9f9bb30cb4a5bb482cef970d35f745012a891586fc"
     },
     "x86_64_windows": {
+      "etag": "0x8D9C282674D91CC",
       "checksum": "411d28c133eea080dcc3b2ec7ca8d90c798d74429ea3a9368e80503c45357bbb"
     }
   },
   "1.3.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9BF34EB67A23E",
       "checksum": "6a2834d45a3ba822a68a1827600dbbb89c5c60864b6de6ccac69109f67c3140b"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BF34DC78A08F",
       "checksum": "b60a74e392f751b74bda12e84a25436930bf74af5464952f3d3622ccf75b281a"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BF35194AA966",
       "checksum": "a5ab4806ba94b4e3b42cf1999c3bcc22f3c208c5c7a11a7663d34945ea674f10"
     }
   },
   "1.3.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B938B1D6FFC5",
       "checksum": "d77ac2f0801ffef3966124abffd6e4347f7ae208fa7100a6db934a97baf76509"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B938B775D7CF",
       "checksum": "66ab79ed9a51a5c7d83f2d0e2476bd9444bb6376dc72f2e7aa4daabc3e771c42"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B938B65ACD39",
       "checksum": "fe5676d8dce1ecfc4d3c0903288ae7a2b0539b9b28a1a4f65789f780c60da996"
     }
   },
   "1.3.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B938C16CDFC0",
       "checksum": "fdf05d7b0cc71d8518b864a17318401440a7f71d06df3c53a01d545689fde618"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B938C04812A9",
       "checksum": "650ae1e917db1b43b7cc7509169cc5f33300ec56c927a9a109df238b6fdc3dff"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B938BAAB0F16",
       "checksum": "6a5c08573aeedb24f5e4e9e9c27c360b2992a22b5b5a8a4b8155a003a3f30e11"
     }
   },
@@ -1772,23 +2236,29 @@
   },
   "1.2.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B938BE556544",
       "checksum": "0ada182d67e852fb1e4ff12d00b16a0a291365c0d28f2405b71b531145374ea4"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B938B324F9C1",
       "checksum": "0f9bb18ae6c8b3968cb22e931ed0ce999826181c25f3ef1e43573d8c23c38f37"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B938C304340B",
       "checksum": "31878b64fbc74898b376604c4cc36ffab01d1fcd77832fa2989b88508a20faf8"
     }
   },
   "1.2.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B938AE83BD93",
       "checksum": "1558aca3f7f009df9e8c696e1abf12563dc0d4e1868be1bd62281765ddf8b697"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B938AE6B3015",
       "checksum": "547868dbc36ba79549dba8ce3fd585caca47ca24cb22cd4e75a4422a317f50b4"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B938C1759109",
       "checksum": "43bb38711be7a59cd0463aea4be8f5d7d96c20d0b00d2ad204e30f9695d34c5f"
     }
   },
@@ -1797,111 +2267,141 @@
   },
   "1.1.9": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B938BB284315",
       "checksum": "6a32cc2b5ea4e9c2857f8df4e75a49ee83b8535a90212d9a454a3cc1e274ac18"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B938B6A27A18",
       "checksum": "e9addfe11a733b0dff24efb20d7b8cadeb132c48a0502714ffefe5323234dbc2"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B938AE81C207",
       "checksum": "7b265200d331d6cd9ba17cd857bafcaec85920d9ec6feecba465aada3a7d3418"
     }
   },
   "1.1.8": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B938C24FF292",
       "checksum": "9e8739907b2cb8361592ae235a13b5475e5364135e9494f04e461f301b166638"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B938BDD87F5B",
       "checksum": "ae078a52f267bea048b9cb436929832a12f90c6960d147e45c0270c7259671ac"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B938B15956AB",
       "checksum": "a14b422f69879004c27ccad4dab7adbdda0e79cdc9885c3b0c0c51df62fea01b"
     }
   },
   "1.1.7": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B938BF809A13",
       "checksum": "0299acdb75a50da1fa95b29c34f28fa5fc0f35882891c8cde0a5c1b1abebfe7c"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B938C1B9E30B",
       "checksum": "25674bb8cbdd82c15ae437cf4fc1e5d3da4f7620ccf8986435cdd4577bc67f89"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B938AF4AC115",
       "checksum": "bfa03db71b5c9307fa636b7964b4faeee8b5837388bf814bd7a097bd66ce3c72"
     }
   },
   "1.1.6": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B938BB3698D6",
       "checksum": "be6e857eb341e2fd3660ac826b1365ce25384083a27f749f5da7f2efae5fefa4"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B938BACDD443",
       "checksum": "98750ce66c9a8b9dbeaa48242b4aaa7074a0dfde7bb6244b9bb3b529e4eb48dd"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B938B9792482",
       "checksum": "b749cfd79fef023630c0d20237d3ebb4bab1d0436d9ecfc5985a8e55edbb1ed5"
     }
   },
   "1.1.5": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B938B3AED614",
       "checksum": "486f0e904e5c0d3a8d3a96ff93bc0f4e9104bc0da9d940f82153093893f2b9fc"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B938AF87E817",
       "checksum": "2c56c8914ebbf69345170465d2b47df48b3443875620255481ae2eb13f3dec59"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B938BD9B5840",
       "checksum": "6fa3b9b64913e39abaca0780845dd7fcbef7ac37e3f38660e378e53aced5ae7d"
     }
   },
   "1.1.4": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B938B1EAD2FB",
       "checksum": "113d8d3cd12fc77355cbdb4847349f120f3597e0882e853814e9ad92ee4afa9d"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B938C13F94D0",
       "checksum": "cbf29c5c717a86e6497a1f75929612053daa473822e944945e624c61712824f4"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B938BDD01C28",
       "checksum": "8a682ac64f197fdaa52a13433c5041fb95a1c6445ce4ebcdafb2de7bc7033f72"
     }
   },
   "1.1.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B938B95797B0",
       "checksum": "86e84b4173a5a3e08a65f05e58e3a3f2456b919af05274adfc28da1e5dd98e83"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B938B2D97CDE",
       "checksum": "01c04a2004368109f8b21ba66e2ca447f9f06309419dfed78449da0c48df0b89"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B938C1EE31D5",
       "checksum": "9fee1776c75444bb5b5451de4341dd8b1924233fb6e2d202edac7a7f6d218485"
     }
   },
   "1.1.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B938C07229B4",
       "checksum": "41c0673899fe85386789da555f4f1576150b6c266f4ff0f868ad4b0128373873"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B938B581A40A",
       "checksum": "0586e2b770f1a36c33da712ca7b3e508c3bc5dc19a7c99c031c6e432d215d098"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B938B89CEE84",
       "checksum": "a27dcc94177efeb14b19ff2a8cd2f808d38108d605e9697eaa0ce801aff1d034"
     }
   },
   "1.1.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B938B3DF2DCC",
       "checksum": "a142d30316656df1b0ae963a9291a17f5a79666b3d1acdfbbe1068612cd87a28"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B938B9679AEA",
       "checksum": "2a53e423cf4c2271ae21eecdc36589aa6954b3e840a5bf58fe4cd46824975453"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B938BEA797E5",
       "checksum": "7d5d2963734364d82a876d742b6ddeeeff46d5145b563a1bd0e41a5d38b5b10e"
     }
   },
   "1.1.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B938C0C74223",
       "checksum": "1f2eb960135d59b7fd40aeb25d2fb698cccac3f05d9c9efab401bacff4a2014f"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B938B18DF38B",
       "checksum": "70583062e241a79dba18ae57a0940138c8e5c9167656c0fac49238c860294a16"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B938B34B19C9",
       "checksum": "00e5451054bde541f5b72f53f36c0521142c9306713ab89f059384d58f208d25"
     }
   },
@@ -1910,89 +2410,111 @@
   },
   "1.0.11": {
     "x86_64_macos": {
+      "etag": "0x8D9B938B0C73E38",
       "checksum": "2b685d923d69e987ea39c330e15df2d8f194070da6bdc03d8570aa701065315d"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B938B2A025C7",
       "checksum": "c67ab79d06b520fffff506c70c50f5bf8f0d54fa7cc39d21983d72b23a95e79a"
     }
   },
   "1.0.10": {
     "x86_64_macos": {
+      "etag": "0x8D9B938BAC2162A",
       "checksum": "f2b72d7a42793bf7f469716575cf7d1b80e66c6ee339d20d63b97cd299faad18"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B938B7F380E8",
       "checksum": "0a041720388e7e7524c852bd0ae219c7c6f207ccbcd8421900dce058204299f2"
     }
   },
   "1.0.9": {
     "x86_64_macos": {
+      "etag": "0x8D9B938B0DA9C4E",
       "checksum": "8a4d9f4d3d11aa6013ea34168ac651bf4e73d29b875b061961b47baf4dc90d30"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B938B80C8380",
       "checksum": "7e03eb22c3ed5e1147216cc447cb0f0513d54443b63734e652722ac02ce7627c"
     }
   },
   "1.0.8": {
     "x86_64_macos": {
+      "etag": "0x8D9B938B82008A1",
       "checksum": "a7a1ab2ac3590de109c4509e216b68948690c5eaf55ab8c8e791dc9393809056"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B938BDB6CB7F",
       "checksum": "8987d4d6d26c8db97d60ad2fb76e0c10f91ed6d72557ecfb692d62835a5e91f3"
     }
   },
   "1.0.6": {
     "x86_64_macos": {
+      "etag": "0x8D9B938B306049C",
       "checksum": "b4ef12ff6e8085bfe1bb670c9d344c6a1ae3f1ec34317ce92a6a2858f1ae363e"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B938B6D605B8",
       "checksum": "7b6923d296dd825cf466c4cf78bfce1db1fcc88fc11ef6f7f696facea54f8da5"
     }
   },
   "1.0.5": {
     "x86_64_macos": {
+      "etag": "0x8D9B938BC8D9237",
       "checksum": "b60f35d7c341bbd0555d7fc0c0bfea3d513f2e238736862f14235c40e26c6c79"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B938B612F94F",
       "checksum": "acd996a91c3413d5b36c486e7daeb75fdafb21aa9e43592729dfa3fe4ec23df5"
     }
   },
   "1.0.4": {
     "x86_64_macos": {
+      "etag": "0x8D9B938BE789F94",
       "checksum": "cdb6a9d6001b85ecf3c3acc804568efcf22218e9e87f74fdd09b10a5fdb95553"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B938B5E698A3",
       "checksum": "86fbd123d00e1af71927d80b401d0502721c2337b4867ecef330a5680161e6b4"
     }
   },
   "1.0.3": {
     "x86_64_macos": {
+      "etag": "0x8D9B938BACDD443",
       "checksum": "e3d565e0e48754b2c7180df8d0622e9128da2382bb3ecc9978844a30edbbfe6b"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B938B0E60C4D",
       "checksum": "bb01f39073157b7080625e8705c160930ef4c87dc2e5045d361e17af5e00018a"
     }
   },
   "1.0.2": {
     "x86_64_macos": {
+      "etag": "0x8D9B938B0DC70C3",
       "checksum": "99b3694e83fa6e9e121eaea1fce769ed7a947a39d8ea49f11d7858970899088b"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B938AED2E368",
       "checksum": "a4fc659afa0f8add5772800e77c8d1def7497526b409647b0f3cecbeb5d4612a"
     }
   },
   "1.0.1": {
     "x86_64_macos": {
+      "etag": "0x8D9B938BACC4DDC",
       "checksum": "65e83854318bcdf777233afccbed84db0bd2a2eaa775209078337c4e579b512f"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B938BBA4B3D7",
       "checksum": "32c6e6053de73d565318ed8ab4fd8bf5315a0f23c4cb8eab23438c68ba6c8f14"
     }
   },
   "1.0.0": {
     "x86_64_macos": {
+      "etag": "0x8D9B938B36665FA",
       "checksum": "97bc6b5c6d7a68e996753a0800db7269789370fdb03c14745142e41eba10c5a0"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B938B6EA4E06",
       "checksum": "718e665812ef6404d64769a35b19889f44f70cf2bb6e42dc2f8b98579f1af46b"
     }
   }

--- a/manifests/wait-for-them.json
+++ b/manifests/wait-for-them.json
@@ -20,12 +20,15 @@
   },
   "0.4.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DB10C06F1D3C45",
       "checksum": "2350e38c79f9e59d83ceade3ba7dc2a449bdaac075ea574786421a4bc4646f3d"
     },
     "x86_64_windows": {
+      "etag": "0x8DB10C070B0944D",
       "checksum": "1f716ee4f755a01b67e9606e91a0a65448d4f06113ba40b09e465af62a1c73da"
     },
     "aarch64_macos": {
+      "etag": "0x8DB10C072173E3D",
       "checksum": "a294da6da0ffc0b0a755eb3db50a968841356ff1fdc14724cfa288732496b6dc"
     }
   }

--- a/manifests/wasm-bindgen.json
+++ b/manifests/wasm-bindgen.json
@@ -51,86 +51,111 @@
   },
   "0.2.92": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC3C3C63D8199D",
       "checksum": "c6e43a3bf0be5231e0b72ea702f73b3f4f47c309037e8a332c5c2e41800ca934"
     },
     "x86_64_macos": {
+      "etag": "0x8DC3C3C63F7178B",
       "checksum": "1091b40f5e2cc67d10deb3b1260a92b97cef8851f2588708c2d4b6bef9444880"
     },
     "x86_64_windows": {
+      "etag": "0x8DC3C3C63D205ED",
       "checksum": "a23d556b35bc4d17222e324b205a1b66b1cdad630f62a1190ba6c42cf5ed2af7"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DC3C3C6436239F",
       "checksum": "ae6070b6f6a86160f9be02ee9c913820814825f6e8aff45b155a129a36acc0cb"
     },
     "aarch64_macos": {
+      "etag": "0x8DC3C3C63F9FA78",
       "checksum": "9ac857faddd4368e5ad3f41b74bbc4c2d32c3726d008bd5760fc52c7c6843e48"
     }
   },
   "0.2.91": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC27096CE78FDA",
       "checksum": "48123760cd139036125dbc07aaf09c73237d2bf910810b00a2dabbbac7a92e4e"
     },
     "x86_64_macos": {
+      "etag": "0x8DC270964DA9C81",
       "checksum": "8c9378515f5162d77c8bbec8925e2444e4509fc5fd4e42c218b70bd7e7b5c34d"
     },
     "x86_64_windows": {
+      "etag": "0x8DC2709747F3AD8",
       "checksum": "9077f846f8e29dbc246688294b02474c4247e176739b43b0ce5df093e3c23ccf"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DC2709651CD93C",
       "checksum": "06a93a6c4ca7166082e8c6179e9f1dc6ca1df822894669b5257cdff08692bf00"
     },
     "aarch64_macos": {
+      "etag": "0x8DC270968FC47C5",
       "checksum": "8f644617cbd12763268854cb550604f18e15a869c9b2e63ba977278fee99ff3d"
     }
   },
   "0.2.90": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC13890E2DD910",
       "checksum": "46131161e31617d102260b1420159fe5006f6b0fdb8a0a90fe7adc858b662132"
     },
     "x86_64_macos": {
+      "etag": "0x8DC13890E1E5A26",
       "checksum": "374a460a4c8cf097e84725082da6c909830cbc6caa16538735bcc066971e3bcd"
     },
     "x86_64_windows": {
+      "etag": "0x8DC13890DF77600",
       "checksum": "919b6f010164c5d2f28df505098d94c0ac3727c9aeeea2df12453008dc451c78"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DC13890E3130A7",
       "checksum": "29075a17870097d800e471ec2a800f915c09c5c8d4b2b1436fd43381aa7bf480"
     },
     "aarch64_macos": {
+      "etag": "0x8DC13890EE4267F",
       "checksum": "d3724348014d028048b9539fac36858a0a1aba165814a69542d3038d65303093"
     }
   },
   "0.2.89": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBEF5E39557C7F",
       "checksum": "e6361f3069a8a94ca44f0eb6e22b1de59ee71236bba2acd0278f1387e09a90d0"
     },
     "x86_64_macos": {
+      "etag": "0x8DBEF5E3AAF1A2D",
       "checksum": "5ca6b6e9a2b971cdc5571a54a963f6f13ae6263bbf921998feeef3ff6b6b70b7"
     },
     "x86_64_windows": {
+      "etag": "0x8DBEF5E3718728E",
       "checksum": "5dd04e972fc0910122f5d9881aa49470e6734e5a1d3294030eaace738771fddc"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBEF5E460AD568",
       "checksum": "4ca6d7cedf6d47eec55d739bfd228270061a1c2bb4b625442e2bb716d2cc7337"
     },
     "aarch64_macos": {
+      "etag": "0x8DBEF5E365451EA",
       "checksum": "cff8b011832e0f17fc94e4673a2910b04cb11bd527736b96f94abea24ff674be"
     }
   },
   "0.2.88": {
     "x86_64_linux_musl": {
+      "etag": "0x8DBDAF36CD1BBC6",
       "checksum": "d7dcb7f5ad1d0cb68df5d45ffd9119d1db3d42ee6d50a8b2d3c42a56c74bdd8e"
     },
     "x86_64_macos": {
+      "etag": "0x8DBDAF36CD12034",
       "checksum": "0d1913322e657444c942c644abb687e46807fec31e3efbafb199a7932e677dcc"
     },
     "x86_64_windows": {
+      "etag": "0x8DBDAF36CDA16D2",
       "checksum": "ed885be56d41c5c1d3b1495307d57a2d48b296cfe5afe92e06b6ea09c4ba4532"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBDAF36D1B1C72",
       "checksum": "f13bb83170a3d44edfbebd263c695e6fb5815d77467490af1c49e2e8ec816803"
     },
     "aarch64_macos": {
+      "etag": "0x8DBDAF36CB3328B",
       "checksum": "712c787c411a765e5bf8f2f3f11db9d5ec823260b763e1017d6790e9b3c225ff"
     }
   }

--- a/manifests/wasm-pack.json
+++ b/manifests/wasm-pack.json
@@ -27,29 +27,37 @@
   },
   "0.12.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB774C42858A36",
       "checksum": "7339ba3ad776bd5fc04dd5d6b9babe952648050a54226c08206fab4ffeec621f"
     },
     "x86_64_macos": {
+      "etag": "0x8DB774C4394B789",
       "checksum": "413bbbc727004ab735f3502755acb193eedd3efe8c0b7f88c1b5125d848f7eb4"
     },
     "x86_64_windows": {
+      "etag": "0x8DB774C4ACAB24A",
       "checksum": "0f000a337b7b69bf984138306e82af3a463467bc0c5e940118bb47e150fd4e74"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB774C417C7085",
       "checksum": "edbfd8c434f7d0dfa27a2f42be73c815c693342f2034778033877b1b54e410cd"
     }
   },
   "0.12.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB6F250EC1401C",
       "checksum": "60d7c5b082c408b9c201aa81813d87d5df23db4b1fa9c4a88302144e69bd3152"
     },
     "x86_64_macos": {
+      "etag": "0x8DB6F2511B14088",
       "checksum": "a2fb0a8ab4b5ae1f7dd459af4634d062d7ca33200b1fe6fb527c3f3797b28fe3"
     },
     "x86_64_windows": {
+      "etag": "0x8DB6F250FD48753",
       "checksum": "98ad2b548247f5ee89b2252d263caead040c155a348ebf780bb73b170e6605da"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB6F250F586906",
       "checksum": "19534e90fbe266a0f19085e186d983976e12a6390a76be1b2f977f53cbe922df"
     }
   },
@@ -58,29 +66,37 @@
   },
   "0.11.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB524BB37B3C29",
       "checksum": "cfe60a2e5d1641b9a09ec6d95787068ac24e03c67b9e36de7036714f71185a2d"
     },
     "x86_64_macos": {
+      "etag": "0x8DB524BAC2D1B56",
       "checksum": "6925ede1db571ceca80f2d48533cd9983f152731d95b794de6826121e5cd603f"
     },
     "x86_64_windows": {
+      "etag": "0x8DB524BAB313969",
       "checksum": "57c976a710da102e3465c7d8a158f3e6b850eaef9c010f5d717d522099e74c9b"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB524BB3EBF595",
       "checksum": "9895d2389cfc315e12f6e35299666439b51a0e6dd36b0a604bcc8737c295c3bc"
     }
   },
   "0.11.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DB2863143BF803",
       "checksum": "f3041ac5fda684d09b28ca23555c2f24cac9d6eef57ee4ef3f29fdab1c19fe24"
     },
     "x86_64_macos": {
+      "etag": "0x8DB2863157338DC",
       "checksum": "5da38cb10536e6fe686402f5af94ea48a4b94dca9bde931bf117ddce3e746f0e"
     },
     "x86_64_windows": {
+      "etag": "0x8DB28630A8AA268",
       "checksum": "10092618d9451bace4f727d344f19a02dda4a28ffd527272595f88b8c15efec9"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DB28630A09C582",
       "checksum": "ebc6339762f95385081a06ce3ac8d5846e7267011bc028266009cf3b4ff0f81c"
     }
   },
@@ -89,51 +105,65 @@
   },
   "0.10.3": {
     "x86_64_linux_musl": {
+      "etag": "0x8DA4D685D14249F",
       "checksum": "9e4e7b4436d6fd914aa75f91f81bdedc31a3f2b8b94fb17578cff2c3aaa83bb3"
     },
     "x86_64_macos": {
+      "etag": "0x8DA4D686003ADF0",
       "checksum": "159751e24de3f50462140621c033a6bf8e89cbf1930e60cc725e2b0e84f23035"
     },
     "x86_64_windows": {
+      "etag": "0x8DA4D685E629533",
       "checksum": "978f00965c42838ccd43f501ff661939629d13fa037a90cbf9fe647d9152825a"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DA4D685DDB770B",
       "checksum": "2e6a0f1e2d07192d8e6b5bd4cc1c82459f3cbc0ecd8a301ed0a075699350b1c0"
     }
   },
   "0.10.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9C0CC04D97321",
       "checksum": "ddf59a454fbee8712932803583d01756204c32fbfb13defa69f08c3e7afb6ac5"
     },
     "x86_64_macos": {
+      "etag": "0x8D9C0CC079C2120",
       "checksum": "6d714c86a6aae1fcde5c6829f2fc17e2aa1588cb35788e1c693e9d8e89cb0430"
     },
     "x86_64_windows": {
+      "etag": "0x8D9C0CC05F5DC32",
       "checksum": "abefc5f8124fd924804db0c792cba38aace00588d9216405a7517afc78e8b63e"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8D9C0CC057B8E53",
       "checksum": "3d693cb45dd242ab4bdb876ac151170d39edd7fb200383f2e40f890ca65c588e"
     }
   },
   "0.10.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B8F7DF26CCA7",
       "checksum": "524f8333e69c7157239c14c3140ee485b8cb4000d530344d62984e544f27c67f"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8F7E13D514C",
       "checksum": "d37880f76962dbc3278d3ec2cf419ac187634af796af1423781d19d492f74505"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B8F7DCF486A3",
       "checksum": "036c632f7293060d69b2754793858701bfeced250cad02b91ef4cbf69594cd5c"
     }
   },
   "0.10.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B8F7E801474E",
       "checksum": "8b5a40add554891888de25ea974b4d096a37614c91c982a383d3eca97aa17e68"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8F7EE14A47A",
       "checksum": "bb1da9b5a10566cabcad593c96fb8d24ba3ac75de603b596eca2c7cbd1cfb31d"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B8F7FCA59CAF",
       "checksum": "a3d7d13e250fa4afc6f27cf1f9e7b0bdc85ee7f06f56e16692ee46f6dd5e9255"
     }
   },
@@ -142,23 +172,29 @@
   },
   "0.9.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B8F7E3C413B4",
       "checksum": "d478bd20811067566bfc88141afcc857e7713b5385c684f6d50e7c2d549847f7"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8F7E695DDFC",
       "checksum": "a98c70f0a40b1689eeaf639611ec6b18d0a73abb4a881533c8e0c2861457440f"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B8F7E08EB411",
       "checksum": "dedd292bfe24756a46687e166ddd86e5dabc34cc5e43901d0efb6fd33da940a6"
     }
   },
   "0.9.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B8F7E7545776",
       "checksum": "b12dcf60d8cf54470e64661eb917722a452ecafbc8678b6ae814b5494d745a70"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8F7FC2C117A",
       "checksum": "819517436b1eda7e6b3abab55de0a81375602ca82b160ae3588cf8a713d3e34a"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B8F7F364CDEE",
       "checksum": "1e680af2b917c145644d57d8c267ebefc1638708aa3533c5fb1b7e61311e9e1a"
     }
   },
@@ -167,23 +203,29 @@
   },
   "0.8.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B8F7E1645BA5",
       "checksum": "623f2274e2fe96f5c9e0cb6fd3464ca7cc5b563025d105da79b827e02eb9a665"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8F7DEF4EE73",
       "checksum": "0da91445eec6eb27feb3d313330594be32e7bc35784e7b3c00659b0d741cf610"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B8F7F911AFFE",
       "checksum": "2317da644b4a9b1e9229ecbed94123f5f6e5c4da037c39ad5454d1b88799c4a0"
     }
   },
   "0.8.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B8F7F5C9B55B",
       "checksum": "a28eea9d8d607495778322f8e28bc523621b3feefca185f6b1947d0bfa949eae"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8F7FD601F1E",
       "checksum": "0e8a8833e59c312b73832cd258667524548428585508716502e99a7b6d7263c5"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B8F7F1189B1A",
       "checksum": "adb132f61792151f7302077bbb94fd7dbaa7abc29cd26aebe44bd09d2ec2c87e"
     }
   },
@@ -192,12 +234,15 @@
   },
   "0.7.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B8F7FC292BB8",
       "checksum": "e29446206ef47c2c7aab659387d66a8bf5018b8c55d91dec485f6415d90edafa"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8F7EB6D3F6F",
       "checksum": "f596fcee41725869554a304e509ef8e2adf023226647edbc8c1d9bcf184609df"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B8F7EDD0796A",
       "checksum": "e9fd17e27dcc0c549f597b2feb7f2030ac737e7f6a3dd338804ae180730cf2a0"
     }
   },
@@ -206,12 +251,15 @@
   },
   "0.6.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B8F7E423D916",
       "checksum": "b575bb48f101926342339036705f21d94ca56266568be4076c6e1a6f3afba290"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8F7FC52CDC5",
       "checksum": "085af3cc14dc6305420fe602638ee7544ae7e57a78abe657a8cb27c0d15bbf30"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B8F7ECE048C2",
       "checksum": "cc5590a718a8a04008d561a4e0cbae421942fdb5e7b6a2ce68336f6fcdf17754"
     }
   },
@@ -220,23 +268,29 @@
   },
   "0.5.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B8F7FAB67079",
       "checksum": "2908d56fc3d94db02b02f07271c0a9926f7060dae2ba684d66e7023ca173bfb3"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8F7E761EA0C",
       "checksum": "54a239d6b7aabfccde6dbcb34519d1e30b14752197a654115b1d0f1639119288"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B8F7FC743399",
       "checksum": "3af55c7d5077c67c0e4cd9b5dd1d7c4247d09d3b1e0388a7c1b08de8b917cdd0"
     }
   },
   "0.5.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B8F7ECB1023A",
       "checksum": "194f29ce4fc246cb1d1df95ce39605d561da84e1098f890bfb9e5094d616b86f"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8F7EFEC2D6F",
       "checksum": "9f8acbcc097a392eb41c5d7a7652a74c844718677884030e912507b1d7964f8b"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B8F7DD6F2325",
       "checksum": "f6536e708aec1aea00768920dbebf953d6135774b11a98e2b1dbd6eba4af9951"
     }
   },
@@ -245,25 +299,31 @@
   },
   "0.4.2": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B8F7E9AD32B2",
       "checksum": "531906b0f1bb2e06c542dbbd6bd56671a59762299a01498e94c62534dc548c65"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8F7FCD8B33B",
       "checksum": "2cb85362aa2b3fab4d07a35f95682ac2b2761948f41d3364aabc174152aec0c4"
     }
   },
   "0.4.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B8F7FAC4ED50",
       "checksum": "38f247a8e94bbefc7e7ccdf4b064286d8843c736792c36dfc9d471a0aefc1514"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8F7E6F94C54",
       "checksum": "2438b867544ce3406f37552c3ca0f08c201a29866fb7a7587806a7be4d321c61"
     }
   },
   "0.4.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B8F7F9D113B3",
       "checksum": "7680cc96560b3e76aa542c51c68cb4ef054f6495875c852931a3a8680bdf6890"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8F7FB128CE1",
       "checksum": "2c0a23e42e0c5f3e428615217137647c6b15c54961fd9f6e28f567f4580e1274"
     }
   },
@@ -272,17 +332,21 @@
   },
   "0.3.1": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B8F7E4E6BEBF",
       "checksum": "eab14fbe5b585c865c7ec24f68820e0d6da0215272058fa3ccf2bffc95dfb464"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8F7FD7133A4",
       "checksum": "5000a22d25e8c57ed7c177aea64260490713499e397baaa9ad59152f16796913"
     }
   },
   "0.3.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8D9B8F7ED5B0C46",
       "checksum": "21426de66eafb74054413366435d8eaf2ca4589fe55ae1524e7fb58919c86496"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8F7E2A2C805",
       "checksum": "6e06c850508b47c58c0079f12941f30bf4ec2a4495ef6f56432909c3afbde33d"
     }
   }

--- a/manifests/wasmtime.json
+++ b/manifests/wasmtime.json
@@ -57,35 +57,45 @@
   },
   "21.0.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DC7A89DBE85A7D",
       "checksum": "d49619e38c660196a048e80d34292e458a11af010ab1780e7b3ae9a42df6e33b"
     },
     "x86_64_macos": {
+      "etag": "0x8DC7A89DCCA6963",
       "checksum": "8452dc6e865553cc7027d45a961f86440fd9459de7a48117236c386e4ceb2a1f"
     },
     "x86_64_windows": {
+      "etag": "0x8DC7A89DF34E18D",
       "checksum": "c2a1e23e2ab49f3f942e6a47aba8c60c863fd66166c3940fa3dd1f9a0286a4b6"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DC7A89D6E3B5E8",
       "checksum": "77e8a381bbc54f39399c71ee305b6ce5b6807e7c088846ea1e406a3a62b38146"
     },
     "aarch64_macos": {
+      "etag": "0x8DC7A89D7AD4F41",
       "checksum": "816a4a50c875de0804c316fc3171fb20a45fb82e4bf3e3313dec4f6d819df688"
     }
   },
   "21.0.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DC790AB6400345",
       "checksum": "605efdd4d073a7574b6d42ef0c9037c6c4e3933ed80615eab84f2d57cfeb3b28"
     },
     "x86_64_macos": {
+      "etag": "0x8DC790AB7319124",
       "checksum": "7beb9f1b6789af74beef8354b675d5cab6477be708bf45aa86f411c4afe55dfd"
     },
     "x86_64_windows": {
+      "etag": "0x8DC790AB9A37B14",
       "checksum": "e57345a2bd644e7f4d0a013617d64a3e16966b9483fee72bad2ab1eebabce59b"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DC790AB0CB6793",
       "checksum": "0fa42c4555617cb4a602216ec45b8dc43686733653ec07f9488ab5e2e3bf5ec8"
     },
     "aarch64_macos": {
+      "etag": "0x8DC790AB1BF3CC3",
       "checksum": "b4a09d69c2cb4655e68895156a1de713b27a6e64796d9073108d20f55b8d5d5c"
     }
   },
@@ -97,52 +107,67 @@
   },
   "20.0.2": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DC6ECB201D7630",
       "checksum": "88857222f6098e1d2988d66cbcb3f73b0b5230e8e6871967de7b44f652a542ff"
     },
     "x86_64_macos": {
+      "etag": "0x8DC6ECB2148E557",
       "checksum": "1206b8afa8f2c89f4599886647bae7258cedcb68e4f73e68a6610a68c9141be5"
     },
     "x86_64_windows": {
+      "etag": "0x8DC6ECB251AA733",
       "checksum": "b6653044531806d424a1f3eff4bf664e071c163f0536b6447318bced316478d8"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DC6ECB17C74A29",
       "checksum": "6df6dfa37c6b7eaef7853b65d0e691eac45c9fb5793ecb37c9404b077d5098f4"
     },
     "aarch64_macos": {
+      "etag": "0x8DC6ECB192CC1EB",
       "checksum": "69d3cfdece114def47cb21bfb37fdc89a2217d2dc7582a68cae4ff2b243837d6"
     }
   },
   "20.0.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DC6B9269D4F123",
       "checksum": "b3335181e672527c1f4b5b424413e6bed437cb4b6cc089082f836e03d076bd2d"
     },
     "x86_64_macos": {
+      "etag": "0x8DC6B926AA67073",
       "checksum": "3c921b994a078a0e703e80e9d2714de60deaec3ecbc25f500eac7d1d098c8d74"
     },
     "x86_64_windows": {
+      "etag": "0x8DC6B926D03146C",
       "checksum": "ca065cd227da0e5c8cadf4ef822b6dbc05a1eeab6d5d85ad558c8c761fd4a9b5"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DC6B9264C8DD5D",
       "checksum": "8b685a76e6a7b2dd89b5778a2b2c17a1ab3ba05e2f1b9cd6955d5a416de572fe"
     },
     "aarch64_macos": {
+      "etag": "0x8DC6B9265A7E205",
       "checksum": "ed972d27e55e80af7baf79003791e9a4434af6b82fcc1a51bea33144f730d8d4"
     }
   },
   "20.0.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DC630FDA7D6EFC",
       "checksum": "c604a929f1039df20b4a2055496fd211a9190b493183b3311bf332be0018f0e2"
     },
     "x86_64_macos": {
+      "etag": "0x8DC630FDC08E109",
       "checksum": "8f2876f85f63f77d9625ef0b75eb7d67329174f57290f47e1b171ebc8d44c493"
     },
     "x86_64_windows": {
+      "etag": "0x8DC630FE0316066",
       "checksum": "aaaf21fa1ea20b6b184ff9d31683038783caf82c2b940a233b40f04e9d2cf89b"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DC630FD20600BD",
       "checksum": "97dc7a3c7bb0541f938918d7effe89958c86619c6408d30eb6ded5fca3e80726"
     },
     "aarch64_macos": {
+      "etag": "0x8DC630FD3839FBF",
       "checksum": "1fbbc16736004f455b2c8ea685573dcfae953ce4c2c6da559533be8e600da491"
     }
   },
@@ -154,52 +179,67 @@
   },
   "19.0.2": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DC5A5FA4D0AF44",
       "checksum": "b4dbfb73b5434bfea92b495fd8bb4721b6cd58d193f892ddbb1f89cfa85867f5"
     },
     "x86_64_macos": {
+      "etag": "0x8DC5A5FA5DCD2C7",
       "checksum": "51aba2cc4cdb56571e0d1f702fb42a46f32e5992d009fddf0065ca345d2500e4"
     },
     "x86_64_windows": {
+      "etag": "0x8DC5A5FA8F19771",
       "checksum": "493427165fbe00899dcd09e446204211c24e3ad7c55a75c0680c3e83166b6118"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DC5A5F9E9F6680",
       "checksum": "747184550b194a1f58c8749c05a623eaaf0bf6f0b7668db8460ca808beeca48c"
     },
     "aarch64_macos": {
+      "etag": "0x8DC5A5F9FC9EC46",
       "checksum": "b32925c7903c7b1029d9634772beb155e2de630571e03f6b9f4b3f0e9b659b74"
     }
   },
   "19.0.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DC5348C4E30CC4",
       "checksum": "d12a6f2a3bd1f1c26461dcd37d8a1d4695d8e126db6c57bee8dff1a1a2794221"
     },
     "x86_64_macos": {
+      "etag": "0x8DC5348C591261F",
       "checksum": "84ff99246f92254ff57b3e9bc817b043df5dfbb3a6fe673d61fc8eebebfa5038"
     },
     "x86_64_windows": {
+      "etag": "0x8DC5348CA247196",
       "checksum": "9c4c3822fb9cd8c05a12b4022218658fffe4c5be4bf2c6472f30471babadef62"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DC5348C4A868C8",
       "checksum": "2c879f9a3a44bbf89e37febe2a7f30baa280a217d9e4bd08ae6ef0f6bc4c828e"
     },
     "aarch64_macos": {
+      "etag": "0x8DC5348BE349855",
       "checksum": "ed9c32ce4f8b54785f30c259c6c88243b845bc51d1995f0ab5093713a14ffbbf"
     }
   },
   "19.0.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DC48F08EA38430",
       "checksum": "9b22a1847ab493e18771d4a7a992ffd02729a83309b9b8526e87c65d65d262a4"
     },
     "x86_64_macos": {
+      "etag": "0x8DC48F090D04E67",
       "checksum": "a1e21e8a9a0aaee42b05aace5891962d2b0c350d4bb19c7bef001bde63d5b2c5"
     },
     "x86_64_windows": {
+      "etag": "0x8DC48F0928CD39F",
       "checksum": "371b23b52b4f4ba8be1524d5ad666c6383c9c30c0365ae66ac404196409731d6"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DC48F0886A2BA6",
       "checksum": "f37c4af2e66177641627b2fcd419eba9f68daa1bc4e2062561af26d6a541f6f9"
     },
     "aarch64_macos": {
+      "etag": "0x8DC48F089943D49",
       "checksum": "bb566cad203eb3dc1942985574223258007a2f5099fdf2971a0a2fc6744c0643"
     }
   },
@@ -211,86 +251,111 @@
   },
   "18.0.4": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DC5A5F998B1E1F",
       "checksum": "b77b3e4ac586f82995cc94540d02d1054adc941ca170aad44c2cafb108419f4e"
     },
     "x86_64_macos": {
+      "etag": "0x8DC5A5F9A982AF7",
       "checksum": "50f4809fdc06a24d47616fa826e1ae8ddaf4443e39a7abdc668607ae02c309e7"
     },
     "x86_64_windows": {
+      "etag": "0x8DC5A5F9E6E2DA5",
       "checksum": "2551e898f8907251e6dce97d2c40b2e10bc3b92dac8a62667bbd5b3a3031526f"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DC5A5F942D752E",
       "checksum": "90ee690b2041c70ce2cdf74abafd50580f43ff26d1e6517b91a0c6a71acee405"
     },
     "aarch64_macos": {
+      "etag": "0x8DC5A5F950CEE91",
       "checksum": "8e3e6ca7248bd29ef28063bc5f1a34cc75402538e97fc35fc9e84d08a935ceb1"
     }
   },
   "18.0.3": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DC42E7D1AB26A4",
       "checksum": "1252dbd077fcdfc54da17a45860dc90c558f7f4d9301143bec9f59ce548301d8"
     },
     "x86_64_macos": {
+      "etag": "0x8DC42E7D2CD03C2",
       "checksum": "b322a75579ee4bb911caf8046050f9f324918891016d07b71f4b9ec17ee8368a"
     },
     "x86_64_windows": {
+      "etag": "0x8DC42E7D5D63CEE",
       "checksum": "63bd449deffa234714acf9c25dcb146590dbcf52ed6046a253d18d002f25ce30"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DC42E7CB972F5F",
       "checksum": "6f2cf8edb9a651adda57de7e64f78e621e6dca14f102ac202f263fb2f7de28f0"
     },
     "aarch64_macos": {
+      "etag": "0x8DC42E7CCAFEEF3",
       "checksum": "ae5e1b5107c85cef66ec6e2bfca8511e56a6b42c237feffe74c31fb30a380d38"
     }
   },
   "18.0.2": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DC38B4B6BD3327",
       "checksum": "dc823d37bfd4641817b33e9b0dea83bfc7879979591d3158491ffb82293cc048"
     },
     "x86_64_macos": {
+      "etag": "0x8DC38B4C20311C0",
       "checksum": "432e8e04aa4370491e11569da7b338daecedea8074420ebeea90d167e45a815a"
     },
     "x86_64_windows": {
+      "etag": "0x8DC38B4D93C4CBF",
       "checksum": "833a15544952d31900da46094b96306b239817505f9457430b983ee8bde1584e"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DC38B4B5CCDCE2",
       "checksum": "732ae6240c90ce3bfe96e3217ad7fc914edf669514eb7b7bf96a32a156c232a8"
     },
     "aarch64_macos": {
+      "etag": "0x8DC38B4B24CFDCF",
       "checksum": "abc68b059e77c231bafd63b47a15fad50605604ae26c5a6cae542a9e81e7d591"
     }
   },
   "18.0.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DC3260935FA251",
       "checksum": "9951c0947cab9e1426b68f8f12f8061a103d0863a2b6ae1a50276013eda780ad"
     },
     "x86_64_macos": {
+      "etag": "0x8DC326095110F68",
       "checksum": "30299e7c8604585dfdfb1172b12a6ea08bdd4a770cf3907e566545c7bee35916"
     },
     "x86_64_windows": {
+      "etag": "0x8DC326099DF9B87",
       "checksum": "07b5f1d03afcbccef2182b92d809dfbb7e076a60f8dc68c204fe54f753231e53"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DC32608A2301D5",
       "checksum": "3f5b08b5fef2864ffc459e2a50fab8e72ba706865c09f6d0d0cd260e5f014b79"
     },
     "aarch64_macos": {
+      "etag": "0x8DC32608BC4C91D",
       "checksum": "cf6a547e8b4dd82732ee6e626aeccdb571d9c157090eed4f50f26557a0d6cbac"
     }
   },
   "18.0.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DC324E842B9737",
       "checksum": "7c2a20b8fc301d4a0cd709529c1d804d7d7584c0f6d5849fc25b911578e651bc"
     },
     "x86_64_macos": {
+      "etag": "0x8DC324E82D3F2DC",
       "checksum": "8e21002f802ff5f9c974f38ea2a339b1fa173582d7b5b4325b149f52eb43b6da"
     },
     "x86_64_windows": {
+      "etag": "0x8DC324E87B3D0BA",
       "checksum": "ee09eb5013dd8af7ade8173517d80430e08e4377dda3f84c0f024b0dd98a3453"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DC324E7BCB661E",
       "checksum": "562e4557d6b8089522069d523131bf6572efd323baa02333f4015fb359c6c671"
     },
     "aarch64_macos": {
+      "etag": "0x8DC324E7CCDF74A",
       "checksum": "796b0a15032db1699d2be3d67e0e6080dffde28df8dc38ab838931b1f51c585e"
     }
   },
@@ -302,69 +367,89 @@
   },
   "17.0.3": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DC5A6148DEC1AA",
       "checksum": "28106cdcf00d4252f080956fcc0a6cc1140695cbb9c4590312b6a6f9118469c0"
     },
     "x86_64_macos": {
+      "etag": "0x8DC5A614A4EB4D6",
       "checksum": "8d0b051a937a81d3b7e3b9c28642c49a5e69dd726da72adea29b91f0bc40d261"
     },
     "x86_64_windows": {
+      "etag": "0x8DC5A614EA1E617",
       "checksum": "3a5a93c23f0e129e183f578f525b1fcee995bb8a2d7f7bd675cdc38f85c31135"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DC5A61407A9BF0",
       "checksum": "7b4243803a07b6febb4f76b8038a056ceb0b03099b7a8e71aa77e13362cdfa06"
     },
     "aarch64_macos": {
+      "etag": "0x8DC5A6141D5E5E9",
       "checksum": "f6b9555c4ffe15e5853d1d5d3f69d23ba235e67c612294f579ce00f795bb2e58"
     }
   },
   "17.0.2": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DC38B459AD6D08",
       "checksum": "6904cff035e73160cfed6dae69865a86faba908e571a701ec131205839d12f5b"
     },
     "x86_64_macos": {
+      "etag": "0x8DC38B501555E92",
       "checksum": "cc2a1fd4dcd91d1078d70a7ca767b45154d585993c0d0a7bcb7b065e714a559b"
     },
     "x86_64_windows": {
+      "etag": "0x8DC38B498FB7B7A",
       "checksum": "99713b272a5df2438b890d865bf09122a3fed554a68644f1fb47c703b517de6a"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DC38B483818069",
       "checksum": "bc8e8f9f34ba3ea16dea87982c8772d472a3417992ebcf2a8e9bba85a10d1107"
     },
     "aarch64_macos": {
+      "etag": "0x8DC38B45810A8D6",
       "checksum": "db07ffb71a3d5ab8f13210ed9095b86327b9b65c938ddf73c9429121b1e68a91"
     }
   },
   "17.0.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DC283483471AEF",
       "checksum": "2d9ac9d37cf4e57a2d9cbe02f866e87d5d50600bed6268120b99b03281c428f4"
     },
     "x86_64_macos": {
+      "etag": "0x8DC283484638053",
       "checksum": "9307d655b7e783d0bcaa22c5d48a8e38f20be367e9eabdc2dbefa120cb082eb9"
     },
     "x86_64_windows": {
+      "etag": "0x8DC28348832FBD2",
       "checksum": "b8b3ddb454094bf24ea83ea7f9d2c1cca35d4519c35a02085f4b73fc0f67b84f"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DC28347A4E3755",
       "checksum": "2a6f5f4118eb5558d3d78672082293ea86622561cea18368e37cc7950eeb9a5b"
     },
     "aarch64_macos": {
+      "etag": "0x8DC28347C08006D",
       "checksum": "29b0f9e0c949c9e5147ebd74dbc537f2f1e9c7d3c6e9d06b80c95b4994da31be"
     }
   },
   "17.0.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DC1DE4939D27BB",
       "checksum": "d419e5280b0bd28084b3586950a90904eb0ea1d77a44464e528365db25f30ff7"
     },
     "x86_64_macos": {
+      "etag": "0x8DC1DE494A24E39",
       "checksum": "20e7d1f18d4763d1ce59f844ba6195c6ec387b76fe94015e473934ef8d918cfd"
     },
     "x86_64_windows": {
+      "etag": "0x8DC1DE497A48A45",
       "checksum": "bc0b837e258e2e7283da90edb9ffeaa7c3716d5b33c9a8c53d9baa957a687c8c"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DC1DE7B264C790",
       "checksum": "2871ae8151e0f93363f16a6f1202561dc15b2b646e5b96a67456f1c8a67caab5"
     },
     "aarch64_macos": {
+      "etag": "0x8DC1DE48EC701CD",
       "checksum": "4a3084e6a426246f2d9e54ea38c1a22418874b4f715d44a88e87668c05540785"
     }
   },
@@ -376,18 +461,23 @@
   },
   "16.0.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DC018AE3400DAE",
       "checksum": "7bb4c78977a711b3af820e7e120e05b63124b0c9707f82b39ec02252caa01504"
     },
     "x86_64_macos": {
+      "etag": "0x8DC018AE463BD65",
       "checksum": "5a0f814a7124407166212866bc5fa381a2e615bc05152e5c749986a2697c5a61"
     },
     "x86_64_windows": {
+      "etag": "0x8DC018AE7919340",
       "checksum": "c6a4a247fbe50ba306dcaf91327e3f4eceac007554739648cf09542f87c12efb"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DC018ADD43C9EF",
       "checksum": "b21cc534b3dc89e6abcfca9981f9a0a156291b2418d2ef45390dd59013a98adc"
     },
     "aarch64_macos": {
+      "etag": "0x8DC018ADE62286D",
       "checksum": "a9d5b7e75d7b8877390b9b0b078fe995d721d86ea9f11fc97a43fc1a3352b0c3"
     }
   },
@@ -399,35 +489,45 @@
   },
   "15.0.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DBF2A02A5A83A1",
       "checksum": "c42e1fe7c5aaa685e40b31c5d5834a52821729ede40a6af3daf4052967c2ed16"
     },
     "x86_64_macos": {
+      "etag": "0x8DBF2A02E08421D",
       "checksum": "0a8cddf89d4d6c142451e7571779e6a432c7fb343a78b2cba34655b957350bba"
     },
     "x86_64_windows": {
+      "etag": "0x8DBF2A02F4F56D8",
       "checksum": "fbd32138bfdfba5cac2067dacd4c3a5d4bcac1137e138177e684f6cd8a5ed6b8"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBF2A0238D38C3",
       "checksum": "037e9e562f69e81c885337916067a9457a3f6b01e7e6ffc5feefb291794bda38"
     },
     "aarch64_macos": {
+      "etag": "0x8DBF2A024D2C88E",
       "checksum": "d0f958d1285b6dff337f4a8c0ef5b282c6484608c712c2ea4482c0b5b87b66af"
     }
   },
   "15.0.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DBE9E396D25BA0",
       "checksum": "ace1bbd35cb6c9aea7f970ea56e19b63d16eaec66d852b767dbd3e3c3092ce08"
     },
     "x86_64_macos": {
+      "etag": "0x8DBE9E18FFD9AFD",
       "checksum": "2913d43f2d943071566daaf4e2a47cf4a7e58bf077817b6e431b2ecc2da772d9"
     },
     "x86_64_windows": {
+      "etag": "0x8DBE9E19542CC7C",
       "checksum": "70ee6bf44afd29cdd6b480675070e899489162906d83449a7d4a2c82cc2371c3"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBE9E1835993CD",
       "checksum": "8feef65dff1acd5b5f69e5f08e34d3c3c29c6fc680c30a3a1cfa8b618c45818a"
     },
     "aarch64_macos": {
+      "etag": "0x8DBE9E184E249C7",
       "checksum": "51c5bb6d83f111228fe59ee42b5e7dfa0f3ff7a65665f20237c44acf20ee5e42"
     }
   },
@@ -439,86 +539,111 @@
   },
   "14.0.4": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DBDB0BB3647067",
       "checksum": "7683aa6a7922cb6c7f687022026057e522abb2b20dde7d7ddef773382703dd78"
     },
     "x86_64_macos": {
+      "etag": "0x8DBDB0BB47B8515",
       "checksum": "7ba9e46478f8340de74154a663473bca8d16efb51f2680c48da59a6164d98e60"
     },
     "x86_64_windows": {
+      "etag": "0x8DBDB0BB7CA7C37",
       "checksum": "d92867844663287f9a74e74f5006212f81f3af80e80ec000245b34a7a9375fe8"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBDB0BAD04A4D6",
       "checksum": "0c9131bb4d022a310cb18900dd91bef2be383c3bce48387c8200804259422b4c"
     },
     "aarch64_macos": {
+      "etag": "0x8DBDB0BAE1D17B0",
       "checksum": "e15b16c0a5184e36d0ffc27d7b5b96f6de04cc4edd6c165d8280a0fad44d9d55"
     }
   },
   "14.0.3": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DBD961E881519E",
       "checksum": "9edc728b4601d4552cbdecd23d1c6e9712ea4e5a645518b1e570c2aa0165954e"
     },
     "x86_64_macos": {
+      "etag": "0x8DBD961E996933B",
       "checksum": "04f994c58febde85c57343c55bbeacfc021a3505257accbea2d2df532244ec3d"
     },
     "x86_64_windows": {
+      "etag": "0x8DBD961ED2274D4",
       "checksum": "6ae803bd0e66f2fc22b4165b0282757571a101af60fbac789a6e7f2074ac72a9"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBD961E21733B8",
       "checksum": "4eed3576ff23152c7f107244d0c1d6f3d2a663aebb160ab972207e82eb796e2e"
     },
     "aarch64_macos": {
+      "etag": "0x8DBD961E384B979",
       "checksum": "59e6f0777d016de7816bac99086f2060114f05a46a25e13ce81b3f23a839d59b"
     }
   },
   "14.0.2": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DBD63BD747D051",
       "checksum": "880827d58ee9224225e06f3cda1dda1df2685569b29a07596c5ddb1c382c998b"
     },
     "x86_64_macos": {
+      "etag": "0x8DBD63C0EB51786",
       "checksum": "b13a78310e78a7acea9d9667aaec896115b293eca5700dcd74764a5521431d33"
     },
     "x86_64_windows": {
+      "etag": "0x8DBD63BD9C56D5E",
       "checksum": "8edf2a37fcb4504a59bccf63fd9e4110d28a5ebb6cf9363267bd584094e81aab"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBD63D1BBA3A3B",
       "checksum": "877dff2c4c619f6ba44691b4ef44a6b89163ba34d47c9a785cc45ff207abd1fe"
     },
     "aarch64_macos": {
+      "etag": "0x8DBD63BC87D5387",
       "checksum": "d1de12a057122c3c15b755469b24f41448aa0b9bbe46f35eb740054a295e386e"
     }
   },
   "14.0.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DBD3F75BCA8855",
       "checksum": "b12443cccd5edab3dfe8d4033348475124275706c2817573bd19be9e5ae32a79"
     },
     "x86_64_macos": {
+      "etag": "0x8DBD3F75A4245D3",
       "checksum": "183ed79e53a3dbf9c726e153a33c1564dc251a033b7a0120ef86ccd37b54625f"
     },
     "x86_64_windows": {
+      "etag": "0x8DBD3F76185064A",
       "checksum": "81f80f914d67d30a403d0593e9ad65c661e47cca65d7013ad07fd977b7409956"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBD3F91AC3F80D",
       "checksum": "eb0c4edc80dd8c98194d7b660daa2778042290a3c2268aee97af691786a189a8"
     },
     "aarch64_macos": {
+      "etag": "0x8DBD3F7536BB047",
       "checksum": "282acc05188c0df89dc3c5ba1ff7d78945b6cb7c7917bdeb4a9ca6360fc204ca"
     }
   },
   "14.0.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DBD18A085F9F12",
       "checksum": "09dba633439859b8d7e21fa803f04951f2ab6da5d8a85ff2178c5748a0f46338"
     },
     "x86_64_macos": {
+      "etag": "0x8DBD18A09BAC2BC",
       "checksum": "17684c65dab1de8bebb81a634a736c53820454ba2dbf97ea7b5f18f7fed1431c"
     },
     "x86_64_windows": {
+      "etag": "0x8DBD18A0E9331C2",
       "checksum": "8751bbefb351a10891a15221770f5948d0b198a56033251e85691159384a7e52"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBD18A00724336",
       "checksum": "78b41d7b1268b624e6302f333994238219459cd3545281265e5efd42d3cbd304"
     },
     "aarch64_macos": {
+      "etag": "0x8DBD18A01B0FE19",
       "checksum": "93400e03c0eaa24cf36156bcf2f871016fb6b542c0f429549b45449714dfe976"
     }
   },
@@ -530,35 +655,45 @@
   },
   "13.0.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DBD6334D5CB1F4",
       "checksum": "65c98b4165d49e5d85fe189c99586c919f6f5d97d307debf02ead9ac239c9637"
     },
     "x86_64_macos": {
+      "etag": "0x8DBD6334EF83FA0",
       "checksum": "210fa2a44460df64a44e13683438cf22036faced14fa77295d50e6a181d853ee"
     },
     "x86_64_windows": {
+      "etag": "0x8DBD633536C69ED",
       "checksum": "38992da8e4d41fa3391465afdd12d625f8b7e9883787354486dd80009f226979"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBD63344F4BCA6",
       "checksum": "fbc5ae03a1289aef4c712580e3f6d41cb9e5c1444149f6caa4cdfb766dd452f1"
     },
     "aarch64_macos": {
+      "etag": "0x8DBD633466E1BC4",
       "checksum": "4f766d93491dd4611063aec55fd723c348f94d0e847a7f5122a825e38783ecbd"
     }
   },
   "13.0.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DBB9EE28E4EC92",
       "checksum": "af14e310a27d28e07675bb5d5254adee1cfddfeab0d9541e68b074f6263f4c2d"
     },
     "x86_64_macos": {
+      "etag": "0x8DBB9EE2A87C499",
       "checksum": "a68023cd806de4432a102f24b07b204c8f83f8ce626c5ac4f248faa0807d0f49"
     },
     "x86_64_windows": {
+      "etag": "0x8DBB9EE2FA3CD10",
       "checksum": "ad1dea7c069eeda2432d4344221b05c46d146aaa7f5b16cbd468932e9fdaac76"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBB9EE1D5F8B9E",
       "checksum": "2422b7c6c0d60bcfbab7d098ead0e120e24971525521a7758ea1a1db5ce57395"
     },
     "aarch64_macos": {
+      "etag": "0x8DBB9EE1EFDAE15",
       "checksum": "12b32b91e07f53ea363505530b6fb3312a7ac1e71ae38957bb545011f10dbaab"
     }
   },
@@ -570,52 +705,67 @@
   },
   "12.0.2": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DBB57158B0321F",
       "checksum": "f78bde3bd5758b9b228b98e45c5b40a3f48f73a8d0b19dbed111cd71fcdca570"
     },
     "x86_64_macos": {
+      "etag": "0x8DBB5715D65D4C0",
       "checksum": "ed1a8760c5ddc9d3565a76908bb1e8a008b731b43ffa069b18d403542e49c683"
     },
     "x86_64_windows": {
+      "etag": "0x8DBB5715D49B9D8",
       "checksum": "9843d87d6bde399d7ccb3ba8699486f5a5ea145b106fa3bd4ca6e13ab2c61119"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBB57150F6CEE7",
       "checksum": "1a59e011e9deb4d3d7eb468028a56026499f5584727ea0a8c90012037455ac3c"
     },
     "aarch64_macos": {
+      "etag": "0x8DBB5715251CB08",
       "checksum": "3f20a5b95950e7291f9dd07c9d84ebe115b34db283c7939b8f4b45e833b84a4e"
     }
   },
   "12.0.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DBA4D2BB14680F",
       "checksum": "59eb24b421c40104240d00848e3d9ffee5403b7e15958ace974aa2705050b0b3"
     },
     "x86_64_macos": {
+      "etag": "0x8DBA4D2BC6FB226",
       "checksum": "1975f51fd251fa19345776328f958985606458b5d7178c5a10fc72fd9f2ba59f"
     },
     "x86_64_windows": {
+      "etag": "0x8DBA4D2E1D239CA",
       "checksum": "1878426629e78c7d80d26448fe5c9d8adf878383edc6ea4c772bc7ef59f963fb"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBA4D2B3290853",
       "checksum": "7ec484c9f3c3002a789c41252b630ac509b0532102bfd3aa66e5d6d7dbebcc74"
     },
     "aarch64_macos": {
+      "etag": "0x8DBA4D2B50A29E1",
       "checksum": "975e286eb7ad4a4e17b7bb73b0b39dd6212ef7606f6d74ff63d5d8f2d5f7c339"
     }
   },
   "12.0.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DBA28E75B69DB2",
       "checksum": "c31e0d8eb2797627ba1f72b313315da960016f87ccec3cce2ae67654060a8f04"
     },
     "x86_64_macos": {
+      "etag": "0x8DBA28E76E1BFD2",
       "checksum": "27a649593f3106f256c227d26ce8f3d03b360a267d89b094537217104fa05e88"
     },
     "x86_64_windows": {
+      "etag": "0x8DBA28E79F54F54",
       "checksum": "fb0c6e981f2d1997174ef198819091bdca517c20ecd727762e0b38d2643b1b4d"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBA28E6EFE41E1",
       "checksum": "3693fd9db6ad37e6937c5fdc003f0038bbfde9eec0ad33ee7cc611a85cac29c4"
     },
     "aarch64_macos": {
+      "etag": "0x8DBA28E7002F464",
       "checksum": "64d594618e47e0b5b70a3b38c943e6d79c145ea281defef1ad13c92faafc3e8c"
     }
   },
@@ -627,52 +777,67 @@
   },
   "11.0.2": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DBB57106AAC269",
       "checksum": "71d67b23ba4e6a1a589dcfe0658fd7125b5ceb5953481f90611c616ba1dd8986"
     },
     "x86_64_macos": {
+      "etag": "0x8DBB57107E6E752",
       "checksum": "b039ce32979d61c9e8d3dd82fa18d900954ee91f160666066d5353a1eb5a15b7"
     },
     "x86_64_windows": {
+      "etag": "0x8DBB5710B2095F0",
       "checksum": "a5b3e795ec242a4c38184b4ce7d4239a8878985338e1afa7c33dbc86bd0f8b43"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBB57100A0FAC0",
       "checksum": "d1d628721c3d8b36d7d19b396b25d5b8d6f2a97f6e7b48f31913893b280a1b90"
     },
     "aarch64_macos": {
+      "etag": "0x8DBB57101A647F4",
       "checksum": "2654ef8ad5c7f64c9c9cf0a4d7b50592785d3402329ca84e0e65e35896293c7a"
     }
   },
   "11.0.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DB8C66A0C2023D",
       "checksum": "90bdbe4c650c7b45f96579f9026cff3071f1fa3ea7cf31fad5a3559c3318e23c"
     },
     "x86_64_macos": {
+      "etag": "0x8DB8C6693BC6C7B",
       "checksum": "85e51d5d87997612690d615868d8a0542cd09f81f60e2f74eb8cb34714c295b7"
     },
     "x86_64_windows": {
+      "etag": "0x8DB8C66AF008C91",
       "checksum": "0048fbc227bd600aa21eff6b32d12092bf96d72c99483fe229e9db698dfa1f6c"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB8C66A06FD1E2",
       "checksum": "f1c9323dec3c84b64cacdcf0e4c9f6a1aee87905ace6732b0c7fb4820a9bd563"
     },
     "aarch64_macos": {
+      "etag": "0x8DB8C668D7A6CD9",
       "checksum": "8c9839a42d47b50caec599f569bb800b74fb1963d7b8c600b9c9b07bb2d01cba"
     }
   },
   "11.0.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DB893D52CD04BB",
       "checksum": "8723d437ff07b02ee3bc8885c8624bb34a52d96e70477f81e87d1936d2b84556"
     },
     "x86_64_macos": {
+      "etag": "0x8DB893D5AA71664",
       "checksum": "2691cb31bf7dfe792d29fd862ed6142e892191e481d1c93e74c8fbf5c4e2bdf4"
     },
     "x86_64_windows": {
+      "etag": "0x8DB893D5E2A75FB",
       "checksum": "e7d17a0613fbbe0194e2340899d347fff2ceacc466decfbb7cfba0a4715df950"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB893D47BD3520",
       "checksum": "662b9ce9a8b447b24ef6cfec811bf6f5f13a6ca4112836f8d3781b8e268dea34"
     },
     "aarch64_macos": {
+      "etag": "0x8DB893D46F93A98",
       "checksum": "6a6910e0fa8f792f650db917f25454782fe00f78f9f8c2f1b30232a5c1fb7981"
     }
   },
@@ -684,52 +849,67 @@
   },
   "10.0.2": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DBB56DE4FF9D5B",
       "checksum": "08b0e924918ff7409ccec14475c753f991e6ef535e2875a1a48c89dbfc85162d"
     },
     "x86_64_macos": {
+      "etag": "0x8DBB56DE7BE64D7",
       "checksum": "2fb77c2ee05ac5c902f0bf57d7f8ab1f876bfd4f3c57c1fbbd36c97f60a8c798"
     },
     "x86_64_windows": {
+      "etag": "0x8DBB56DF1683FE7",
       "checksum": "3ca5fd7b4f6251e1b183d287dee08d6c38786f5ffb7dd313dda5b1672b7c2456"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DBB56DCCC312D1",
       "checksum": "15ab7c7650499200729f3514d9232f848b304485fe60add47e22fc6c55629d48"
     },
     "aarch64_macos": {
+      "etag": "0x8DBB56DCEFE714A",
       "checksum": "e2c66ca8ec6cf5999c93a3823a187e7cfba9225a06027922e9ed7f1fe6d86f5a"
     }
   },
   "10.0.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DB72A9B61F2AD1",
       "checksum": "ea7a96e7d30ff6d64d0e212900f9a2c4f1d009266e014d62cb5edb16c6f1a7f6"
     },
     "x86_64_macos": {
+      "etag": "0x8DB72A9B7CEC56C",
       "checksum": "e9d7e1511e67a1f21ae11ad765f62a3bfc99999b251de4fd368480348f7e6c03"
     },
     "x86_64_windows": {
+      "etag": "0x8DB72A9BB8FA9CF",
       "checksum": "05452d493a620c1cef3612c007c6050be77598265d72ea50081294712808c949"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB72A9AEEC13DD",
       "checksum": "c237f3e661dcf9e69a890f8c327db5f65085fa94020cabd6d95c7d4b32fb85af"
     },
     "aarch64_macos": {
+      "etag": "0x8DB72A9B010FA83",
       "checksum": "aa0a00896e08a942e6416a67b7914f880bf6b494d16fb75484187e48adc24f35"
     }
   },
   "10.0.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DB71A24C4613B2",
       "checksum": "6df3770c26a0c892a89980d4a7d785b7356a855a4ac79c6745f02a7f2bf914fc"
     },
     "x86_64_macos": {
+      "etag": "0x8DB71A24E066491",
       "checksum": "dc499e4caae3149036571005d3bec542ec10e48725e11fcbb4f50652489b6464"
     },
     "x86_64_windows": {
+      "etag": "0x8DB71A25388AA74",
       "checksum": "c08cb3e8cdfb1e01ca01f3b6a80b48d9e50d3a344daeaac333748f23279cfac6"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB71A242F122AB",
       "checksum": "840834ef89612d3392e108e6550d6b362e96952c09fcb2404f6ac59c1c707ed5"
     },
     "aarch64_macos": {
+      "etag": "0x8DB71A2449A0E55",
       "checksum": "b14b4f4a4e639347a0f6e990056bd27c0510857b965f27ee08d0f347704a6e74"
     }
   },
@@ -741,86 +921,111 @@
   },
   "9.0.4": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DB6C2A3C3DC724",
       "checksum": "1e38bae33433c2c31ceefd450a6d54f938b608d48a256497239342feeb6db772"
     },
     "x86_64_macos": {
+      "etag": "0x8DB6C2A3DE381B0",
       "checksum": "558aa42596a2dd08ef2c8d57901659f98fa2689769738039429a8ed56f91a606"
     },
     "x86_64_windows": {
+      "etag": "0x8DB6C2A534B3F49",
       "checksum": "809aca3fa66d3322dd9eca1e0e423efa3bb13b9feb7a3d3ffd4a79fbdcd74d61"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB6C2A393E9563",
       "checksum": "e5d01fae620bf2a9e9816f4e5cf5ae8830e2154e8238c78ce49380a5aae2c2fb"
     },
     "aarch64_macos": {
+      "etag": "0x8DB6C2A2D49B4F0",
       "checksum": "bc3258b94f71f7c1278af48ac89844b55e1236f58e3a917828d5c7e68093c0dd"
     }
   },
   "9.0.3": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DB622A95F6D4EF",
       "checksum": "7089f0ab5bf4d870e79a4c61404b36562e5ad486325d5da20d9c7dfd01cbce50"
     },
     "x86_64_macos": {
+      "etag": "0x8DB622A987166C7",
       "checksum": "d2dc9c04ec2877728c85cc08ab6a7ff5569746c462a6639c41b2e10d372fc330"
     },
     "x86_64_windows": {
+      "etag": "0x8DB622A9B083A79",
       "checksum": "ac2c610f83d994b09a85f3467ce2252da69c9db37a638d1b4c372a1f3d9be160"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB622A8EB3C95E",
       "checksum": "88ae51524df14ebb01564ba459ced6d5cb9fd20c1c576de32a33c13e6bb2ee13"
     },
     "aarch64_macos": {
+      "etag": "0x8DB622A8FC12408",
       "checksum": "799310028674842752e6621e8418590cc1ddbc344a7e21a21f6ae8dfe7045414"
     }
   },
   "9.0.2": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DB5E30F783A990",
       "checksum": "002822c52ea3499e7a0e4033a390123c7877b6655a69ce9426e1a370f351cae6"
     },
     "x86_64_macos": {
+      "etag": "0x8DB5E30F9386F42",
       "checksum": "5641b9234774a8ea503a860815dcdacb423d1b1a84310f7dc4faeac09e629fbf"
     },
     "x86_64_windows": {
+      "etag": "0x8DB5E3100202F54",
       "checksum": "621a97ec51d06c814f89688dab4315d1425685c609102d4b8d7dd80e5dc5231e"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB5E30EE0B0151",
       "checksum": "ad614fc1b72618b9afd5645e0212bd763468f4f2a5572de09890e4759b29e8d4"
     },
     "aarch64_macos": {
+      "etag": "0x8DB5E30EF9F9209",
       "checksum": "68f5f644f4c814d36f5190a41dc312acd97d8ef4e6a5b60e41fdcf966ea19140"
     }
   },
   "9.0.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DB5B18E3575687",
       "checksum": "f90a3f7a0fe5a7c059947c029c28a2ae65ef24335d190f82e57725d9706cb413"
     },
     "x86_64_macos": {
+      "etag": "0x8DB5B18E47B2D1A",
       "checksum": "2d0671338148745c4370eafb7b829f40fae7a2ad072bdd26e78dac799a848d82"
     },
     "x86_64_windows": {
+      "etag": "0x8DB5B18E7E8F834",
       "checksum": "dbe62d44ef93e633201aa20043965c5546697fdaa80b81af8f6b0414a5f58b2f"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB5B18DCB81041",
       "checksum": "c1bf970bd2af9574714441150954b7631887e54e600be4b274169668b1077ca4"
     },
     "aarch64_macos": {
+      "etag": "0x8DB5B18DDA5AA8D",
       "checksum": "94f242ec880e91970a70b2c03da6a7fe90ded32ba9c4e400dc7484a25cec2d31"
     }
   },
   "9.0.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DB5AD540717658",
       "checksum": "7616b94d7c30eaa4d4ddf41a58128ac73b943c21565adb12d143ea46959de4e2"
     },
     "x86_64_macos": {
+      "etag": "0x8DB5AD541C8319A",
       "checksum": "fcceb6f2cf525f3c8050172bb455d635552a3d446fa051447606de2d2aa5ebca"
     },
     "x86_64_windows": {
+      "etag": "0x8DB5AD544F717A9",
       "checksum": "19ee22cb45c43bd81a1f7752c4bdb7498f830cfad2a69b39a7e0bacbb23aa22c"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB5AD539F0B93C",
       "checksum": "89c521f6df8dc5a5ac72f24aa5644c9c685f3e0ce4713ca9b95038c40ec7685d"
     },
     "aarch64_macos": {
+      "etag": "0x8DB5AD53AEC26A4",
       "checksum": "1fb0e56cb6e20a9b1d0abc8e65e7daabeca219e55ecf661ec71f5d05e0b0a198"
     }
   },
@@ -832,35 +1037,45 @@
   },
   "8.0.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DB4760F9864BB9",
       "checksum": "555985b17523269350d253c160dac601e383e1612126489daf80648571e0b8c4"
     },
     "x86_64_macos": {
+      "etag": "0x8DB4760F9D5723E",
       "checksum": "e81af9924a98cf565ff8eba9664b0433cc3ff579ad3ee93fb46c7e16e37daec4"
     },
     "x86_64_windows": {
+      "etag": "0x8DB4762EE4DD941",
       "checksum": "602bfe3fd715e5673b869f6f48ddc8d16df906701690562a3c29d5a02c894c6b"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB4760F593DFB5",
       "checksum": "9b8563547a8f57f15dd8392e538ed871d2e431d55556789934529e743cb6e498"
     },
     "aarch64_macos": {
+      "etag": "0x8DB4760F4FE8944",
       "checksum": "b428f872aca437c7ebbc341ff15a24e31ba8c097cfc7f97db0ac637901b984fd"
     }
   },
   "8.0.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DB41AD6C974FEC",
       "checksum": "0ba34842bbac8896dbdd860173b2c554d93d63ecc490f725fe3331db913714ad"
     },
     "x86_64_macos": {
+      "etag": "0x8DB41AD6DAC90A3",
       "checksum": "7748306b9be4d37e76d6df7e2d8b9b84bdcc62d9f3a642d008184075e4f10018"
     },
     "x86_64_windows": {
+      "etag": "0x8DB41AD7237344F",
       "checksum": "28171dc028abd209e3d46c6aa5d230f89f0213b756a6e276a98538bbe3d3b9a8"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB41AD654404AD",
       "checksum": "d2025860565caa24d39003b3c65dc9391248caeb7d586b3885ec2cc11a158bab"
     },
     "aarch64_macos": {
+      "etag": "0x8DB41AD66433E42",
       "checksum": "8d600ea89e0e7290763a17360daf2afec3a9fbfd774cd343a2b2f730fdcb34e3"
     }
   },
@@ -872,35 +1087,45 @@
   },
   "7.0.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DB476276AFBDDB",
       "checksum": "3616ece4f17435d80abe71ea9a2b40446e2a1d936b1628c3566b08473ec5758d"
     },
     "x86_64_macos": {
+      "etag": "0x8DB476277470E2C",
       "checksum": "478331cf38259fecf4ee3d8fe504c7aa65a9ad46f74f7811a9e66e5e7011b5b9"
     },
     "x86_64_windows": {
+      "etag": "0x8DB476279F34F2E",
       "checksum": "1f92ebc31dae09963e072a8c1909df058448d44e54f3bf3322a81fa505edf508"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB47627261B422",
       "checksum": "086d3157ebe5cb1a7d4c5d0264389728951cc3b95b5d949031437af6e335d56a"
     },
     "aarch64_macos": {
+      "etag": "0x8DB476271F892EF",
       "checksum": "5e8555898bccb2f378f5bb1183f3b93d8e38e003b66c83884d31df08a2d6c664"
     }
   },
   "7.0.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DB295BFDC77188",
       "checksum": "b8a1c97f9107c885ea73a5c38677d0d340a7c26879d366e8a5f3dce84cffec99"
     },
     "x86_64_macos": {
+      "etag": "0x8DB295C019528F0",
       "checksum": "70596a9f8fcf0b2467877cb184f41f6b451ade4ac74d1e0bb8986bbfbac925b4"
     },
     "x86_64_windows": {
+      "etag": "0x8DB295C0439A70E",
       "checksum": "bf796c35020df2df3a29475949e0330ea3fd47bbfd719d2959564c3e32a8c1a7"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB295BF5B3B00B",
       "checksum": "723171912c7cd6332c1ac599851dd04dcb107f60a9f18d9d2d3bd319e3c2c6ba"
     },
     "aarch64_macos": {
+      "etag": "0x8DB295BF789FFE4",
       "checksum": "8e66af9cb46726f2c9b22f96cd8a08a5f1112d2f02f13f84ff2167444b14366e"
     }
   },
@@ -912,52 +1137,67 @@
   },
   "6.0.2": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DB474136D1B8B1",
       "checksum": "270bbda1054ce0cfd537744e0697dfcdd8dc321af5973a6af13c408e4e2c9b58"
     },
     "x86_64_macos": {
+      "etag": "0x8DB4742700BBE8F",
       "checksum": "8368e02ece09ffea2af010013aabe6183653a5a6c6ad3c1b34dcfadb42c9b67b"
     },
     "x86_64_windows": {
+      "etag": "0x8DB4741A53FBBD0",
       "checksum": "6c0ff2877edab4bcb13b6114eff96be511b454b1bb3241eb6fc5ab8753ba675f"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB474118E14D3D",
       "checksum": "718d7c73317cafbcb67625ce24b5b358638e19d90a1339aa61db925832fbab1f"
     },
     "aarch64_macos": {
+      "etag": "0x8DB47421330F30F",
       "checksum": "189a91fe723c34624c1c767a17b6fc5cb50e9780e50b0377fb7b6c3c77db6e06"
     }
   },
   "6.0.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DB2009DF234D88",
       "checksum": "9fdc5f4cd679d77c42f6333793cd66ecca45347e4cbbeaf06cb0300f27ac5119"
     },
     "x86_64_macos": {
+      "etag": "0x8DB200A3001FA06",
       "checksum": "b9a3fff59995da204649123872126f08d4719c339be58a22f59768087e87c4e5"
     },
     "x86_64_windows": {
+      "etag": "0x8DB200A050552FB",
       "checksum": "366b6a598165c3e20b99ba32f1aad1c6373f1f52104ce2e5decafc9e1cba73ec"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB200950FB1EE8",
       "checksum": "dc6e69b1a90e2a35ea3d89284e3a1898df8d6dc4ea55c6fec3ae7e35b752a0fc"
     },
     "aarch64_macos": {
+      "etag": "0x8DB200AB83A9012",
       "checksum": "00e738f78448ae41f99f7c2c648277ef56a725198e33486191f2c0772bcd7ae1"
     }
   },
   "6.0.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DB1359BCE84615",
       "checksum": "19090d9f0b6320d69908c3a9d3915c1b8149555d971061eda462edc0e212e0d3"
     },
     "x86_64_macos": {
+      "etag": "0x8DB135A20A6EDC5",
       "checksum": "c5a817ed5b3e31301a74011459a8a4b887265fcaf32106f7455d1be44419b305"
     },
     "x86_64_windows": {
+      "etag": "0x8DB135A0A9F9E04",
       "checksum": "43ca5c47c396fbf1edbf6de06841be0be296b11d17e5753cb1266bd3c5653f28"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB13591A388FFF",
       "checksum": "465156922e11e423730f2884d3c5ecf781a27098d58c7b6b4388d739d30bb7f3"
     },
     "aarch64_macos": {
+      "etag": "0x8DB1359D4AEDD5C",
       "checksum": "f6c128aaea4aa7a1bb74d1d3eb00a82ea083208419345176af22afb9634ec7ae"
     }
   },
@@ -969,35 +1209,45 @@
   },
   "5.0.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DB20091E4E9413",
       "checksum": "c87e4e820ee4b605b4c6aa7dd12807da6fb9789a5906b7ad9df83e8b43dc547a"
     },
     "x86_64_macos": {
+      "etag": "0x8DB2009794C92C9",
       "checksum": "cbc75db0e8ce12e0026c59f8e3301714b9f1334beb4737d42ec7cf6dbd0f8269"
     },
     "x86_64_windows": {
+      "etag": "0x8DB2009ECC3C5B4",
       "checksum": "9dc38b15bc700aa0f37999354b48e94288a638711cf30bcea5470b80f106ab47"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB2009792ADEE0",
       "checksum": "9c8ef3abe412ad57af4dcff25b7dc0d5e86a2106e4cf71948ff098362023098e"
     },
     "aarch64_macos": {
+      "etag": "0x8DB2009B2A7B798",
       "checksum": "f2f2bd497a0e49efb6e5b705284995b2d3e58dfffb49bfba672682c306948418"
     }
   },
   "5.0.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DAFB140DEF0354",
       "checksum": "a627a0391c52f3543bb48bb3052038291b4bd94e1dee8e520afb7ad2d7dabbbb"
     },
     "x86_64_macos": {
+      "etag": "0x8DAFB1475E59302",
       "checksum": "f504550ef67ae66472b301477fb6218c1b4e2c8bf6ed343c928f070cadd11609"
     },
     "x86_64_windows": {
+      "etag": "0x8DAFB14D246E4BB",
       "checksum": "0275aa5632e8714222e85b7b04e186c2c354df148c04d37fe41b13e15fbf4bed"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DAFB13CA8C3300",
       "checksum": "ca319db21d252a7bdcb81bd3c1def5d57a0e3951e1b747661e68c86b562786ff"
     },
     "aarch64_macos": {
+      "etag": "0x8DAFB1512D55348",
       "checksum": "1dfe45ea469a790528a10ddc4251673ce167a4c845d71e248b37d425d8d706dc"
     }
   },
@@ -1009,35 +1259,45 @@
   },
   "4.0.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DB200943245BB6",
       "checksum": "ef6a6c6d1025031565eaeb4510dadc72fcfd3d11f2c402fbebb3f2022e8ce466"
     },
     "x86_64_macos": {
+      "etag": "0x8DB2009CF696B09",
       "checksum": "fd38be4e16a9aa75d5fc0fb440f97b0cdc1b8e90cf0a6f306ee06a938c8ef6ca"
     },
     "x86_64_windows": {
+      "etag": "0x8DB2009C83907F4",
       "checksum": "d682ecb45753c3f676306d983c53ba3d695caf4380dc4ef457d69eacdff3d2d7"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DB2009124FA781",
       "checksum": "07629fca5c6e7ea855245093c1e772570ba3e8dc00e908f556ca8b16b1388dc3"
     },
     "aarch64_macos": {
+      "etag": "0x8DB20098DDCC561",
       "checksum": "82905e054aded0d87b40fd9040d6a56a41a0ccb758c13076bb89ed7c7c6e534c"
     }
   },
   "4.0.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DAE385D524132A",
       "checksum": "3dadebe46ff415fc5c0e7245bdcead36fb0e236247be966d5c653e8b4bed3f65"
     },
     "x86_64_macos": {
+      "etag": "0x8DAE38621DE511A",
       "checksum": "40b821a91cce3dc3f9d61b26a1e2eedb240bd3c3b685a364bff7e63e89abc86b"
     },
     "x86_64_windows": {
+      "etag": "0x8DAE386FE061307",
       "checksum": "b0c88cde29b05f3329445046b9fda9e503886e36d2580ee261bda173b4506d95"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DAE385F815F1FB",
       "checksum": "b29029ef3dca2547c50c5d665ee6d00011d5f6dc6985760aae94636ef3007fae"
     },
     "aarch64_macos": {
+      "etag": "0x8DAE38611157028",
       "checksum": "8a38e3830bbc8f413586d572fa4e683947dfa7221376d637893b280a4cec5d0d"
     }
   },
@@ -1049,35 +1309,45 @@
   },
   "3.0.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DAD3CFD35F1DF1",
       "checksum": "8798b587251a6ebc535ba94000242ac4eaf6f38ae3884ce9dcbf9550f99a7359"
     },
     "x86_64_macos": {
+      "etag": "0x8DAD3D12DAEB219",
       "checksum": "f47a6b594bca606edc024fe9fadff971517a4ae0520eb175784d6a27a10a49e8"
     },
     "x86_64_windows": {
+      "etag": "0x8DAD3D1978293C1",
       "checksum": "2746bbeeb1489fd547b681a63e64f7a04d9704c35de465059e9f6e412aa62ead"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DAD3D141D5FAAC",
       "checksum": "7fedd9f9e45523953cd86d8c8add620eecd47d1d7a4c5b293984af9dd55d612d"
     },
     "aarch64_macos": {
+      "etag": "0x8DAD3D05507CA00",
       "checksum": "45daab521a64a07040d512fccd05c012c10b97b40ccab011f2de242cbe14deed"
     }
   },
   "3.0.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DACBED28E4523A",
       "checksum": "f10556b2a3e4780032bc95955a5fa77411ce5d3c23c8af07f5306d0ed57794d8"
     },
     "x86_64_macos": {
+      "etag": "0x8DACBEDFF7479DE",
       "checksum": "1b620426a11bd4e5df1f06222e0efd3f4ae8bb236b84fe9250b247c42490025d"
     },
     "x86_64_windows": {
+      "etag": "0x8DACBEDF115FC74",
       "checksum": "2a34b4a6179d749019787494352775a38d470c9df42d096d43c1dd99ac57a824"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DACBEBE0A82614",
       "checksum": "e2291272c69bdeaec98d4a9236e2b29ea2d166af46e2999111f70a7f7e14d258"
     },
     "aarch64_macos": {
+      "etag": "0x8DACBED6031CBA3",
       "checksum": "c5ecab37cc878270f00a532d89eca9ee5b9015b570babbb20fe6e1679de03c4c"
     }
   },
@@ -1089,52 +1359,67 @@
   },
   "2.0.2": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DAC3537C806BAF",
       "checksum": "c49daee342399f6f2396db71b1042e81c5e5ab24d16306d99481c209cf0abb38"
     },
     "x86_64_macos": {
+      "etag": "0x8DAC354C6ECE3B6",
       "checksum": "326b3d6933aaec78dbd132b305cca9f33e6607df144ea0d3cd1fff74640d4aee"
     },
     "x86_64_windows": {
+      "etag": "0x8DAC353E88F9B84",
       "checksum": "a112d6f6f5df21f20189e1c1e25a39e702daa3b0546a66065d279ecdfa99745a"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DAC352F605CDAB",
       "checksum": "c3cfbb1e1a7926dd0f6ba4052c8b6c4e5437d9bf6f13fc6166595c65b46203d4"
     },
     "aarch64_macos": {
+      "etag": "0x8DAC35377F35D90",
       "checksum": "e64454f92888f8d3cf85a1ea48d475e12029103fb2594920c9aace5eb0af6e83"
     }
   },
   "2.0.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DAB848D318CA00",
       "checksum": "da92a4370c363ac583176c264bcc7f90a802af8832f6723106431885c1fab3eb"
     },
     "x86_64_macos": {
+      "etag": "0x8DAB84BD3102233",
       "checksum": "e50f666d1e8ec5e2800dc08c3aac6750f7ab0c1d4a2bf165222eb13756996bc9"
     },
     "x86_64_windows": {
+      "etag": "0x8DAB84968A293D2",
       "checksum": "535c68b66a40410d5a1df282c77a9c9a707404b7a4f03037d1703b26a8ef99f2"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DAB848414A21A4",
       "checksum": "78e929e309d665930c295575c5766be5a98cf3351dca4f9169b8772ea3ce0dfb"
     },
     "aarch64_macos": {
+      "etag": "0x8DAB849A8146962",
       "checksum": "d60cefd9c2f63f68af36b7deba0d3cce7727e30ba5b05bae6990bd53fe1fef27"
     }
   },
   "2.0.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DAB2DD1A06B0B8",
       "checksum": "e641b35d3e3e4535d75ff89ba2db16d14c018051f923e80376faefe615b9391a"
     },
     "x86_64_macos": {
+      "etag": "0x8DAB2DD1001DBAA",
       "checksum": "74a0513522c78ad70d9d2b1a47cb8aae60530393e90374f796a222182027472a"
     },
     "x86_64_windows": {
+      "etag": "0x8DAB2DCFE729FE1",
       "checksum": "c319cda35bb2b12956543630befe572b802b0ad85c4910ed31b0cbb04f4125e1"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DAB2DD3AAABA32",
       "checksum": "370f46176e816d2e873fef4c1e90feeee4d88410ab60f297efa05bd6cfcc7b40"
     },
     "aarch64_macos": {
+      "etag": "0x8DAB2DD377E2CCC",
       "checksum": "2b8322bd1297cdc8d2579c0f1a8b98598026a59d4be1670d21bd5a67b7ce6d1c"
     }
   },
@@ -1146,52 +1431,67 @@
   },
   "1.0.2": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DAC37B42E124C9",
       "checksum": "8be5fc770235bc61b023f1e0f586c7abfb7a38ed9c4e4e8530e73387cb0c6314"
     },
     "x86_64_macos": {
+      "etag": "0x8DAC37C94CCFB5D",
       "checksum": "e4ce227ea572ed4fadc8843f9d7cb17921501f3313d3200366bc14c2e09e98d9"
     },
     "x86_64_windows": {
+      "etag": "0x8DAC37C7275FCB5",
       "checksum": "a2c86434b88ec365f5ad9ce90f5093f6cf8851f4c0ca6962e502fc09033b7f9b"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DAC37AAAFBBFEF",
       "checksum": "bd4c15d7ab775951cdeea2d19dfb338f6da0e10131537373e32b538e47d59780"
     },
     "aarch64_macos": {
+      "etag": "0x8DAC37B1E1BFC61",
       "checksum": "0ab7b13cadb889ee51839bd976b6fc5adf87496d2bf409f3a456e128a191958a"
     }
   },
   "1.0.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DAA09C518B14E2",
       "checksum": "8d539b8a62b4a4934a6d91b94e6f50ba797c81a3370b217da6e23827428150b1"
     },
     "x86_64_macos": {
+      "etag": "0x8DAA0A2FAA07BA0",
       "checksum": "aff7db90c0d307e9d9feb5ac7207ed736d506cb1e5555bf345aac2732777de98"
     },
     "x86_64_windows": {
+      "etag": "0x8DAA09F543B769B",
       "checksum": "ee084911c4135c8337dd6a3819a04214d864fde332e3ee42eae11e93489cce69"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DA9FFEEF8A5E05",
       "checksum": "5f158d0922481f89f00d8d7366c79481e6b59bc044e68e0b3e70906e07236f48"
     },
     "aarch64_macos": {
+      "etag": "0x8DA9FFF2E9BAA3A",
       "checksum": "a42282c41f8dc3b842a6e03a06906c73ca8b2878ea78524e57e24428bc5d4d75"
     }
   },
   "1.0.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA9B21E406DA0C",
       "checksum": "e7e379b98b89440e381401dcf845a1325169df2bf5a38604ae5d6213ca819936"
     },
     "x86_64_macos": {
+      "etag": "0x8DA9B22156CBE6D",
       "checksum": "c45a701ebd80a13da84eec3c411171b374959dbbca55c1fb6c8e077a0dd8e830"
     },
     "x86_64_windows": {
+      "etag": "0x8DA9B22C0FDD286",
       "checksum": "31caa64c719797b701b6486f9de68e354b297e14defdaabb5f2c945a391394bc"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DA9B21E245E30E",
       "checksum": "4cd7be12b8f5fbeab89bebb430bfe3150b205ed7e9b17142ed4804270f9723bf"
     },
     "aarch64_macos": {
+      "etag": "0x8DA9B22916761C0",
       "checksum": "0060c0ff042a09b44e785991f1a4ae768cd6f5044ce741944da0139eca2763f5"
     }
   },
@@ -1200,35 +1500,45 @@
   },
   "0.40.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA8B98198D6441",
       "checksum": "328e37d1ca84899ac561ba162777f055cf738e54dcf884ac70bb9d9614bd7094"
     },
     "x86_64_macos": {
+      "etag": "0x8DA8B985618E976",
       "checksum": "288474151d97cf97b3681b87fa7ba10b9a99beaf9859a840aeeb35ad6246e341"
     },
     "x86_64_windows": {
+      "etag": "0x8DA8B98B39C1B0D",
       "checksum": "b3841e92ec026c93c5ec4e9651d7940fcd117d0a915b64d3330727a2d70126a6"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DA8B9846F803B3",
       "checksum": "735a96c05c5faf018f0706a05d357e8c21fab638527de6a817a9261f6f4594ff"
     },
     "aarch64_macos": {
+      "etag": "0x8DA8B9842C24B7A",
       "checksum": "89086ffd35b50fc9d5d6b7684d2864e7f209f410c845182ce86d38a559ae957a"
     }
   },
   "0.40.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA846EE4FF28E0",
       "checksum": "30fc4b130c0c1ea94ffc7c6ab9cf37db792938117f6db5c0e7cc689672423ea8"
     },
     "x86_64_macos": {
+      "etag": "0x8DA846F494A3E35",
       "checksum": "d082402677d2d20a7d0f58a3ece59388310b20f854bc19e449ae5793095731e0"
     },
     "x86_64_windows": {
+      "etag": "0x8DA8470839E9E17",
       "checksum": "269ded6cdea94663e6e9cab2e21cbba5866c0bd5f7c7cbd85c492b70e3f76512"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DA846EE0A04841",
       "checksum": "0c77decb30862868effe4049be91d3ea0bd0a0a572b9e8e9165eaecf69a00eb8"
     },
     "aarch64_macos": {
+      "etag": "0x8DA846FE64FE967",
       "checksum": "07da37eb3191b56053056e27d62103db3a0edc878b88a9510053aa90eda60668"
     }
   },
@@ -1237,35 +1547,45 @@
   },
   "0.39.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA6ABE60D1C4F1",
       "checksum": "5f4f48ca335a066b478de9c0f3c009b6f7484f4261d292c1eedae3ce5dd02061"
     },
     "x86_64_macos": {
+      "etag": "0x8DA6ABEBDC315D6",
       "checksum": "1302ab804323b0e03a03f27ce5460eb6ea4f8ea4b35aa6a3dbb0b1fa5afb51c5"
     },
     "x86_64_windows": {
+      "etag": "0x8DA6ABEFA952815",
       "checksum": "767ed8e1950002bb71f4e3ca667a2e94bae5dcb31932355c4f56d8affdaa3b4b"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DA6ABDD4DE172E",
       "checksum": "a6f3317724ec582a2b3f0af83930ecbf771ad4b666a215b351fe5ec168a8fbec"
     },
     "aarch64_macos": {
+      "etag": "0x8DA6ABE77128CCC",
       "checksum": "06baa7c1edf9aa384b600bcbff66cbde7e7d01bcc089d70b50169ade076be65f"
     }
   },
   "0.39.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA6A7C823814E1",
       "checksum": "1f03d94dc7fe2fbc4ab21a82a058e0ccad1eb7ead17b39647ff482f2dcf91901"
     },
     "x86_64_macos": {
+      "etag": "0x8DA6A7CAC2BB5C0",
       "checksum": "dfce7580d74c7831aeb1b1ed638793e54e47a2a8bf302646165187c31a2d6f4c"
     },
     "x86_64_windows": {
+      "etag": "0x8DA6A7D90ECCE17",
       "checksum": "b9fd0a8e3ae5c59fa805ac69a8357271a75720e677a8a7d20ff16c7c5cee148a"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DA6A7CBFDC6E7E",
       "checksum": "c971faebc56e659e6ce14144792bc295c2a646d20d3fd6aa6746df35d6583d18"
     },
     "aarch64_macos": {
+      "etag": "0x8DA6A7D07EA067A",
       "checksum": "1fea803642a20dbd77cb415f3afa394e9331b236422f27d99a672a69395c25c6"
     }
   },
@@ -1274,69 +1594,89 @@
   },
   "0.38.3": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA6ABB4C0C2736",
       "checksum": "6db7ddff5d3a0f9a60154db9441c4f4c46fff82c75d52aa01a44c9f266ca38bd"
     },
     "x86_64_macos": {
+      "etag": "0x8DA6ABBC1DACDAA",
       "checksum": "a412d2e29de28d9232c9ee1da578fefa8334aa497bfd6485d4a1587044d8da62"
     },
     "x86_64_windows": {
+      "etag": "0x8DA6ABD354FF63C",
       "checksum": "a684be451d50481455dd5d8c7a9c6b6a0276050b426b4aca0efe1a562ed4b668"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DA6ABAFEE834BA",
       "checksum": "af8d0521681ebfa0f67a4dfb66e52eff8cd6ca6a9041b465d4a00310f736b4a4"
     },
     "aarch64_macos": {
+      "etag": "0x8DA6ABB18F5C77A",
       "checksum": "55836388b248302f1d6241919190564a5076efeeff3d93b54a69d604c4520932"
     }
   },
   "0.38.2": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA6A8C12CF26AA",
       "checksum": "5a922d2f15a79da624e17f41ce3c5bbdd048e6cce395d85cd7d1d159bfa965b2"
     },
     "x86_64_macos": {
+      "etag": "0x8DA6A8C921EF0C2",
       "checksum": "d2216b1ab6940b3832a552b88bcdf9222e335d6a16d32e4b1d8d97d7f6b879c1"
     },
     "x86_64_windows": {
+      "etag": "0x8DA6A8DDA9892D0",
       "checksum": "9b16c477deedfe713b079541af7a5e1428d403ae5e3e239fab9fc9501008ad89"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DA6A8BDEBA406B",
       "checksum": "0bed673e70b8b1497af6d346cead47d3d74823e73f889747467612da00afc92e"
     },
     "aarch64_macos": {
+      "etag": "0x8DA6A8C5179AABE",
       "checksum": "aa2f8d15bf734b16d395ef747025e6ea5ae514b3876d7cedfd9fc3af75b20261"
     }
   },
   "0.38.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA588C5924349F",
       "checksum": "a8805d626b660dc62a5d526cfcd657d41a67522725ff2810f61892ba5519e700"
     },
     "x86_64_macos": {
+      "etag": "0x8DA588C77A6C2EB",
       "checksum": "15bfdbe7c0ab9999e45db597cbfcf434f88b34ef39a2dc11e46312e20c0e3c17"
     },
     "x86_64_windows": {
+      "etag": "0x8DA588CE6E7EF66",
       "checksum": "5128a7fb491fd467107a3e0cc7155a00d6218989c3fb7be263660221dbc41712"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DA588C4CB1A513",
       "checksum": "9b98e78446adc5f15c2282561d6b387922ffa359a3ff677739e071a9a71d2743"
     },
     "aarch64_macos": {
+      "etag": "0x8DA588C81DF727F",
       "checksum": "182cd78daa7523c1fb204edb66714dc9d26d2b307816887ce9594fa886acbd02"
     }
   },
   "0.38.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA539935BEFDB2",
       "checksum": "caf0a64aa3aef0e1cb5f7889384a2718d239f0f62f91a067b367ca8a45296758"
     },
     "x86_64_macos": {
+      "etag": "0x8DA53999869E1F2",
       "checksum": "1a00b51e4510c5d1d610bb61632a924cbb41e1c15a60a9b1737ee63aadce9721"
     },
     "x86_64_windows": {
+      "etag": "0x8DA5399C91634F8",
       "checksum": "9353ff342b9dc131c0b3c148e6064378b9ec92c63647d2d91b370424559cd45d"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DA53987A5FA288",
       "checksum": "3ac9533780ab69f50cd6ccbf4df95e120ef7467d1f2735e5a274d881bf3fb25d"
     },
     "aarch64_macos": {
+      "etag": "0x8DA53989A573DB0",
       "checksum": "e01598932fb54a9c39457d9a295c924d697313be4c2da6eefffa69a4c26d562f"
     }
   },
@@ -1345,18 +1685,23 @@
   },
   "0.37.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA3A7058207039",
       "checksum": "96e0068905c55bf24e84913f0d60ca91202eb3ea2b928fe236c63e64c3118fe8"
     },
     "x86_64_macos": {
+      "etag": "0x8DA3A7107EB7C7D",
       "checksum": "1d33f5853cc33077eb1ebefe429de2236b09d2ff5c0c0d7b5312a1b7a0ae5225"
     },
     "x86_64_windows": {
+      "etag": "0x8DA3A7108219FC2",
       "checksum": "d75e26addd3bd32ccbbbedd37ace5dffa71d603b57600c3c90c54c7e45b96142"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DA3A6FA8C832B0",
       "checksum": "e20a4d092356f4d90fcb53b4e1e6de362c2455960a2bce4fc008499c5a715ec9"
     },
     "aarch64_macos": {
+      "etag": "0x8DA3A6FF4D82747",
       "checksum": "8b1ce3f7142dbffebe1ec52071aea2c6ff224cf45ae7298d35c53bbf8e32e0d1"
     }
   },
@@ -1365,15 +1710,19 @@
   },
   "0.36.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA230587CDF1BC",
       "checksum": "97ba12da1f96e40197998d843afb4e08a1d61cd844b721dfa0d1fa044a38b35a"
     },
     "x86_64_macos": {
+      "etag": "0x8DA2305E496BFB9",
       "checksum": "f3bed69a3453c37a7f8b94ccdad064b4d5675f393a408ee5d6198363bdbf9003"
     },
     "x86_64_windows": {
+      "etag": "0x8DA2306B8EF64BF",
       "checksum": "516c418ea4a69e31d8d107e72d6c2081ccef45c05fc3d541b75f148796458b54"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DA23055CAE6BBB",
       "checksum": "6bfe5015f6f61ee090ba5d0ff72c8582be2a32491e3fc35550b1ae8f80d8199a"
     }
   },
@@ -1382,57 +1731,73 @@
   },
   "0.35.3": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA1BF1C2FE1D1A",
       "checksum": "7519ef0e08716416cc44167ec838ff1362054c43c8bf6fc56056282c9107840a"
     },
     "x86_64_macos": {
+      "etag": "0x8DA1BF262FCEBDF",
       "checksum": "d511ee7962aee569a4f595c3926af5cfdee6693cc9c50fd18d12a117a87c4c35"
     },
     "x86_64_windows": {
+      "etag": "0x8DA1BF2506A6C19",
       "checksum": "454810c33e8116a23624f09492defe8e11fad24abbee4181f225eb8cd6bbd3a3"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DA1BF19E6850C8",
       "checksum": "bbabfdad35fc1dbef6402354251856cff6ddd5ce9ab260440ca9ddcd75064e49"
     }
   },
   "0.35.2": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA1352A9B907F6",
       "checksum": "9fac8bf1027238c9295896851c08c3d4b76f61bc9b3db5d3a607a092f5d13369"
     },
     "x86_64_macos": {
+      "etag": "0x8DA1353557EEA15",
       "checksum": "202ecfb71f88e36fd729e4bed67e5e192b95ab7609b7ce4d6fb7a302559eeb5e"
     },
     "x86_64_windows": {
+      "etag": "0x8DA135315902DC4",
       "checksum": "3d00f497299aec304708f73595fa5e3c4defd0ea8a9143e940c53ff4b368f074"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DA13522A4F071D",
       "checksum": "b1e2218d041f4dad91d5c52c8fa9aa6b54d8148d2d7ccc9487cc00b1dd65264c"
     }
   },
   "0.35.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA021B82A79620",
       "checksum": "c7c22cd0aada9636f99f203aa0b14bc99a48518272270dd4dce277d4a51f07e6"
     },
     "x86_64_macos": {
+      "etag": "0x8DA021BA1145319",
       "checksum": "6b9d790cd8c7d0465c8e180261e2498db7cb359ddd7a4131a0528ae52cdef853"
     },
     "x86_64_windows": {
+      "etag": "0x8DA021D5DF14503",
       "checksum": "b5291cc8518cb34b5ed98fe0eda84dbd962aa5fd420694f54e55c03f80ef5982"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DA021AEFB845DC",
       "checksum": "e5e7b8ca392325cc9b513aac9b001c1b2b5ca1fe6ceff20f2a08149da4d8a326"
     }
   },
   "0.35.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA00849BFC6F72",
       "checksum": "c068fe467973b2dcf5a37ab3926ee8ee363a180b8b42796c8a25efa35b13e397"
     },
     "x86_64_macos": {
+      "etag": "0x8DA0085719DEDEE",
       "checksum": "6d06cc09b66f7e612bcafc65acb00d04408a497b411e80571bb6e7c10d3f1ee6"
     },
     "x86_64_windows": {
+      "etag": "0x8DA0086314DF4EB",
       "checksum": "f7df9d78eb8e8d11f84bbdc6121e914ccc74a1c9548bc9642c8e6d913669f3f2"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DA0083E860BA95",
       "checksum": "f48df183bfd69c4652394f5be85fd6db69c34ff33e4d2efefd793fa1200fccba"
     }
   },
@@ -1441,40 +1806,51 @@
   },
   "0.34.2": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA135EA804BCA4",
       "checksum": "211666ef45a651a6fe885dd456e3098fc9be57573146e56e8ae7684ae4d8a9ec"
     },
     "x86_64_macos": {
+      "etag": "0x8DA135F2235CDA4",
       "checksum": "487862a85fe30d32ea6c265799701448863bc86d175b8f308bfec49445d57a5f"
     },
     "x86_64_windows": {
+      "etag": "0x8DA135F50435E65",
       "checksum": "f02692e40f0ec9da777b932cb4f8646d7bff092b55a78bd4a6098430c3dd0789"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DA135E64E18EB1",
       "checksum": "6b06b124e8dc57e0458bd85deb12f162ef409b505744541fea2f7e6e2b78e336"
     }
   },
   "0.34.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9F6141EE75FDC",
       "checksum": "6e707170e8dc1d8279b698ce2a1ed7a50c7d986c91012ddc890589439515a9e5"
     },
     "x86_64_macos": {
+      "etag": "0x8D9F1804865F00F",
       "checksum": "8deccbb1a2761fc6e694de173c996de3e5491325c0da0a499d6c7860e804be13"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8D9F1800DB0CD96",
       "checksum": "1a9d0b0d3f0d7bc02b603e5408953fd805d4e920137ff7978a8714b90a0d2606"
     }
   },
   "0.34.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9EAA6A029A28E",
       "checksum": "8937edc3a940a92323a9405510110cb0dddbce25a5bd866e4a5af088da560ef0"
     },
     "x86_64_macos": {
+      "etag": "0x8D9EAA76C6D71DA",
       "checksum": "0aba0787b9de1f8be095a0175b87fef080e51b6d2c8801d442e8b3c57b7135de"
     },
     "x86_64_windows": {
+      "etag": "0x8D9EAA78CA9DBE4",
       "checksum": "0f13ff074fa2d6be0ecf4961260c3d1c707e7a9a2df9b5b9fd54745cb5637a3b"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8D9EAA632AAAAD5",
       "checksum": "b0d901e19ae87bdbea24305c72342c505d47e26a7a1a3bd90713673a1f09b67f"
     }
   },
@@ -1483,29 +1859,37 @@
   },
   "0.33.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9F1919BD57228",
       "checksum": "e7b4c30451dde8f79d2aec2112b68929e7603ff93d59e46cc3a1bee13d28cf30"
     },
     "x86_64_macos": {
+      "etag": "0x8D9F1919B91204A",
       "checksum": "989074b6e6feb838bacf8d2ab0c05387ff3aecec1822ca99b18c7ed45ff5675d"
     },
     "x86_64_windows": {
+      "etag": "0x8D9F192A17031C6",
       "checksum": "611345e4b274b47f2a722e10e5f5191c5529c0ce3f0cc73974b867918a84b75b"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8D9F190EE3048A0",
       "checksum": "b8041de41a0969416c6a5153cb99db903ddb7d7887b86cc7396f2806cb8cc301"
     }
   },
   "0.33.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9D102331F8207",
       "checksum": "c4c9f2ed9187c97e0ded9004dcaaeba1459d27f62f28797cc28d68be36276294"
     },
     "x86_64_macos": {
+      "etag": "0x8D9D110053E548A",
       "checksum": "7f00f5402cbbe15274ca8a59aad88a3b2ff0f6c921d0791458306a97a449b0d9"
     },
     "x86_64_windows": {
+      "etag": "0x8D9D100FEFC8617",
       "checksum": "370876d13b812872ac758674c56780bc6eb1edbdd0a086b2ec78a139f4376f97"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8D9D105A1B77588",
       "checksum": "a70123bc5055a48b37e42465b1adf9c8aef9c036ac769c48c43ceff7b0aab43e"
     }
   },
@@ -1514,29 +1898,37 @@
   },
   "0.32.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9D02F005BDFCF",
       "checksum": "278b30dedfd02b788822fe73ab96a86ff9b13c9df2efd9847dbba6164884d54d"
     },
     "x86_64_macos": {
+      "etag": "0x8D9D03686686479",
       "checksum": "6450dcc2a20e5386be4f92a687cc6ede2a906201339f8c189c52967126c42a87"
     },
     "x86_64_windows": {
+      "etag": "0x8D9D036FF3E3065",
       "checksum": "e6ed305c3323190c9948a86015f035e8e6ee927d5dbec9061ea3b56939e48510"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8D9D041D7560F76",
       "checksum": "da5b466208835af902bff25125f5c19dfc67e7a95864c1540cb0a298293e8940"
     }
   },
   "0.32.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9BE72D164043A",
       "checksum": "24d7bf11bccc21e71b724c90cf35ca232a8a9dba62ab766bd30e0ccc928fc83b"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BE72E49F5410",
       "checksum": "67a1023da19d78a7c8ba9c9b1ead7b7c119013658f90d13d0f8fafe95d281ac7"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BE73AA8BEBAD",
       "checksum": "223506e4e82c167f711fc102b1bd4e562841d764bce180f6a8d6d93c10bfd1db"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8D9BE72B601BDE3",
       "checksum": "c64270ca6e4c2530f4854a1ad9b747b148be6756108be30e9d5b76cc20163ee1"
     }
   },
@@ -1545,15 +1937,19 @@
   },
   "0.31.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B8E74757E035",
       "checksum": "8d6f3f3b9691a6a36cec3c18227cb7bf1f62e95390083577a3f207f60afb39ea"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8E743EAD872",
       "checksum": "d1e207ae1c6010ebdd0e127863ae1819d21b0bcda7c27fc460e66bfe5f24b89f"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B8E7427EAC9A",
       "checksum": "48b410f6db9548f0c89ae370cd31a02e9a0119edc9d39af5f9798ab192bab566"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8D9B8E742EE9C16",
       "checksum": "c121209020e16f413b88944ad370547e5ff0905f61c7540e581b75a0b2f620b4"
     }
   },
@@ -1562,15 +1958,19 @@
   },
   "0.30.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B8E7382DDFCD",
       "checksum": "5cbf1193df60f441eb54a247daab18680357cfa24ad320a590b364e9342632f8"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8E74C32732C",
       "checksum": "74902d5df4aa293851749db36d1cf300155cdc751ed25f7bd8b3471bb411fa68"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B8E7422723A0",
       "checksum": "85268ada8df5a10655fe3539c3d8ef120b6d06c2c00f166241381ce4c51e6a69"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8D9B8E74BA514F1",
       "checksum": "206c0c5ed50f33c265128e0a9a6a98b0401089c19697682c0b9db6396470e9b2"
     }
   },
@@ -1579,15 +1979,19 @@
   },
   "0.29.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B8E7369B9388",
       "checksum": "623f2ca8074aeeba5d9bb69b3f60c55c773ddc2b4d564c52f9454ab0d45d012e"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8E736C8DE7C",
       "checksum": "54f372c9317e42619a32fcaaffaba97abb91a6d11237b8d217e3ca11ee0c5c46"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B8E745B5DF36",
       "checksum": "f75e621a66eb6099af091a40cfabdb8595acfcbf35ea3204707ac52fc7dec61d"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8D9B8E74852481D",
       "checksum": "64edd00e8fc146da38cc56c7f0f61114433e244f264ab72c45d3126ba943a6e3"
     }
   },
@@ -1596,15 +2000,19 @@
   },
   "0.28.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B8E740CF6727",
       "checksum": "714b3fcfd37621e2bd59c786208ebe7e2542cf88f0cef192e4eed2aefbecaa53"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8E74575AB54",
       "checksum": "018f5ce10ab3d618cf87d72a4c8500846637c8a8fa426167b98459a0973289cd"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B8E73B157849",
       "checksum": "68f9a42bdad0337b96668a40b149a88d8c08f384426d64dab82ebff6e0db2dce"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8D9B8E742BA745A",
       "checksum": "ae0297fdeac20b2c5721a6db74093a8f46da44f0a11e70b2b00f48441049bdbf"
     }
   },
@@ -1613,15 +2021,19 @@
   },
   "0.27.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B8E741DBA6BF",
       "checksum": "2a9d3f09198e63c2e39cb8cd59c4a4cf196daa0111514e355304575f590c3f4a"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8E73848DE03",
       "checksum": "43e841183dd29c24a0dc043f1ea2b43b06b51e5658a283e0c2edad60fc3adf55"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B8E739D84476",
       "checksum": "c717cc9f6fd568b136d1e9e5d230f3f0cd8e7101094ab344f5223fb10a8546d7"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8D9B8E7408F5A4A",
       "checksum": "7572e56bd7521527edd9ca0dc51c43c97b2171289c455670fd595ce1ea707a64"
     }
   },
@@ -1630,29 +2042,37 @@
   },
   "0.26.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B8E746745860",
       "checksum": "ff0785c3528e8f1471a3a23858c46414924733c91f604871fc84e401e51b7ec0"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8E74BF80AC6",
       "checksum": "469b9dc5302774be41fcf3c5933b1926b84a495f81c10a097233dffd28bdc7c1"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B8E7484D18BF",
       "checksum": "6abbebd80c6b34dc76b9ef253d51f74174bdbf217eefff9e05e41d59c7d41439"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8D9B8E747D9804C",
       "checksum": "d7370fd3c7fca246ae9760c07df149110477459bfd682e6b6d86bee6cb1328da"
     }
   },
   "0.26.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B8E73AD2D3B9",
       "checksum": "8a83ef7c6592200e86800e5f119bca5dbe4f30ab0d0ef56829a7e266e036c3f7"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8E740A8F909",
       "checksum": "051ad6f4ff34057e90f193b46b0f5d96849e76d7fa4d378f43105f811acec9db"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B8E73854C314",
       "checksum": "cd8becd5b4d6860049b05081302e87849e0187adb230d606757b1208617be967"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8D9B8E7378F1EE0",
       "checksum": "1a3a2b9aa4e84edb86242e67544fd226e5ce764cafba5429b962c486cc9d5de1"
     }
   },
@@ -1661,15 +2081,19 @@
   },
   "0.25.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B8E74670AF64",
       "checksum": "33458447d9499bc560c6a74887607e02732214435c49ea3d86573ff755581821"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8E73A29DB0B",
       "checksum": "cdc18250437a238bf852d4fcde659fe2067e8605d248c59aab3e0a54f23f8370"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B8E73DDCD492",
       "checksum": "eaf28b48d0ba460546063f600da09e94eb3ec448331f1a3fcf3841666b350631"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8D9B8E74BF35087",
       "checksum": "8f254796a91d9f369448d8f2bbe29c9db57c6e8e1fb7a9c7b7c23215e87bb204"
     }
   },
@@ -1678,15 +2102,19 @@
   },
   "0.24.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B8E738364303",
       "checksum": "ab69f137d1843a075aa9b732557add70939bb45d67e95d233ad6f101c7607c69"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8E7497F514E",
       "checksum": "9dc47d6c9ab3199084d97d53c161cf7c6279383a665d2c0df3d69c6792f6656e"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B8E742DBB315",
       "checksum": "c353f2804f0c1b79d31a37ef4e2e850eb4c0425980d1d2d4caac17927a20b641"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8D9B8E739CF932A",
       "checksum": "d3a842705a24de814047f8289362c2efb1bcf85df5f78bca0a00454c573f2a21"
     }
   },
@@ -1695,15 +2123,19 @@
   },
   "0.23.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B8E7414BB0D6",
       "checksum": "d410a78cb8820d1106edb49d296da80bc05420f17a04b8a6ec5e005da3bf5883"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8E740FC8B07",
       "checksum": "257e10c892a95a2e18d58c207ecf05193cec74f8de132271ee94751faf49fe1d"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B8E73A56D7ED",
       "checksum": "7e7e1707ac2ef7c7c3f12f9eceaeb50a57d32ff23432328921f0ad2025bb4e87"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8D9B8E749FA14A2",
       "checksum": "0001025a683d8aff91f4f6b5047b08c15c7a5e3584fe4aa005f5fa59dee2e44c"
     }
   },
@@ -1712,29 +2144,37 @@
   },
   "0.22.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B8E74A68F2D6",
       "checksum": "09f050372070084b3fc7096ae0974aaa6a2651d1278dd71e8eab55244b157e2c"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8E747127CFB",
       "checksum": "8406d5907bf4850c84e1ff11a5f4498dc86ddf5a3743070e7b5f567a086efd82"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B8E73B1AA7A5",
       "checksum": "fbc2ca8a09cb80846a64020446655bcfcb93196cb1a109c96ad8cba65f4c72a8"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8D9B8E742D4FD57",
       "checksum": "4d876768b4023c63fd32ed7d31059be5dcf61d725aa4a3bc5fa3ed5e78ce67e3"
     }
   },
   "0.22.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B8E74B22B1A6",
       "checksum": "bb700bb4896a7190c4472b82cdc565518ad335b829538d5d0295dc4afcac70a7"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8E73836DF30",
       "checksum": "66b8cee164ec30f53da16becc72d51d30b0e17dbb84c90edc680e45f98b8022c"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B8E737509854",
       "checksum": "a4f566b24d661df23a7e96ed93982b5fb67eca58a9175d7adc5dfdf74912e38c"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8D9B8E7461AD3CD",
       "checksum": "0d67070a0a5379b8ccd5aa7217221f7c513b7a3d19cbe6e8e2b58bdf20384c5a"
     }
   },
@@ -1743,15 +2183,19 @@
   },
   "0.21.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B8E74CA2B0B9",
       "checksum": "d3af5fa02091baaf637026c5d8fe1b5011f9f7de257dd838639c2916f929aa4e"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8E74011FF4C",
       "checksum": "e9875185cc19edb98c2c28db67c8329c683dc6b50612d6a0f09105f0db482fa7"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B8E73A05B67B",
       "checksum": "6fd450185b749e5d9b6473ebb6809725f5685cf604e486c55c23e9054bce2277"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8D9B8E74599F6E3",
       "checksum": "fe1f5a54079b12c14ed4b0f3c0029f25ac9b2bef24f4711f3adcf63d7765c1c7"
     }
   },
@@ -1760,15 +2204,19 @@
   },
   "0.20.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B8E7412B8364",
       "checksum": "e32ad7d1e7bb70f5e9ad3128967fba6b32ebcc003332ba6c5276558ab2e4a864"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8E7432AFFF1",
       "checksum": "f22ae7ab5e3096c4e9422db64b5623bf823f620f5d74207c946162be2fbc23fc"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B8E74C611D6E",
       "checksum": "d1ff5636935d3eccfa150fe647f5bfa7b36054644296c84935088180b88560bc"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8D9B8E7441BCC53",
       "checksum": "e305c06393b800937e214df059f6ba5763ad96523720f8f4fcbfe935fe9e82a3"
     }
   },
@@ -1777,15 +2225,19 @@
   },
   "0.19.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B8E74C90D904",
       "checksum": "1b69df2a18c21effce127b7dc56b4ff0cf0ea7274cd28f2a314d07a99d8da928"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8E745348D35",
       "checksum": "a4aa62877a94c89b9d7bc5a16d801b3b129ec294f636999a73a229b31ad2758e"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B8E74385E3E2",
       "checksum": "4e297c2a3bf067bef7ad4b1c23c08766c3d90db72904b894f2ef086f53081a25"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8D9B8E73A5F8935",
       "checksum": "38d9a75908d88cb80a2bedf920e5f88d05512ce0e07b4abcbe8616ca19fecd4f"
     }
   },
@@ -1794,15 +2246,19 @@
   },
   "0.18.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B8E7457B28C7",
       "checksum": "3475760b68382237d396157f9593da5febdfed1bebdb36f688c5d06f9ca28ca4"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8E74B8B9D3F",
       "checksum": "449d1aa79dbeca875376081f447e27504db15de181661dc4af4d3223c3f6eb1f"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B8E7467235CF",
       "checksum": "98350c5e24a944a282118a367e584db3c47362795a3bf47ce9ed09c4fd8590bf"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8D9B8E7470DC2B4",
       "checksum": "77ca7c1407c672ddf9e0e699c53cb634cb2efe0691f1176aa044e4aa88451939"
     }
   },
@@ -1811,15 +2267,19 @@
   },
   "0.16.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B8E7449D4564",
       "checksum": "834c0719a263f04ad8273e8568a9b96d12ebfe26711895f47abf774b6a7f5809"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8E7430D9135",
       "checksum": "9a7b04f212f54c0956db7626a11c66484449a5f0517b6226176d2e52d62914b0"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B8E739AD6A24",
       "checksum": "1b98ca1e3da044c207ad4f5c7ebf8baa63552f3067d6eed1473652d6d3a90035"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8D9B8E74590F780",
       "checksum": "f8cadf9586ddc8fccda94641d542a0dfdcdd967ce361522beb1563601d1bbaab"
     }
   },
@@ -1828,12 +2288,15 @@
   },
   "0.15.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B8E73FB2D641",
       "checksum": "3ffe31010c1363648cf4d2a145b0b1efbd9f09c3869372fb38fd88e7e84dee50"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8E74A0ADB04",
       "checksum": "c1b844f02730cb39ebc41d0321cc3a4ca190d394de15bcb56fabb74342792df6"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B8E74B117620",
       "checksum": "cdc88573de1cb287fdd7458220b5a1589dd734fd9a9e97b622aa501026a42ca8"
     }
   },
@@ -1842,12 +2305,15 @@
   },
   "0.12.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B8E7477E755E",
       "checksum": "16fe9964a21ae57661cea5971d5d8d2dba796195c2952420a66865123caad2b0"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8E7400A3843",
       "checksum": "59fd765b5640bf4ee279daedfe359fa601163568bceece0bb83f4215c6d27610"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B8E736D141B3",
       "checksum": "2884221b99ebc94dd0840d639b0da302e76e9f9397dc4d84f72bf490d5a6e1da"
     }
   },
@@ -1856,12 +2322,15 @@
   },
   "0.8.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9B8E737AB0746",
       "checksum": "17b19cd56e537ac63b1ab1f91d54f0a2be6d7387ec2eec5fadbc6773d7e58ec4"
     },
     "x86_64_macos": {
+      "etag": "0x8D9B8E73F3F8BF1",
       "checksum": "540cf126b2115a53abb8052fcb48bb5e4eb1db67f88abaeb9a9017b6c1b72774"
     },
     "x86_64_windows": {
+      "etag": "0x8D9B8E7464B528E",
       "checksum": "1038ed20f40cdddd50144ee3ad7ab3fc9381f4eb32b48507e154458f14c1e702"
     }
   }

--- a/manifests/wasmtime.json
+++ b/manifests/wasmtime.json
@@ -34,18 +34,23 @@
   },
   "22.0.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DC914968F14329",
       "checksum": "415d09d77f5375a6c5f6a1fc102bbaf3fe8e830b438690e6ea59a7d690458dea"
     },
     "x86_64_macos": {
+      "etag": "0x8DC914969BE33D5",
       "checksum": "2d39c488e391c1e18875a0aa22db0f2b3c737002beb83712639ff608666fccea"
     },
     "x86_64_windows": {
+      "etag": "0x8DC91496CECA521",
       "checksum": "87c9d8dd42cc5506edbe9736fb098f8d960606c85d4608d543dd07f79194f35e"
     },
     "aarch64_linux_gnu": {
+      "etag": "0x8DC9149635B8B4F",
       "checksum": "0c4bc38070d856a6cfc4b4ec6344b1f5de8cffdde875550c285010d645f24330"
     },
     "aarch64_macos": {
+      "etag": "0x8DC9149641E9BF5",
       "checksum": "891552cd21d08f330b872ef462bd7ac3903b668f4461cf0de0d16a175b40f57f"
     }
   },

--- a/manifests/xbuild.json
+++ b/manifests/xbuild.json
@@ -23,12 +23,15 @@
   },
   "0.2.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DAE34EEA3FC37E",
       "checksum": "9c294809ec3cb314b34e9f644b5bbf6ed262c25c1eeb78a3691836a95bc58e0d"
     },
     "x86_64_macos": {
+      "etag": "0x8DAE3503EEF4B32",
       "checksum": "e357205fde5262d77b8b1dc1cb066a4f7b4edd0a83b71b3513ae466b08343305"
     },
     "x86_64_windows": {
+      "etag": "0x8DAE34F8C6939DA",
       "checksum": "ce503cd64e6449d1c3e3bc2bfb621e9dd3ebfc775e99c97f98c2ab145e533946"
     }
   }

--- a/manifests/xh.json
+++ b/manifests/xh.json
@@ -31,18 +31,23 @@
   },
   "0.22.0": {
     "x86_64_linux_musl": {
+      "etag": "0x8DC5B4261C54E83",
       "checksum": "270a4ece43a44f4c270417b50ddea430029b98cc5103e264bf65f64fac5b60a8"
     },
     "x86_64_macos": {
+      "etag": "0x8DC5B42A43612BA",
       "checksum": "891a015ac04fda2a27df82991b9495213ce38d97827192c771da798bf10c875b"
     },
     "x86_64_windows": {
+      "etag": "0x8DC5B428229FD84",
       "checksum": "cbaeabbfece018e05f1ef0e380b5b797c61524b11662598bc444402bcb0607d0"
     },
     "aarch64_linux_musl": {
+      "etag": "0x8DC5B4250843E65",
       "checksum": "e4feb4a463183c3cc139f906a2cfe84dd3790d277f2915271a9a2ef3a0978ffb"
     },
     "aarch64_macos": {
+      "etag": "0x8DC5B4219955A94",
       "checksum": "48fdabeedd42b2638a9e79bbb2506eaea7371e381dbf3cebf62e5cd40a39cc64"
     }
   }

--- a/manifests/zola.json
+++ b/manifests/zola.json
@@ -23,15 +23,19 @@
   },
   "0.19.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DC9172A48655E2",
       "checksum": "5d26b7c63d36bcfc42a2db41d35cdd7bbde1762571ee936a89d155d7fd600f77"
     },
     "x86_64_macos": {
+      "etag": "0x8DC917321774581",
       "checksum": "96cc5501541cc220c0e3d234f5c8b869afbba90ff6a10923824dfbb51f87f487"
     },
     "x86_64_windows": {
+      "etag": "0x8DC91738AEBF00D",
       "checksum": "831adf641d2c691aa95771285f13fdbff8897d481084b360c49a9d933e81cec8"
     },
     "aarch64_macos": {
+      "etag": "0x8DC917301A99D5C",
       "checksum": "c57d5c6b6ed55fa1eb04ed8bc17432bff9d0ca0d96558c0c476edbef7fc77d95"
     }
   },

--- a/manifests/zola.json
+++ b/manifests/zola.json
@@ -40,15 +40,19 @@
   },
   "0.18.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DC001BB5BB2FCF",
       "checksum": "521ca7990b60e1270df807e01cbeb1ce69ef099745883b7929a4944cd5625d3e"
     },
     "x86_64_macos": {
+      "etag": "0x8DC001C2624F9F9",
       "checksum": "19833c38ce455cb97a9b2dce1dd882af973553e66f722e9a599e1ca152e412ba"
     },
     "x86_64_windows": {
+      "etag": "0x8DC001C80BBED8F",
       "checksum": "9c0f2880ace47a723999a2b9a96fb12178d12d62cd5e56f3c975266552594949"
     },
     "aarch64_macos": {
+      "etag": "0x8DC001C435F9DBB",
       "checksum": "2b558ad9f8ca7d68275916d5af7b0cbcbf94ccc49af7f7f33cd5b2ae1560316d"
     }
   },
@@ -57,34 +61,43 @@
   },
   "0.17.2": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DB28B45CF37FC7",
       "checksum": "48742322fc0660afb22a4ce194e9b2bd610b5bd36f43abe121e56eb8a704b464"
     },
     "x86_64_macos": {
+      "etag": "0x8DB28B5101A10AE",
       "checksum": "5e17a54c9b1db55ae71d49587b399b8b39bdee8cbb4a198ab6449c3e0f9ad21e"
     },
     "x86_64_windows": {
+      "etag": "0x8DB28B51C2F126F",
       "checksum": "89c504756a2c34f8540adf7eee83a8f1b61527bc55daa7e42481a0c727cae88f"
     }
   },
   "0.17.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DB16B031940CC9",
       "checksum": "f1ddbe0c1b0672da6eeb959eeb3f311b915ecc18719963934bcbc0c62783b711"
     },
     "x86_64_macos": {
+      "etag": "0x8DB16B0BD11FCD3",
       "checksum": "96eb9ce229bdfb34cdcc05f540c965e0ad4104a253729bb6e3d2b7b3a57044a7"
     },
     "x86_64_windows": {
+      "etag": "0x8DB16B105A2237C",
       "checksum": "be0ea09c178a01bc04c1444349676a59b31c7a97930a5461fc170b3947ea4553"
     }
   },
   "0.17.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DB105AD8D9D862",
       "checksum": "41f8a78b85d4a138581dff468fa5a01378c7f7afeaf2d81524c45a9fba8988ad"
     },
     "x86_64_macos": {
+      "etag": "0x8DB105C67202844",
       "checksum": "41d69c8995f6a77acc3d0a0389de06f42000e8362264f6bd2c8ac12a7124827b"
     },
     "x86_64_windows": {
+      "etag": "0x8DB105BD763CAB6",
       "checksum": "6e92a4186e2a5ddd61bc388c2d28558060e352d39e7ddb0985463e14728523da"
     }
   },
@@ -93,23 +106,29 @@
   },
   "0.16.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA7E07BED4225D",
       "checksum": "a8a4205b7fdd817d9866d1a4b4b8d53c206177bd7e95b37e35cb5f830b0e6234"
     },
     "x86_64_macos": {
+      "etag": "0x8DA7E082C93FD66",
       "checksum": "cb14676dfbfbf3252315196515ab386a63d3a336b18bdcc632d8e31c0a4c791b"
     },
     "x86_64_windows": {
+      "etag": "0x8DA7E08D04991E5",
       "checksum": "b19b8317a9a0d53339df8a5d910af0682abad5c65f593d58fcc35c6d00ab8732"
     }
   },
   "0.16.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8DA67767E3237D9",
       "checksum": "88cde8f1edfe609a9ae8a7a95226d3ae9bb62279c5c5254d9f5984ab843529a1"
     },
     "x86_64_macos": {
+      "etag": "0x8DA6776F31D5FBB",
       "checksum": "e31e0fcce6da8777b8a3c2475d55fa98c513224dabefb4274da2cd0094f441fc"
     },
     "x86_64_windows": {
+      "etag": "0x8DA67773F801211",
       "checksum": "38a6b2ddeac3c32aff948ad4b07d7479d89115dce3f07adde6d5a53844f23c95"
     }
   },
@@ -118,45 +137,57 @@
   },
   "0.15.3": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9DE7906665C28",
       "checksum": "7952bf166f29caeec595a299d94bc7da6ad5ba9ae71ea8bae142e2322faf821d"
     },
     "x86_64_macos": {
+      "etag": "0x8D9DE78BADD5368",
       "checksum": "3a8a9b137b87fdee546ab5f12c9eb7b2e33a554349c95c4a9ae4c1599e06538f"
     },
     "x86_64_windows": {
+      "etag": "0x8D9DE794F2C1A2B",
       "checksum": "d806e1e2e954369f350b6de9d755374fb57f8e820bf8e8df18e6c2db9daf9443"
     }
   },
   "0.15.2": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9BC299BB5F5F4",
       "checksum": "d067e8261f0a9121ea0388616f74fcba4b1ed87df8ea78ca20a577424c15fa20"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BC29A4ED495D",
       "checksum": "e39c94158bb8f0dd0af3c1fcf1b52845a49ed6ab87721f2dd3bf0ba05294327a"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BC2A854C93D5",
       "checksum": "c265ac94c33caf89d900963994568440e200a0620e4d6a1092fc35a1fca17b33"
     }
   },
   "0.15.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9BA81E45748D5",
       "checksum": "57c69a4f651567a9507b73ced6ec3c04f3ec20487877657502a04be93748f204"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA823E75EFFF",
       "checksum": "847a24fe21676aa4ded670dd6850444792bd98d4713677067c472450a72b3d9c"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA837B9A2EE7",
       "checksum": "3da07da833704265e5751435fbafc64eb58326f3b9069f4bc1fed9dfb75f7226"
     }
   },
   "0.15.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9BA15C63ACFCF",
       "checksum": "901a330100d5f265c7a00821bef564dd7353b2b0884b80996ba4592b635a7ad3"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA15D2D8A228",
       "checksum": "8461c39034c2606a9a7b65f6f1c964f322707d262ec83fd271cb468ae71389f9"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA15C83EE02A",
       "checksum": "eb248641acdb341d457c9a3d2560c7877f9d528a061582fa9636a69dea9d9dac"
     }
   },
@@ -165,23 +196,29 @@
   },
   "0.14.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9BA15D45A7616",
       "checksum": "4223f57d9b60ad7217c44a815fa975b2229f692b7ef3de4b7ce61f1634e8dc33"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA15D6BBB40D",
       "checksum": "754d5e1b4ca67a13c6cb4741dbff5b248075f4f4a0353d6673aa4f5afb7ec0bf"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA15CE13B58D",
       "checksum": "62bf50a6e2b606faf80cdf9112deca945fe89f67863fb06f793c27a26c968a91"
     }
   },
   "0.14.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9BA15C8FFF12F",
       "checksum": "4b68ec636b858178095873c038f21d24640220295f70b7a9f2e82109aa451926"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA15D0026C42",
       "checksum": "23b91e138ca6d16ad7560ca2d13dcf80ecdf382bed1548297791f4920bfc10c4"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA15CF048238",
       "checksum": "fad6516c9b9ecf294d047dd24195f521a8ece662249bc937f380fa154a30a43d"
     }
   },
@@ -190,12 +227,15 @@
   },
   "0.13.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9BA15C6E3A168",
       "checksum": "1a919e00cce61e30c31cd8d0979349ecd3f7c1666d32fa77314cbfbb89447adb"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA15D5FD13AC",
       "checksum": "2b3f5f2d7b2368ba128344170e5ca0dc0e1e46f322baf1048d3e206c35258975"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA15D584E7E9",
       "checksum": "7e603c8b0da95a4f01f833d7d4664209b4ec3ad72fca5e59be99020f99086c12"
     }
   },
@@ -204,34 +244,43 @@
   },
   "0.12.2": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9BA15CFAD7AD7",
       "checksum": "572e34c4c2b874f9704fb8512abea84532623f7567996bac456291a21c1b2595"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA15D5DA4E79",
       "checksum": "f9e2018c5f4989ee38055c9c876438f83988e574e8acfe68780e13a1b466713a"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA15C20ED8A4",
       "checksum": "b6d731a9abd2364bcf1d4e0d5390c3dbf4ac8044bf06df124806420115e2d74b"
     }
   },
   "0.12.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9BA15D184B559",
       "checksum": "fdca646be87e05213b7306d04247c4226c1d514aee96ef390935545aee84a074"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA15D613097D",
       "checksum": "095d6844af1fcda969ec656d44b0b21c2952472319c12285630883ce73633ca8"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA15C91153C4",
       "checksum": "370871760201d29c7fd4f492b716dbf501aed9ba1992c282f3eedf672443b548"
     }
   },
   "0.12.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9BA15D1671F87",
       "checksum": "c955228d468b9233bd66417b0f39c078f510f8adf1a6138bbe7e80423198224b"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA15C719288C",
       "checksum": "5c1d6dc3978970f33beea3ac252a9303ca5d179fce988de4e55a4cb99ee74237"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA15C5EE1A8F",
       "checksum": "ea07d70d62f573cf51f8f5ba89c9fab0cff15f2cbdd5e39d897f6ee3d9855897"
     }
   },
@@ -240,12 +289,15 @@
   },
   "0.11.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9BA15CA34259B",
       "checksum": "8afe40edff5e995afdc132e02442d24eb633ef4b6e81913d69cf97f17905b9c3"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA15CB968F3C",
       "checksum": "346d14a914de0d33adc25e7fb70abc02aca9e2cf808283538d4bb5b3cebfcb56"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA15D0057919",
       "checksum": "d95ed0d652e8ce2d904eaafc369c796bea9b593d5808e10b033e14edea93534a"
     }
   },
@@ -254,23 +306,29 @@
   },
   "0.10.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9BA15C77914EA",
       "checksum": "7bce21ad56d0cab213b5b9188076b93d9d130b9b046cd118305dc2b9b43b84b8"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA15C4D3D2FA",
       "checksum": "b1a5583421bb370a2e345ebef9a549fe44d58aecfbb67b1e619f5dd6990fcd44"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA15CE92BE1E",
       "checksum": "459f358b4210a8d53a440f957a4c69b12c663dd4c4939c02d0d91ebc685ade2a"
     }
   },
   "0.10.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9BA15CF7841C2",
       "checksum": "5ae166ff105359c87f3d6c57ef6f1a3dd14b266b68dc8059dee88f8916818d6c"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA15C83BD355",
       "checksum": "aeabf5b6477fa2884d21e6c6ccf30269ac98c33680510752786876dac0e85ed0"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA15CDA23F93",
       "checksum": "bff5de453883a429cef8ea4823f8dccead21d97f38a287841a073c7c97a2fefb"
     }
   },
@@ -279,12 +337,15 @@
   },
   "0.9.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9BA15CC5222CF",
       "checksum": "c06b5406fd6cddf346fac448e95780e5b161f3d560a7df86a202d7f6c20d3f72"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA15C1E29EFD",
       "checksum": "e961f3cde3a9b995dc0227fb7de8c01a4c6618cdd196e2622f3ba1e7c8370035"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA15D4C0F12B",
       "checksum": "1a69861f6602579ac0391e63cdd14f143b1f1e373b34ca8a3a4bd98c22151df5"
     }
   },
@@ -293,12 +354,15 @@
   },
   "0.8.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9BA15C4AB9051",
       "checksum": "bcdb334b47c34b0b35ffbba8400ca29df0d85377020c6468d2657a74dbef117e"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA15C94F652D",
       "checksum": "1afb06d2187c039c750821cb2bc682af97f71ff3d7853e00b8298a54b7a695bd"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA15CCBEDE80",
       "checksum": "71563aefdc28d6094891d9d2860f8dfe6e4685581b4bf7216342b84e07648a07"
     }
   },
@@ -307,12 +371,15 @@
   },
   "0.7.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9BA15CE8A81F1",
       "checksum": "fd9bb11a80a4246bc3415d2ce7e09029f4b1a609f89ba82d23d61971f54d1c2d"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA15C10B982D",
       "checksum": "becbb39f28e65af72186ba11d476dcaf4ab22153ce7c4f267278dc3958575850"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA15D5FBB454",
       "checksum": "173da6285aa9e2fedc4fe7a64c0c930f5306d8a95ff31625a71659ddfd3c819f"
     }
   },
@@ -321,12 +388,15 @@
   },
   "0.6.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9BA15C6D09160",
       "checksum": "7f8837cd354aa16a334d3877fe0dfb6e0d063e5a268f6e6c21422f4ce6566ec5"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA15D2A4535B",
       "checksum": "57ddf70519f69f3d7bfa6761aa416154d1b5afc14444c25d516d3f82519dcf52"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA15C232FD37",
       "checksum": "7312197b8dc6f6c6b5413e3dbccf5cb8a3061e5da3b1451ff17980c59a972601"
     }
   },
@@ -335,23 +405,29 @@
   },
   "0.5.1": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9BA15C24856D9",
       "checksum": "f0c6a433f217d123da7d89b744c0cdf277a3ef5c3973f424c784f33a74c535a9"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA15D5CF539D",
       "checksum": "a945d371fd5266ae1b50e9abc9837df780d94c2f5262f1cccfa381ae833a011e"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA15C3E61325",
       "checksum": "9f36cdd62bec6e16a7dd0bfaf89addc9362bd9280e26971f45b8c141ecf195f9"
     }
   },
   "0.5.0": {
     "x86_64_linux_gnu": {
+      "etag": "0x8D9BA15D1FF03A6",
       "checksum": "f7ab37b542461357862b6e91459a211a8cbeb872f84c6de227076e3d6db7eff7"
     },
     "x86_64_macos": {
+      "etag": "0x8D9BA15C2833463",
       "checksum": "86ce9babce8c7398c00c21383eda59895ede6be5e7ab688cfef6b5a11050fcc8"
     },
     "x86_64_windows": {
+      "etag": "0x8D9BA15D44606B3",
       "checksum": "492ccea9c52cf8026352488b6064b02ca91ae93a9e70f34d09928868b2f0f011"
     }
   }

--- a/tools/codegen/src/lib.rs
+++ b/tools/codegen/src/lib.rs
@@ -190,6 +190,7 @@ pub struct Manifest {
 pub struct ManifestDownloadInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
+    pub etag: String,
     pub checksum: String,
     /// Path to binaries in archive. Default to `${tool}${exe}`.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/tools/manifest.sh
+++ b/tools/manifest.sh
@@ -10,11 +10,11 @@ cd "$(dirname "$0")"/..
 #    ./tools/manifest.sh [PACKAGE [VERSION_REQ]]
 
 if [[ $# -gt 0 ]]; then
-    cargo run --manifest-path tools/codegen/Cargo.toml --release -- "$@"
+    cargo +nightly run --manifest-path tools/codegen/Cargo.toml --release -- "$@"
     exit 0
 fi
 
 for manifest in tools/codegen/base/*.json; do
     package=$(basename "${manifest%.*}")
-    cargo run --manifest-path tools/codegen/Cargo.toml --release -- "${package}" latest
+    cargo +nightly run --manifest-path tools/codegen/Cargo.toml --release -- "${package}" latest
 done


### PR DESCRIPTION
c.f. https://github.com/taiki-e/install-action/issues/540#issuecomment-2170998595

This doesnt reduce the number of API hits - it only halts downloads if the current etag is the same as in the head of the asset fetch.

As a result the manifest CI job goes from 4m30s to ~2m.

Using `If-None-Match` header would also work, but 

1. that would add complexity to `download(..)`, and the logic around the invocation to optionally provide an etag if it was found in the existing manifest.
2. I found using `head` doesnt work, as the Server responded to `ureq::head` with 401 if `If-None-Match` is used; however responds to `wget` head with 304.

IMO it would be worthwhile adding complexity to `download(..)` if more of the fetches also become etag capable, which I believe is possible and worthwhile, but IMO not as valuable as the asset fetches because they are so numerous and voluminous to be likely to prevent features being developed by new contributors who will balk at downloading so much data just to check a new feature against the full set of manifests.

The other major addition is writing the manifest during processing of many versions - some of the larger manifests were failing when I was downloading all of the old assets, and needed to be restarted, and I was loosing too much data/time if it had to restart at the beginning with all the etags missing.