### PR TITLE
Set GITHUB_TOKEN for cargo-binstall by default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,3 +27,4 @@ runs:
         INPUT_TOOL: ${{ inputs.tool }}
         INPUT_CHECKSUM: ${{ inputs.checksum }}
         INPUT_FALLBACK: ${{ inputs.fallback }}
+        DEFAULT_GITHUB_TOKEN: ${{ github.token }}

--- a/main.sh
+++ b/main.sh
@@ -818,6 +818,9 @@ if [[ ${#unsupported_tools[@]} -gt 0 ]]; then
     info "install-action does not support ${unsupported_tools[*]}; fallback to cargo-binstall"
     IFS=$'\n\t'
     install_cargo_binstall
+    if [[ -z "${GITHUB_TOKEN:-}" ]] && [[ -n "${DEFAULT_GITHUB_TOKEN:-}" ]]; then
+        export GITHUB_TOKEN="${DEFAULT_GITHUB_TOKEN}"
+    fi
     # By default, cargo-binstall enforce downloads over secure transports only.
     # As a result, http will be disabled, and it will also set
     # min tls version to be 1.2


### PR DESCRIPTION
https://github.com/taiki-e/install-action/pull/554#discussion_r1649548929

> The fact that cargo-binstall's performance or robustness would be worse without this env var at a high probability is very unfortunate.

cc @NobodyXu 