### PR TITLE
Support whitespace separated list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,12 @@ jobs:
       - uses: ./
         with:
           # NB: Update alias list in tools/publish.rs and case for aliases in main.sh.
-          tool: nextest,taplo-cli,typos-cli,wasm-bindgen-cli,wasmtime-cli
+          tool: |
+            nextest
+            taplo-cli
+            typos-cli
+            wasm-bindgen-cli
+            wasmtime-cli
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Test bash

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ GitHub Action for installing development tools (mainly from GitHub Releases).
 
 | Name | Required | Description | Type | Default |
 | ---- | :------: | ----------- | ---- | ------- |
-| tool | **✓** | Tools to install (comma-separated list) | String | |
+| tool | **✓** | Tools to install (whitespace or comma separated list) | String | |
 | checksum | | Whether to enable checksums | Boolean | `true` |
 
 ### Example workflow

--- a/tools/ci/tool-list.sh
+++ b/tools/ci/tool-list.sh
@@ -206,7 +206,29 @@ IFS=$'\n'
 tools=($(LC_ALL=C sort -u <<<"${tools[*]}"))
 IFS=$'\n\t'
 
-# TODO: inject random space before/after of tool name for testing https://github.com/taiki-e/install-action/issues/115.
-IFS=','
-printf 'tool=%s\n' "${tools[*]}"
-IFS=$'\n\t'
+comma_sep=$((RANDOM % 2))
+list=''
+for tool in "${tools[@]}"; do
+  if [[ -n "${list}" ]]; then
+    if [[ "${comma_sep}" == "1" ]]; then
+      list+=','
+    else
+      case $((RANDOM % 2)) in
+        0) list+=' ' ;;
+        1) list+=$'\t' ;;
+      esac
+    fi
+  fi
+  case $((RANDOM % 3)) in
+    0) ;;
+    1) list+=' ' ;;
+    2) list+=$' \t ' ;;
+  esac
+  list+="${tool}"
+  case $((RANDOM % 3)) in
+    0) ;;
+    1) list+=' ' ;;
+    2) list+=$' \t ' ;;
+  esac
+done
+printf 'tool=%s\n' "${list}"


### PR DESCRIPTION
`tool` input option now supports whitespace (space, tab, and line) or comma separated list. Previously, only comma-separated list was supported.

Closes #1147