### PR TITLE
docs: Clarify "tool is supported" doesn't mean "tool is trusted or reviewed by maintainer"

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -9,6 +9,9 @@ See the [Supported tools section in README.md](README.md#supported-tools) for ho
 > If `$CARGO_HOME/bin` is not available, Rust-related binaries will be installed to `$HOME/.cargo/bin`.<br>
 > If `$HOME/.cargo/bin` is not available, Rust-related binaries will be installed to `$HOME/.install-action/bin`.<br>
 
+> [!WARNING]
+> Please note that the fact that a specific tool is listed here does **NOT** mean that the maintainer trusts the tool for safety or has reviewed its code.
+
 | Name | Where binaries will be installed | Where will it be installed from | Supported platform | License |
 | ---- | -------------------------------- | ------------------------------- | ------------------ | ------- |
 | [**biome**](https://biomejs.dev) | `$HOME/.install-action/bin` | [GitHub Releases](https://github.com/biomejs/biome/releases) | Linux, macOS, Windows | [Apache-2.0](https://github.com/biomejs/biome/blob/main/LICENSE-APACHE) OR [MIT](https://github.com/biomejs/biome/blob/main/LICENSE-MIT) |


### PR DESCRIPTION
Add the following warning to TOOLS.md:

> [!WARNING]
> Please note that the fact that a specific tool is listed here does **NOT** mean that the maintainer trusts the tool for safety or has reviewed its code.

Based on #488's discussion, I felt that perhaps there are somewhat excessive expectations placed on the maintainers.

Please note that many tools are added by the community, and I only trust or review tools that I actually use.

cc @jayvdb