### PR TITLE
Speedup codegen by caching tools/codegen compilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,8 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    env:
+      RUSTFLAGS: -C link-arg=-fuse-ld=lld
     steps:
       - uses: taiki-e/checkout-action@v1
       - name: Install Rust

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,7 @@ jobs:
         run: cargo update
       - uses: Swatinem/rust-cache@v2
         with:
-          cache-all-crates: "true"
+          cache-all-crates: 'true'
       - run: tools/manifest.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,12 @@ jobs:
     steps:
       - uses: taiki-e/checkout-action@v1
       - name: Install Rust
-        run: rustup toolchain add nightly --no-self-update && rustup default nightly
+        run: rustup toolchain add stable --no-self-update --profile minimal && rustup default stable
+      - name: Generate Cargo.lock
+        run: cargo update
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-all-crates: "true"
       - run: tools/manifest.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,8 @@ jobs:
       - uses: ./
         with:
           tool: ${{ steps.tool-list.outputs.tool }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell
       - name: Test bash
         run: just --version && shfmt --version && protoc --version
@@ -151,6 +153,8 @@ jobs:
       - uses: ./
         with:
           tool: ${{ steps.tool-list.outputs.tool }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   manifest:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,8 +158,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    env:
-      RUSTFLAGS: -C link-arg=-fuse-ld=lld
     steps:
       - uses: taiki-e/checkout-action@v1
       - name: Install Rust

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
     steps:
       - uses: taiki-e/checkout-action@v1
       - name: Install Rust
-        run: rustup toolchain add stable --no-self-update --profile minimal && rustup default stable
+        run: rustup update stable --no-self-update
       - name: Generate Cargo.lock
         run: cargo update
       - uses: Swatinem/rust-cache@v2

--- a/tools/codegen/Cargo.toml
+++ b/tools/codegen/Cargo.toml
@@ -18,7 +18,6 @@ tar = "0.4"
 toml_edit = { version = "0.22", default-features = false, features = ["parse", "serde"] }
 # TODO: call curl command instead of using ureq?
 ureq = { version = "2", features = ["json"] }
-once_cell = "1"
 
 [lints]
 workspace = true

--- a/tools/codegen/Cargo.toml
+++ b/tools/codegen/Cargo.toml
@@ -18,6 +18,7 @@ tar = "0.4"
 toml_edit = { version = "0.22", default-features = false, features = ["parse", "serde"] }
 # TODO: call curl command instead of using ureq?
 ureq = { version = "2", features = ["json"] }
+once_cell = "1"
 
 [lints]
 workspace = true

--- a/tools/codegen/src/main.rs
+++ b/tools/codegen/src/main.rs
@@ -7,7 +7,7 @@ use std::{
     ffi::OsStr,
     io::Read,
     path::Path,
-    sync::{LazyLock, RwLock},
+    sync::RwLock,
     time::Duration,
 };
 
@@ -17,8 +17,10 @@ use install_action_internal_codegen::{
     workspace_root, BaseManifest, HostPlatform, Manifest, ManifestDownloadInfo, ManifestRef,
     ManifestTemplate, ManifestTemplateDownloadInfo, Manifests, Signing, SigningKind, Version,
 };
+use once_cell::sync::Lazy;
 use sha2::{Digest, Sha256};
 use spdx::expression::{ExprNode, ExpressionReq, Operator};
+
 
 fn main() -> Result<()> {
     let args: Vec<_> = env::args().skip(1).collect();
@@ -670,7 +672,8 @@ impl GitHubTokens {
         }
     }
 }
-static GITHUB_TOKENS: LazyLock<GitHubTokens> = LazyLock::new(|| {
+// TODO: Use std::sync::LazyLock once 1.80 is released
+static GITHUB_TOKENS: Lazy<GitHubTokens> = Lazy::new(|| {
     let token = env::var("GITHUB_TOKEN").ok().filter(|v| !v.is_empty());
     GitHubTokens {
         raw: RwLock::new(token.clone()),

--- a/tools/codegen/src/main.rs
+++ b/tools/codegen/src/main.rs
@@ -399,26 +399,23 @@ fn main() -> Result<()> {
                 None => {}
             }
 
-            download_info.insert(
-                platform,
-                ManifestDownloadInfo {
-                    url: Some(url),
-                    etag,
-                    checksum: hash,
-                    bin: base_download_info.bin.as_ref().or(base_info.bin.as_ref()).map(|s| {
-                        s.map(|s| {
-                            replace_vars(
-                                s,
-                                package,
-                                Some(version),
-                                Some(platform),
-                                base_info.rust_crate.as_deref(),
-                            )
-                            .unwrap()
-                        })
-                    }),
-                },
-            );
+            download_info.insert(platform, ManifestDownloadInfo {
+                url: Some(url),
+                etag,
+                checksum: hash,
+                bin: base_download_info.bin.as_ref().or(base_info.bin.as_ref()).map(|s| {
+                    s.map(|s| {
+                        replace_vars(
+                            s,
+                            package,
+                            Some(version),
+                            Some(platform),
+                            base_info.rust_crate.as_deref(),
+                        )
+                        .unwrap()
+                    })
+                }),
+            });
             buf.clear();
         }
         if download_info.is_empty() {
@@ -498,17 +495,17 @@ fn main() -> Result<()> {
                 );
             }
             if version.major != 0 {
-                manifests.map.insert(
-                    Reverse(Version::omitted(version.major, None)),
-                    ManifestRef::Ref { version: version.clone().into() },
-                );
+                manifests
+                    .map
+                    .insert(Reverse(Version::omitted(version.major, None)), ManifestRef::Ref {
+                        version: version.clone().into(),
+                    });
             }
             prev_version = version;
         }
-        manifests.map.insert(
-            Reverse(Version::latest()),
-            ManifestRef::Ref { version: prev_version.clone().into() },
-        );
+        manifests.map.insert(Reverse(Version::latest()), ManifestRef::Ref {
+            version: prev_version.clone().into(),
+        });
     }
 
     let ManifestRef::Ref { version: latest_version } =
@@ -575,10 +572,10 @@ fn main() -> Result<()> {
                     break 'outer;
                 }
             } else {
-                t.download_info.insert(
-                    *platform,
-                    ManifestTemplateDownloadInfo { url: template_url, bin: template_bin },
-                );
+                t.download_info.insert(*platform, ManifestTemplateDownloadInfo {
+                    url: template_url,
+                    bin: template_bin,
+                });
             }
         }
     }

--- a/tools/manifest.sh
+++ b/tools/manifest.sh
@@ -10,11 +10,11 @@ cd "$(dirname "$0")"/..
 #    ./tools/manifest.sh [PACKAGE [VERSION_REQ]]
 
 if [[ $# -gt 0 ]]; then
-    cargo +nightly run --manifest-path tools/codegen/Cargo.toml --release -- "$@"
+    cargo run --manifest-path tools/codegen/Cargo.toml --release -- "$@"
     exit 0
 fi
 
 for manifest in tools/codegen/base/*.json; do
     package=$(basename "${manifest%.*}")
-    cargo +nightly run --manifest-path tools/codegen/Cargo.toml --release -- "${package}" latest
+    cargo run --manifest-path tools/codegen/Cargo.toml --release -- "${package}" latest
 done


### PR DESCRIPTION
 - Use `once_cell::sync::Lazy` instead of `std::sync::LazyLock`, I've left a TODO comment there since it will be stablised in 1.80 on 25 July 2024
 - Switch to stable rust toolchain
 - Use [Swatinem/rust-cache](https://github.com/Swatinem/rust-cache) to cache tools/codegen