### PR TITLE
Fix tool name whitespace parsing bug

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -440,8 +440,11 @@ tool="${INPUT_TOOL:-}"
 tools=()
 if [[ -n "${tool}" ]]; then
   while read -rd,; do
-    t="${REPLY# *}"
-    tools+=("${t%* }")
+    # Trim leading and trailing whitespace
+    t="${REPLY}"
+    t="${t#"${t%%[![:space:]]*}"}"  # Remove leading whitespace
+    t="${t%"${t##*[![:space:]]}"}"  # Remove trailing whitespace
+    tools+=("${t}")
   done <<<"${tool},"
 fi
 if [[ ${#tools[@]} -eq 0 ]]; then


### PR DESCRIPTION
## Problem

The tool name parsing logic in `main.sh` had incorrect parameter expansions for trimming whitespace:

```bash
t="${REPLY# *}"      # Incorrect: removes leading space + any chars
tools+=("${t%* }")   # Incorrect: removes shortest match of "any chars + space" from end
```

This caused version strings to contain stray characters when tool names had unexpected whitespace, leading to semver validation failures with errors like:

```text
Error: install-action does not support semver operators: '0.10.3
'
```

The debug output showed the version was parsed as `'0.10.3` with both a leading single quote and the closing quote appearing on a separate line, instead of the expected clean `0.10.3`.

## Solution

Replaced the faulty whitespace trimming with proper bash parameter expansion patterns:

```bash
# Trim leading and trailing whitespace
t="${REPLY}"
t="${t#"${t%%[![:space:]]*}"}"  # Remove leading whitespace
t="${t%"${t##*[![:space:]]}"}"  # Remove trailing whitespace
tools+=("${t}")
```

This uses the standard bash idiom for trimming whitespace:

- `"${t%%[![:space:]]*}"` finds the leading whitespace
- `"${t#...}"` removes it from the beginning
- `"${t##*[![:space:]]}"` finds the trailing whitespace
- `"${t%...}"` removes it from the end

## Example Usage

This fix resolves issues like the one in this real-world workflow where a version is read from a file:

```yaml
- name: Read Tool Version
  id: tool-version
  run: |
    VER=$(sed -e 's/^[v=]*//' -e 's/[[:space:]]*$//' .tool-version)
    echo "version=${VER}" >> $GITHUB_OUTPUT

- name: Install Cargo Tools
  uses: taiki-e/install-action@v2
  with:
    tool: |
      cargo-lambda
      my-custom-tool@${{ steps.tool-version.outputs.version }}
```

Before this fix, if the version file had unexpected whitespace, the version string would be corrupted with stray quotes, causing the semver validation to fail.
