### PR TITLE
Allow installing pre-release versions using binstall

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -639,11 +639,11 @@ for tool in "${tools[@]}"; do
   if [[ "${tool}" == *"@"* ]]; then
     version="${tool#*@}"
     tool="${tool%@*}"
-    if [[ ! "${version}" =~ ^([1-9][0-9]*(\.[0-9]+(\.[0-9]+)?)?|0\.[1-9][0-9]*(\.[0-9]+)?|^0\.0\.[0-9]+)$|^latest$ ]]; then
+    if [[ ! "${version}" =~ ^([1-9][0-9]*(\.[0-9]+(\.[0-9]+)?)?|0\.[1-9][0-9]*(\.[0-9]+)?|^0\.0\.[0-9]+)(-[0-9A-Za-z\.-]+)?$|^latest$ ]]; then
       if [[ ! "${version}" =~ ^([1-9][0-9]*(\.[0-9]+(\.[0-9]+)?)?|0\.[1-9][0-9]*(\.[0-9]+)?|^0\.0\.[0-9]+)(-[0-9A-Za-z\.-]+)?(\+[0-9A-Za-z\.-]+)?$|^latest$ ]]; then
         bail "install-action does not support semver operators: '${version}'"
       fi
-      bail "install-action v2 does not support semver pre-release and build-metadata: '${version}'; if you need these supports again, please submit an issue at <https://github.com/taiki-e/install-action>"
+      bail "install-action v2 does not support semver build-metadata: '${version}'; if you need these supports again, please submit an issue at <https://github.com/taiki-e/install-action>"
     fi
   else
     version=latest


### PR DESCRIPTION
Closes #858

cc @SillyFreak: Could you confirm that this actually solves your problem? (This PR can be used as `uses: taiki-e/install-action@pre`.)