### PR TITLE
Support more platforms in various tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Support `cargo-auditable`, `cargo-cyclonedx`, `cargo-machete`, and `knope` on AArch64 Linux.
+
+- Support `cargo-nextest` on AArch64 Linux (musl).
+
+- Support `coreutils`, `dprint`, and `sccache` on riscv64 Linux.
+
+- Support `sccache` on s390x Linux.
+
+- Support installing native binary for `cargo-audit` and `wasm-pack` on AArch64 macOS. (Previously x86_64 macOS binary is used as fallback.)
+
+- Support installing native binary for `cargo-auditable`, `cargo-nextest`, `syft`, and `taplo` on AArch64 Windows. (Previously x86_64 Windows binary is used as fallback.)
+
 ## [2.69.0] - 2026-03-19
 
 - Support `auto-doc`. ([#1596](https://github.com/taiki-e/install-action/pull/1596), thanks @quotidian-ennui)
@@ -520,7 +532,7 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [2.67.4] - 2026-01-22
 
-- Support installing native binary for `cargo-llvm-cov`  on AArch64 Windows. (Previously x86_64 Windows binary is used as fallback.)
+- Support installing native binary for `cargo-llvm-cov` on AArch64 Windows. (Previously x86_64 Windows binary is used as fallback.)
 
 - Update `cargo-llvm-cov@latest` to 0.6.24.
 

--- a/main.sh
+++ b/main.sh
@@ -538,9 +538,11 @@ esac
 # NB: Sync with tools/ci/tool-list.sh.
 case "$(uname -m)" in
   aarch64 | arm64) host_arch=aarch64 ;;
-  # Ignore Arm for now, as we need to consider the version and whether hard-float is supported.
+  # Ignore 32-bit Arm for now, as we need to consider the version and whether hard-float is supported.
   # https://github.com/rust-lang/rustup/pull/593
   # https://github.com/cross-rs/cross/pull/1018
+  # And support for 32-bit Arm will be removed in near future.
+  # https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/#removal-of-operating-system-support-with-node24
   # Does it seem only armv7l+ is supported?
   # https://github.com/actions/runner/blob/v2.321.0/src/Misc/externals.sh#L178
   # https://github.com/actions/runner/issues/688
@@ -551,9 +553,8 @@ case "$(uname -m)" in
   # Very few tools provide prebuilt binaries for these.
   # TODO: fallback to `cargo install`? (binstall fallback is not good idea here as cargo-binstall doesn't provide prebuilt binaries for these.)
   loongarch64 | mips | mips64 | ppc | ppc64 | sun4v) bail "$(uname -m) runner is not supported yet by this action; if you need support for this platform, please submit an issue at <https://github.com/taiki-e/install-action>" ;;
-  # GitHub Actions Runner supports x86_64/AArch64/Arm Linux, x86_64/AArch64 Windows,
-  # and x86_64/AArch64 macOS.
-  # https://github.com/actions/runner/blob/v2.321.0/.github/workflows/build.yml#L21
+  # GitHub Actions Runner supports x86_64/AArch64/Arm Linux and x86_64/AArch64 Windows/macOS.
+  # https://github.com/actions/runner/blob/v2.332.0/.github/workflows/build.yml#L24
   # https://docs.github.com/en/actions/reference/runners/self-hosted-runners#supported-processor-architectures
   # And IBM provides runners for powerpc64le/s390x Linux.
   # https://github.com/IBM/actionspz

--- a/manifests/cargo-audit.json
+++ b/manifests/cargo-audit.json
@@ -16,6 +16,10 @@
     "aarch64_linux_gnu": {
       "url": "https://github.com/rustsec/rustsec/releases/download/cargo-audit/v${version}/cargo-audit-aarch64-unknown-linux-gnu-v${version}.tgz",
       "bin": "cargo-audit-aarch64-unknown-linux-gnu-v${version}/cargo-audit"
+    },
+    "aarch64_macos": {
+      "url": "https://github.com/rustsec/rustsec/releases/download/cargo-audit/v${version}/cargo-audit-aarch64-apple-darwin-v${version}.tgz",
+      "bin": "cargo-audit-aarch64-apple-darwin-v${version}/cargo-audit"
     }
   },
   "license_markdown": "[Apache-2.0](https://github.com/rustsec/rustsec/blob/HEAD/cargo-audit/LICENSE-APACHE) OR [MIT](https://github.com/rustsec/rustsec/blob/HEAD/cargo-audit/LICENSE-MIT)",
@@ -41,6 +45,10 @@
     "aarch64_linux_gnu": {
       "etag": "0x8DE64326434D959",
       "checksum": "4c8df835ee484441bd2c8c6bcac28c4ce4b4058ba9e7477cb9e0012fe7769f66"
+    },
+    "aarch64_macos": {
+      "etag": "0x8DE643283AA3EF2",
+      "checksum": "04e76e1da25f597bea4814c44faf8aac215838b9f3646e3b6a873d87acd31b73"
     }
   },
   "0.22.0": {

--- a/manifests/cargo-auditable.json
+++ b/manifests/cargo-auditable.json
@@ -13,9 +13,17 @@
       "url": "https://github.com/rust-secure-code/cargo-auditable/releases/download/v${version}/cargo-auditable-x86_64-pc-windows-msvc.zip",
       "bin": "cargo-auditable.exe"
     },
+    "aarch64_linux_gnu": {
+      "url": "https://github.com/rust-secure-code/cargo-auditable/releases/download/v${version}/cargo-auditable-aarch64-unknown-linux-gnu.tar.xz",
+      "bin": "cargo-auditable-aarch64-unknown-linux-gnu/cargo-auditable"
+    },
     "aarch64_macos": {
       "url": "https://github.com/rust-secure-code/cargo-auditable/releases/download/v${version}/cargo-auditable-aarch64-apple-darwin.tar.xz",
       "bin": "cargo-auditable-aarch64-apple-darwin/cargo-auditable"
+    },
+    "aarch64_windows": {
+      "url": "https://github.com/rust-secure-code/cargo-auditable/releases/download/v${version}/cargo-auditable-aarch64-pc-windows-msvc.zip",
+      "bin": "cargo-auditable.exe"
     }
   },
   "license_markdown": "[Apache-2.0](https://github.com/rust-secure-code/cargo-auditable/blob/HEAD/LICENSE-APACHE) OR [MIT](https://github.com/rust-secure-code/cargo-auditable/blob/HEAD/LICENSE-MIT)",
@@ -38,9 +46,17 @@
       "etag": "0x8DE7A23747DAF46",
       "checksum": "e2da8d873978982381269c27be8b76cfd4084fbf99c43bd83231ac9c714488bb"
     },
+    "aarch64_linux_gnu": {
+      "etag": "0x8DE7A237416D5D6",
+      "checksum": "fcf9121e5a0115cb1563852dd532d8c6aec3e84229908c576462c98eb4006521"
+    },
     "aarch64_macos": {
       "etag": "0x8DE7A23741AA219",
       "checksum": "fade0f3befebce7b54a46edfa31bea27789ea2136c51e662c2922b10f9d6f701"
+    },
+    "aarch64_windows": {
+      "etag": "0x8DE7A2374234AE3",
+      "checksum": "f7e64d1b6762c15cc4bc91afdd5366797239c503b983593c252b088ab4b2f2bf"
     }
   },
   "0.7.3": {
@@ -56,9 +72,17 @@
       "etag": "0x8DE7972E26AA3C4",
       "checksum": "78c9f05a39d2104b8177820e459e831edc64d595e8b5e7506718dc19678574e5"
     },
+    "aarch64_linux_gnu": {
+      "etag": "0x8DE7972E1F0F3D0",
+      "checksum": "0a3cea758e8e76da048ed588a084b1c466306ec914eeab98deea3eeae2c49e3f"
+    },
     "aarch64_macos": {
       "etag": "0x8DE7972E1F66BE9",
       "checksum": "a78e886dbb15646dbeb435f1270ecf0b36688d87ce7e2e0cce823b655adda755"
+    },
+    "aarch64_windows": {
+      "etag": "0x8DE7972E2026C53",
+      "checksum": "7a61dfc607bd7fdf601662ecbfd12efdd8fa1eeeb9c7d645d0a064dee951133b"
     }
   },
   "0.7.2": {
@@ -74,9 +98,17 @@
       "etag": "0x8DE1F786D79ACFC",
       "checksum": "cbee5b0e2465793c260468afaeee3c77234e7aafaae123e2ce8d148c933c9840"
     },
+    "aarch64_linux_gnu": {
+      "etag": "0x8DE1F786CFFFCF3",
+      "checksum": "4979df37f1512e44fc4e309503fd44d6dd5869a559c5e501f089942b3179d6f8"
+    },
     "aarch64_macos": {
       "etag": "0x8DE1F786CF202FF",
       "checksum": "9b0a5aea8bb3aec6c2bf303ea5068a7c6c3521e875f571b41cda491baa150960"
+    },
+    "aarch64_windows": {
+      "etag": "0x8DE1F786CFD1A09",
+      "checksum": "1c0cf4c27877cc8c9439478f5e79f4d0bf83b3395edaeac489cc0f4dad23ddc9"
     }
   },
   "0.7.1": {

--- a/manifests/cargo-cyclonedx.json
+++ b/manifests/cargo-cyclonedx.json
@@ -27,6 +27,12 @@
       "checksum": "8750e00775661dcb75bc482c1a298839fd94e8a0c033b49905ba0f246ffed202",
       "bin": "cargo-cyclonedx.exe"
     },
+    "aarch64_linux_gnu": {
+      "url": "https://github.com/CycloneDX/cyclonedx-rust-cargo/releases/download/cargo-cyclonedx-0.5.9/cargo-cyclonedx-aarch64-unknown-linux-gnu.tar.xz",
+      "etag": "0x8DE859AEEAE6F5C",
+      "checksum": "7bf131ca5389b07a4f10c182bcf8a5ad339d64408b6f0d8f6834a0bd6120a06a",
+      "bin": "cargo-cyclonedx-aarch64-unknown-linux-gnu/cargo-cyclonedx"
+    },
     "aarch64_macos": {
       "url": "https://github.com/CycloneDX/cyclonedx-rust-cargo/releases/download/cargo-cyclonedx-0.5.9/cargo-cyclonedx-aarch64-apple-darwin.tar.xz",
       "etag": "0x8DE859AEEB78CD2",
@@ -52,6 +58,12 @@
       "etag": "0x8DE805A5010C283",
       "checksum": "81577d0bdc7dbe99bed56ec79437afef476842999541a85096efa1f28f7fd965",
       "bin": "cargo-cyclonedx.exe"
+    },
+    "aarch64_linux_gnu": {
+      "url": "https://github.com/CycloneDX/cyclonedx-rust-cargo/releases/download/cargo-cyclonedx-0.5.8/cargo-cyclonedx-aarch64-unknown-linux-gnu.tar.xz",
+      "etag": "0x8DE805A4FB0BF22",
+      "checksum": "e5b3e6abb9614cd603ea142b35f511976ea14a260f20ecdce9468a1e8e9da3c6",
+      "bin": "cargo-cyclonedx-aarch64-unknown-linux-gnu/cargo-cyclonedx"
     },
     "aarch64_macos": {
       "url": "https://github.com/CycloneDX/cyclonedx-rust-cargo/releases/download/cargo-cyclonedx-0.5.8/cargo-cyclonedx-aarch64-apple-darwin.tar.xz",

--- a/manifests/cargo-machete.json
+++ b/manifests/cargo-machete.json
@@ -27,6 +27,12 @@
       "checksum": "c812550857db16ae352ae0b3a67ad806a172e7caf33380fc338fca298faf3ec8",
       "bin": "cargo-machete-v0.9.1-x86_64-pc-windows-msvc/cargo-machete.exe"
     },
+    "aarch64_linux_gnu": {
+      "url": "https://github.com/bnjbvr/cargo-machete/releases/download/v0.9.1/cargo-machete-v0.9.1-aarch64-unknown-linux-gnu.tar.gz",
+      "etag": "0x8DDDC3C9F46BDC5",
+      "checksum": "ec71436fb90acd8cb1e22ec1e9f9fe507abffcd66741b20b481a0d0f13ce4fa0",
+      "bin": "cargo-machete-v0.9.1-aarch64-unknown-linux-gnu/cargo-machete"
+    },
     "aarch64_macos": {
       "url": "https://github.com/bnjbvr/cargo-machete/releases/download/v0.9.1/cargo-machete-v0.9.1-aarch64-apple-darwin.tar.gz",
       "etag": "0x8DDDC3CA9378A6D",
@@ -52,6 +58,12 @@
       "etag": "0x8DDDBF9222B421E",
       "checksum": "b2e5faa490a5e3872d5fdc062b6989b6acf5b5f2ac430f770036a87fe224e75c",
       "bin": "cargo-machete-v0.9.0-x86_64-pc-windows-msvc/cargo-machete.exe"
+    },
+    "aarch64_linux_gnu": {
+      "url": "https://github.com/bnjbvr/cargo-machete/releases/download/v0.9.0/cargo-machete-v0.9.0-aarch64-unknown-linux-gnu.tar.gz",
+      "etag": "0x8DDDBF8EFF6960A",
+      "checksum": "8089d25aa3c57ba3a529e90fd3ed7b39c112964a9216ecfcfe062ee783ec759c",
+      "bin": "cargo-machete-v0.9.0-aarch64-unknown-linux-gnu/cargo-machete"
     },
     "aarch64_macos": {
       "url": "https://github.com/bnjbvr/cargo-machete/releases/download/v0.9.0/cargo-machete-v0.9.0-aarch64-apple-darwin.tar.gz",

--- a/manifests/cargo-nextest.json
+++ b/manifests/cargo-nextest.json
@@ -16,6 +16,12 @@
     "aarch64_linux_gnu": {
       "url": "https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-${version}/cargo-nextest-${version}-aarch64-unknown-linux-gnu.tar.gz"
     },
+    "aarch64_linux_musl": {
+      "url": "https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-${version}/cargo-nextest-${version}-aarch64-unknown-linux-musl.tar.gz"
+    },
+    "aarch64_windows": {
+      "url": "https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-${version}/cargo-nextest-${version}-aarch64-pc-windows-msvc.tar.gz"
+    },
     "riscv64_linux_gnu": {
       "url": "https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-${version}/cargo-nextest-${version}-riscv64gc-unknown-linux-gnu.tar.gz"
     }
@@ -49,6 +55,14 @@
       "etag": "0x8DE852B597809A7",
       "checksum": "ce3bc715344d51e6f0fbb944489e37d17e25d24dfafaf861cc37643cfe7de663"
     },
+    "aarch64_linux_musl": {
+      "etag": "0x8DE8529E3613859",
+      "checksum": "12c617783c8944caa51ba1abd983db46798308a87531e5ef357afc9422398f53"
+    },
+    "aarch64_windows": {
+      "etag": "0x8DE852BFF07B37A",
+      "checksum": "ec88e8e75e395849383565a61052be7621ff164d145013a1277172e6343bacd2"
+    },
     "riscv64_linux_gnu": {
       "etag": "0x8DE852AB87E4324",
       "checksum": "22adaaf5fa232dc78a8b2a3f51c41eb175440fda999c20eff17709a2905d0f94"
@@ -75,6 +89,14 @@
     "aarch64_linux_gnu": {
       "etag": "0x8DE7E3DA1E53018",
       "checksum": "cca77f0b71dca2c82458294fc2b5992d8754c816e8b19ee64c76b3402e242e89"
+    },
+    "aarch64_linux_musl": {
+      "etag": "0x8DE7E3D0AB9CE35",
+      "checksum": "e06868782f00964106918213c8ea798ada50b990c2bde071ddc44cd7543b9f9a"
+    },
+    "aarch64_windows": {
+      "etag": "0x8DE7E408C981FA1",
+      "checksum": "cbdcd89dfdecdfbdf5e5ea69e8174b7e8cce802a197dc75181bdbaf8c8af124e"
     }
   },
   "0.9.129": {
@@ -98,6 +120,14 @@
     "aarch64_linux_gnu": {
       "etag": "0x8DE725EDC1ECF1A",
       "checksum": "27f6a395baa53a98c0d817104dcef4795d493dd41f33348f49f45ac616a1bfa7"
+    },
+    "aarch64_linux_musl": {
+      "etag": "0x8DE725ED44B4BDC",
+      "checksum": "24961e6ed5acff59cda9644595ce7c814bd55346f14e14b0907740be2b16e507"
+    },
+    "aarch64_windows": {
+      "etag": "0x8DE725F32EC0DF4",
+      "checksum": "e3a30eab50c42ffbb11ae1d9504a6b35e9a371a70a5976d90ce56e65f7743f7e"
     }
   },
   "0.9.128": {
@@ -121,6 +151,14 @@
     "aarch64_linux_gnu": {
       "etag": "0x8DE700DE4DB8B4C",
       "checksum": "4efeeb7ef3c6a4ed63998b2cecfef35503a38eeb9469dee84690abadcd6bb363"
+    },
+    "aarch64_linux_musl": {
+      "etag": "0x8DE700EDC01DD95",
+      "checksum": "ff97578a6474e7e680c1ca7aff1f32b1a423ad007dcdcdebd8dfdeedc09967e2"
+    },
+    "aarch64_windows": {
+      "etag": "0x8DE700FD215D368",
+      "checksum": "19215ffa6fdb8d4382b4aec348a9ea0f1fcf7360324484ce3899739e9bf23317"
     }
   },
   "0.9.127": {
@@ -144,6 +182,14 @@
     "aarch64_linux_gnu": {
       "etag": "0x8DE6B2E95DD5A04",
       "checksum": "ce9f682227a131497227f84328e0b2eb36d2a7f43515f867a47bdb35c69516e4"
+    },
+    "aarch64_linux_musl": {
+      "etag": "0x8DE6B2F390B9836",
+      "checksum": "513cf0a013724c45871ad106a887ccdecb12500936ed9a543dc804f1259c1602"
+    },
+    "aarch64_windows": {
+      "etag": "0x8DE6B30A3833AB1",
+      "checksum": "80651143cdefca4d8733bee73959e8a61e0a44442732358e71a8a2aa629c0fc8"
     }
   },
   "0.9.126": {
@@ -167,6 +213,14 @@
     "aarch64_linux_gnu": {
       "etag": "0x8DE643F82ACBDD3",
       "checksum": "0f248c2032d1cbabafc0c780901c3ce032114f4fbd7ff81b7f656edfeffcff21"
+    },
+    "aarch64_linux_musl": {
+      "etag": "0x8DE6440650D5347",
+      "checksum": "2c84b59749002d15ab76372dd608a41efb1db4aaccdda5bb50b7f4f5f9097730"
+    },
+    "aarch64_windows": {
+      "etag": "0x8DE6442BCCB0DBF",
+      "checksum": "d15fc067eadd901b329cab3eca805cd1d5aae85173d5c7d3b922e77a2c4fda3e"
     }
   },
   "0.9.125": {
@@ -190,6 +244,14 @@
     "aarch64_linux_gnu": {
       "etag": "0x8DE63887D605FD0",
       "checksum": "ea3174c1d8941f85d9f4c6d5619178482811b0a3b78010d3ea369ba20705fc2b"
+    },
+    "aarch64_linux_musl": {
+      "etag": "0x8DE638900B697DC",
+      "checksum": "fd28ce8d2a7bef0e8c93bb141301e2ce5bf8f8b4b4a7d186953f1b6f903251a5"
+    },
+    "aarch64_windows": {
+      "etag": "0x8DE638A7BBF6435",
+      "checksum": "9eda869f27af69aa44f8a8e4a660a963251a883541d265e054c38a45c37c59b0"
     }
   },
   "0.9.124": {
@@ -213,6 +275,10 @@
     "aarch64_linux_gnu": {
       "etag": "0x8DE5C68DDAA1BFF",
       "checksum": "d428e20e704715f8597e9b79bf30d0c1a3c5558a4e640766e7c746db368e2c34"
+    },
+    "aarch64_windows": {
+      "etag": "0x8DE5C6AAA5F98A4",
+      "checksum": "80a71af094104db8888d8dfb2b54cd8220f241cbfb92941181c08101ddc59651"
     }
   },
   "0.9.123": {
@@ -236,6 +302,10 @@
     "aarch64_linux_gnu": {
       "etag": "0x8DE5AB6B821862F",
       "checksum": "91ab98eedb817a52f4d4ae31e4c354e630ce1cc7d81c534b37b4d1edd42451c8"
+    },
+    "aarch64_windows": {
+      "etag": "0x8DE5AB7CC1E72D2",
+      "checksum": "6c2fd038710b1fe375a0d0a2a8a1ca383b7b65264172d2e81cf96c93df433d1b"
     }
   },
   "0.9.122": {
@@ -259,6 +329,10 @@
     "aarch64_linux_gnu": {
       "etag": "0x8DE5392C3119736",
       "checksum": "a6ebfd8bf8f962730172c6d9b10ae1895df52927ca90d37a1be43215eb1aa346"
+    },
+    "aarch64_windows": {
+      "etag": "0x8DE53945C99BAA5",
+      "checksum": "9f5f5b31826cac7d072f3c2f438965112dfdb0e50f5c4632bc4c103b5c052399"
     }
   },
   "0.9.121": {
@@ -282,6 +356,10 @@
     "aarch64_linux_gnu": {
       "etag": "0x8DE52100E646680",
       "checksum": "e57599407edeccec8c924cc2b4549ddd3e25d1b36018e2026a1796017da8182f"
+    },
+    "aarch64_windows": {
+      "etag": "0x8DE521100E1EFDD",
+      "checksum": "b72130cd9dd4b7beb7ebc9237f23a1001128acef1cf23ffd356fc2c9e73620bd"
     }
   },
   "0.9.120": {
@@ -305,6 +383,10 @@
     "aarch64_linux_gnu": {
       "etag": "0x8DE4E4771F3B230",
       "checksum": "5e13751733a1fc4d26984ad5e1bce10d057d95299b02ed3ac96877b7288c8feb"
+    },
+    "aarch64_windows": {
+      "etag": "0x8DE4E48ED915BE3",
+      "checksum": "98a9e6e338fed5ab95cb7f4e94acca0657099d5ebfb706740302d39bc85b11fc"
     }
   },
   "0.9.119": {
@@ -324,6 +406,10 @@
     "aarch64_linux_gnu": {
       "etag": "0x8DE4E458640BA9B",
       "checksum": "442f7c0d6f42db57a8644e15999a7c09e7b1816c8df5c4b72b2d64fcff089f4f"
+    },
+    "aarch64_windows": {
+      "etag": "0x8DE4E453D490495",
+      "checksum": "cdebd0bc0609828717a1068b2703e6751a7a4745f540854571e3e92dde10975f"
     }
   },
   "0.9.118": {
@@ -347,6 +433,10 @@
     "aarch64_linux_gnu": {
       "etag": "0x8DE4BDEB6B38E11",
       "checksum": "1b89b3cbac2e27095168f8edaa5165a344a83743b42dfb90a95b8896187807e8"
+    },
+    "aarch64_windows": {
+      "etag": "0x8DE4BE01D987B6B",
+      "checksum": "a86ec015d33dc7d55c4e750c70a158ff13611eadcbacd0ec08436b813c5ba733"
     }
   },
   "0.9.117": {
@@ -370,6 +460,10 @@
     "aarch64_linux_gnu": {
       "etag": "0x8DE49927D056219",
       "checksum": "85015537d3e987dce5326246eb53c9a086c7f862072898baed56b347d90d8e07"
+    },
+    "aarch64_windows": {
+      "etag": "0x8DE4992F894564C",
+      "checksum": "a64f2d65a7edb3383d1999da38517a59c3ba5bcabe2e6c1a272230bda16899b4"
     }
   },
   "0.9.116": {
@@ -393,6 +487,10 @@
     "aarch64_linux_gnu": {
       "etag": "0x8DE44DBACAB3643",
       "checksum": "f7ffe12e8859683a20b76738bc0f0352a24bbcd06ecfc40950f07ccceba96a27"
+    },
+    "aarch64_windows": {
+      "etag": "0x8DE44DD36F78DCE",
+      "checksum": "ebf7cb7446ff73d5a98d76ab19eaf2782021f830163c6c9322873ab6faab10a7"
     }
   },
   "0.9.115": {
@@ -416,6 +514,10 @@
     "aarch64_linux_gnu": {
       "etag": "0x8DE3B7608B3B857",
       "checksum": "731662a2ce5f4b8555581c1557739b50111a066dd77c150e79a18abd05ff09e9"
+    },
+    "aarch64_windows": {
+      "etag": "0x8DE3B76549CA4B8",
+      "checksum": "40e001f5262bd409c83cd9213feafbab0ec9e25194588fc00239034c4d7e4d7e"
     }
   },
   "0.9.114": {
@@ -439,6 +541,10 @@
     "aarch64_linux_gnu": {
       "etag": "0x8DE2712AB16728F",
       "checksum": "7de7f60700cc9d0397d1f909522270ce229ed752283ad59b2d413772d4b8409a"
+    },
+    "aarch64_windows": {
+      "etag": "0x8DE271399029A9F",
+      "checksum": "ac52cfbba5bd48a85a253e77ade2e38e8219811d894c4c1d31e3552037eb71eb"
     }
   },
   "0.9.113": {
@@ -462,6 +568,10 @@
     "aarch64_linux_gnu": {
       "etag": "0x8DE2558C81DD82B",
       "checksum": "f47787940e8ffaf37a5d9e0aa38005d756a03c31a14ce06871981b1cdc9fd75b"
+    },
+    "aarch64_windows": {
+      "etag": "0x8DE255973F56120",
+      "checksum": "d8961d8af3149164f4fe4c3519b255246333821a48c8eee8906e2b3cd150020b"
     }
   },
   "0.9.111": {
@@ -485,6 +595,10 @@
     "aarch64_linux_gnu": {
       "etag": "0x8DE1BD30B54E424",
       "checksum": "cfef84084184f9ee92e927102cfdca46580cdb4385c575f76296527ebf56304f"
+    },
+    "aarch64_windows": {
+      "etag": "0x8DE1BD44A24F66D",
+      "checksum": "c72ebe72e4c87da9845db43bdd4668a87df17e75821a7231275a5fd5afabd662"
     }
   },
   "0.9.110": {
@@ -508,6 +622,10 @@
     "aarch64_linux_gnu": {
       "etag": "0x8DE18C8A413A81E",
       "checksum": "5b2f9d09d093371c85f78402d8122879d30af07858ac66102b31a551139baad7"
+    },
+    "aarch64_windows": {
+      "etag": "0x8DE18CC2825E79E",
+      "checksum": "cd619991757fbc0a7075d0e1d98849c2eb47679ce0465250b76e1f9f16560896"
     }
   },
   "0.9.109": {
@@ -531,6 +649,10 @@
     "aarch64_linux_gnu": {
       "etag": "0x8DE174B3EF8B23B",
       "checksum": "87eed177e96a0eaec421acc9b80bfe8a310946a4af5257171c55889045a1e198"
+    },
+    "aarch64_windows": {
+      "etag": "0x8DE174B55BB78CC",
+      "checksum": "aa7a1ded47168b46ddfeffa2943c792ea8154d239442ee902a8cafd2c462336a"
     }
   },
   "0.9.108": {
@@ -554,6 +676,10 @@
     "aarch64_linux_gnu": {
       "etag": "0x8DE10E63CAEC447",
       "checksum": "0d34e2e4e28754e09ea07e32cad23f17a0d0cfecf3e5371c5c5466a22ce6d6f7"
+    },
+    "aarch64_windows": {
+      "etag": "0x8DE10E6C0FF72A2",
+      "checksum": "1dce55bdcb983d24f307f69eaed09f520e8109290827556380b3b4d278565376"
     }
   },
   "0.9.107": {
@@ -588,6 +714,10 @@
     "aarch64_linux_gnu": {
       "etag": "0x8DE0A8759CB559E",
       "checksum": "495653e78b690b21492daeebee86377fbab364cd1a52bdea9d3b412d42dfa707"
+    },
+    "aarch64_windows": {
+      "etag": "0x8DE0A876D81F634",
+      "checksum": "a715b31bb6c9c4a0fac191741a63ea64cb1d8df8c861917cf9421a41793f0ec6"
     }
   },
   "0.9.105": {
@@ -611,6 +741,10 @@
     "aarch64_linux_gnu": {
       "etag": "0x8DE01E75915A4AC",
       "checksum": "66e11bb9b53e84b0423b49274949bedce526826c5594427b82756a810956c368"
+    },
+    "aarch64_windows": {
+      "etag": "0x8DE01E959FB40F7",
+      "checksum": "fc1300d3ec69d690fac2b22234656f515f8bf01392896ec6aab95eb519fe419e"
     }
   },
   "0.9.104": {
@@ -634,6 +768,10 @@
     "aarch64_linux_gnu": {
       "etag": "0x8DDF3FB234AE773",
       "checksum": "91efa420f3a49c98be5559295e8eb48d6d7982a59e9a41851dae57d7ac16ac90"
+    },
+    "aarch64_windows": {
+      "etag": "0x8DDF3FB76A65504",
+      "checksum": "51f6d1b966850d0911e3ac98ad191267cf6cdc9a0100664996c33f20bbc44bb9"
     }
   },
   "0.9.103": {
@@ -657,6 +795,10 @@
     "aarch64_linux_gnu": {
       "etag": "0x8DDE371AF69BFF1",
       "checksum": "caf1cbf376a485a30795d08dad21f1d9d2baddc6c102d24b60432e7ae7d9d7a4"
+    },
+    "aarch64_windows": {
+      "etag": "0x8DDE37233E202D5",
+      "checksum": "ed0eeef585f0ae55c3f367272dcf99cb14dd1d8ed97c0703fbce7553b0902293"
     }
   },
   "0.9.102": {
@@ -680,6 +822,10 @@
     "aarch64_linux_gnu": {
       "etag": "0x8DDD2D0A6BDDCC3",
       "checksum": "f4124ab60b36bd558f8893dabd6024edd9d7e88deea7b3f54bb952295d6e256e"
+    },
+    "aarch64_windows": {
+      "etag": "0x8DDD2D19E7E3E10",
+      "checksum": "f3fcdfd56de3b5624020145584a4c2f9786965b3fa2d45d05b0033efbe1e700f"
     }
   },
   "0.9.101": {
@@ -703,6 +849,10 @@
     "aarch64_linux_gnu": {
       "etag": "0x8DDC0E2AFE0D97C",
       "checksum": "24ec2bafd6c4da1ce17d9821cca0ddf675eca482f193ec70e3b66eb2311e0c6b"
+    },
+    "aarch64_windows": {
+      "etag": "0x8DDC0E2E3CA0B22",
+      "checksum": "215090faca78b3c7ed429b5ea7ca1ef4718d03ab26c8b54bbc2f79872916bf8e"
     }
   },
   "0.9.100": {
@@ -726,6 +876,10 @@
     "aarch64_linux_gnu": {
       "etag": "0x8DDBD8BAD51169A",
       "checksum": "53c2e65b61a3736304b3784f1300aaef61fc1538e0b36b7bc7461d4a1c690556"
+    },
+    "aarch64_windows": {
+      "etag": "0x8DDBD8CC1B33F51",
+      "checksum": "a1f82302e0b778737393ad53a43125fc22f198b04f511078ac538773ce334412"
     }
   },
   "0.9.99": {
@@ -749,6 +903,10 @@
     "aarch64_linux_gnu": {
       "etag": "0x8DDAD1AFEB67D5C",
       "checksum": "2097164de24b364c9a518fb583bcc822577d29fa0083168126d0c9c3684e149f"
+    },
+    "aarch64_windows": {
+      "etag": "0x8DDAD1B0B64639B",
+      "checksum": "344748675f7c660c145ee19da3d6d8a24dba3a237e33edcb5749efb0a0144684"
     }
   },
   "0.9.98": {
@@ -772,6 +930,10 @@
     "aarch64_linux_gnu": {
       "etag": "0x8DDA538BE7B7B38",
       "checksum": "207adaa39756808aa9a719eb3e9002a710510c320da80b7f76bc373e3fadec4a"
+    },
+    "aarch64_windows": {
+      "etag": "0x8DDA539D2BC97D3",
+      "checksum": "063efd34ca18ed08abcdac408ffb0d83c5fd2f5fbb8c665ed50355f88f040539"
     }
   },
   "0.9.97": {
@@ -795,6 +957,10 @@
     "aarch64_linux_gnu": {
       "etag": "0x8DD9F331447466C",
       "checksum": "6dce638cb68b614a0c5a098531606b83bba221146592faafd246f79292a47cc7"
+    },
+    "aarch64_windows": {
+      "etag": "0x8DD9F332E7DE59F",
+      "checksum": "f53caa76df850579f453e40a73f0bed38db583c2e396ff752abce8e70107be29"
     }
   },
   "0.9.96": {
@@ -818,6 +984,10 @@
     "aarch64_linux_gnu": {
       "etag": "0x8DD93EFC692BAE4",
       "checksum": "bb5fc72c135d8f1a1613538613e2e25bed64b2c0f378a559eaa15fe94af89311"
+    },
+    "aarch64_windows": {
+      "etag": "0x8DD93EFDE4A85A2",
+      "checksum": "6f478f9202cd5ed2b5de12b6dff017404778b7669115a3692427e90960bdf20a"
     }
   },
   "0.9.95": {
@@ -841,6 +1011,10 @@
     "aarch64_linux_gnu": {
       "etag": "0x8DD883CCCAB87FD",
       "checksum": "1022bbb91403ada1d516ce2e3e2738f61e1cd22e1fe797200dd23a4b5b7eba6e"
+    },
+    "aarch64_windows": {
+      "etag": "0x8DD883D4376024F",
+      "checksum": "0e5fc499b460c2eadf8bdce2dae7b8149ba04dd84e4adb9bb89c81ec7fc8e801"
     }
   },
   "0.9.94": {
@@ -864,6 +1038,10 @@
     "aarch64_linux_gnu": {
       "etag": "0x8DD786D936575B7",
       "checksum": "04fc236be7b6f31bc89af76a95cd6a28b81279b83eaa04644b0b1f4667c85cd7"
+    },
+    "aarch64_windows": {
+      "etag": "0x8DD786DC297E87A",
+      "checksum": "d834d1bb62352151831cd355bfbfabb47ffdec1c3743cf9dd0377843fa65de9c"
     }
   },
   "0.9.93": {

--- a/manifests/coreutils.json
+++ b/manifests/coreutils.json
@@ -41,6 +41,12 @@
       "etag": "0x8DE7DA02369BEFA",
       "checksum": "372323492402f3249876599f1ff99aad9bd2aecaa217b1cb146608ef58d3ed4b",
       "bin": "coreutils-0.7.0-aarch64-pc-windows-msvc/coreutils.exe"
+    },
+    "riscv64_linux_musl": {
+      "url": "https://github.com/uutils/coreutils/releases/download/0.7.0/coreutils-0.7.0-riscv64gc-unknown-linux-musl.tar.gz",
+      "etag": "0x8DE7DA02D98FC34",
+      "checksum": "472be17cbe0b69b4c328c3c3e37d889f3792fb37a642603ac94b3c99a9cfae0e",
+      "bin": "coreutils-0.7.0-riscv64gc-unknown-linux-musl/coreutils"
     }
   },
   "0.6": {
@@ -82,6 +88,12 @@
       "etag": "0x8DE62481C536BB1",
       "checksum": "7183bd5aff648b76517182e50d94819efdaede637650f5b9ad9117c171c4eebf",
       "bin": "coreutils-aarch64-pc-windows-msvc/coreutils.exe"
+    },
+    "riscv64_linux_musl": {
+      "url": "https://github.com/uutils/coreutils/releases/download/0.6.0/coreutils-0.6.0-riscv64gc-unknown-linux-musl.tar.gz",
+      "etag": "0x8DE6247C8CECA39",
+      "checksum": "0deaa2ccf9c41f2f727e6715c40c433dc7ad4cd024cfc497d4d67e4020635be9",
+      "bin": "coreutils-0.6.0-riscv64gc-unknown-linux-musl/coreutils"
     }
   },
   "0.5": {

--- a/manifests/dprint.json
+++ b/manifests/dprint.json
@@ -21,6 +21,9 @@
     },
     "aarch64_macos": {
       "url": "https://github.com/dprint/dprint/releases/download/${version}/dprint-aarch64-apple-darwin.zip"
+    },
+    "riscv64_linux_gnu": {
+      "url": "https://github.com/dprint/dprint/releases/download/${version}/dprint-riscv64gc-unknown-linux-gnu.zip"
     }
   },
   "license_markdown": "[MIT](https://github.com/dprint/dprint/blob/main/LICENSE)",
@@ -50,6 +53,10 @@
     "aarch64_macos": {
       "etag": "0x8DE82F1B95C3423",
       "checksum": "1906f3292dab7d333afbbb15b2e05a29f080f5cf91746ca6c73ee843da298d82"
+    },
+    "riscv64_linux_gnu": {
+      "etag": "0x8DE82F1B968A933",
+      "checksum": "936b493204e47d25b820d3f91daa8ea2a2ec0fdebe93d69fc5dd4ca011c4deed"
     }
   },
   "0.52": {
@@ -75,6 +82,10 @@
     "aarch64_macos": {
       "etag": "0x8DE73D41594E259",
       "checksum": "bb3a5be1444fcfaf2f405cbf8af7da809d055705a2ca17bd2e7edff6f2959354"
+    },
+    "riscv64_linux_gnu": {
+      "etag": "0x8DE73D415A87B66",
+      "checksum": "5806e6f16799d32484134281c60cdfdd335cc9f5d37bfaa6a413e811504844b1"
     }
   },
   "0.51": {
@@ -100,6 +111,10 @@
     "aarch64_macos": {
       "etag": "0x8DE46550DA130BC",
       "checksum": "cc1321a524d8e1312d376ce2c51343f43f8f5489c2e265f11aea5a6af4de52ad"
+    },
+    "riscv64_linux_gnu": {
+      "etag": "0x8DE46550DA806DD",
+      "checksum": "35cf03b5c8f3e0218f78f9351463e035c411b2c3743a911e3d103613a4e282f8"
     }
   },
   "0.51.0": {
@@ -122,6 +137,10 @@
     "aarch64_macos": {
       "etag": "0x8DE45B158E61664",
       "checksum": "f3fb85da6b10011835f3b5a14faf11d03594b4b3b32602ae2b45418794c5039b"
+    },
+    "riscv64_linux_gnu": {
+      "etag": "0x8DE45B158F10696",
+      "checksum": "5d20460a263e858bd28b61be2ddec12277863c8f29ddc4591c18105ec3d2ab0c"
     }
   },
   "0.50": {
@@ -147,6 +166,10 @@
     "aarch64_macos": {
       "etag": "0x8DDF3116397FAD4",
       "checksum": "f534bcc054947ab2a42c069b5f6027914d252729bd15c1109812313b35a662a5"
+    },
+    "riscv64_linux_gnu": {
+      "etag": "0x8DDF311638BACA1",
+      "checksum": "6918c45b0070da1da137fa328c7ca82133c6ab0b49a651fa53513305611fe3a8"
     }
   },
   "0.50.1": {
@@ -169,6 +192,10 @@
     "aarch64_macos": {
       "etag": "0x8DDB82271DB6D99",
       "checksum": "c92e1a8dddd9bc65391468265b2805cb2317e4490fd777bca2dfaf1ef716ac36"
+    },
+    "riscv64_linux_gnu": {
+      "etag": "0x8DDB82271E26A9E",
+      "checksum": "841120bd28f9d3afdd89bab65a2cb676877c808a460507f1567d97604a111b61"
     }
   },
   "0.50.0": {
@@ -191,6 +218,10 @@
     "aarch64_macos": {
       "etag": "0x8DD965DE76DBF13",
       "checksum": "b6a25e1dff9ea8d9e023548c0ec80fcde5d425e48fab60028fc0003fddf2debb"
+    },
+    "riscv64_linux_gnu": {
+      "etag": "0x8DD965DE770A205",
+      "checksum": "29cac7205ddfc5d94cc1c89f7935e7ec41572e4fe921725c7e2a0a391d0740d5"
     }
   },
   "0.49": {
@@ -216,6 +247,10 @@
     "aarch64_macos": {
       "etag": "0x8DD6634A4F57D78",
       "checksum": "e8d0da82dd56ea629519e250ad54f084c4a0a1c42cfc4680d73d9f31be21c849"
+    },
+    "riscv64_linux_gnu": {
+      "etag": "0x8DD6634A50F2A26",
+      "checksum": "60ba95d4335d09f72a280e77985b5d2719654dbffb0922a9dd5f58a8110c3831"
     }
   },
   "0.49.0": {
@@ -238,6 +273,10 @@
     "aarch64_macos": {
       "etag": "0x8DD4320D520B868",
       "checksum": "6772b452179a7142710860a8da8d8ec112b84c1b4dd5a7e4458c759c44b76751"
+    },
+    "riscv64_linux_gnu": {
+      "etag": "0x8DD4320D513CE9D",
+      "checksum": "71b941ae78f9a83ace40a2c5a88f4d8fb49881f32c75144fb67d685e2001b1ad"
     }
   },
   "0.48": {
@@ -263,6 +302,10 @@
     "aarch64_macos": {
       "etag": "0x8DD22149A9C71B2",
       "checksum": "31efaf7d6fbdbb53188c457105e894d08b0c43eb02878abae778edaedd0a5c70"
+    },
+    "riscv64_linux_gnu": {
+      "etag": "0x8DD22149AAD9C78",
+      "checksum": "a72959d94a520ebb728eec3e8d318e4181108fe910c7df2a7e2292d9351cde35"
     }
   },
   "0.47": {
@@ -288,6 +331,10 @@
     "aarch64_macos": {
       "etag": "0x8DD1261B07FD733",
       "checksum": "4f33c24141a19638ab045fe5e95654ff0ef8db29949e145d28ea3cc5b088a042"
+    },
+    "riscv64_linux_gnu": {
+      "etag": "0x8DD1261B0899042",
+      "checksum": "c335c3aff2812ca1f640af10f13a2d94cc6d414814dc8038e7412aacc3065ea0"
     }
   },
   "0.47.5": {

--- a/manifests/knope.json
+++ b/manifests/knope.json
@@ -27,6 +27,12 @@
       "checksum": "2ea29e6c9cd81f0f50c241ac26eb518b77d16202f87878d0aa3e6065f97526c0",
       "bin": "knope-x86_64-pc-windows-msvc/knope.exe"
     },
+    "aarch64_linux_musl": {
+      "url": "https://github.com/knope-dev/knope/releases/download/knope/v0.22.3/knope-aarch64-unknown-linux-musl.tgz",
+      "etag": "0x8DE6D9C83216C20",
+      "checksum": "5ffbc14453a383f241c2ce8214f4c02769a3376f3c61a89552d42fd10a1bd41b",
+      "bin": "knope-aarch64-unknown-linux-musl/knope"
+    },
     "aarch64_macos": {
       "url": "https://github.com/knope-dev/knope/releases/download/knope/v0.22.3/knope-aarch64-apple-darwin.tgz",
       "etag": "0x8DE6D9C831DED94",

--- a/manifests/sccache.json
+++ b/manifests/sccache.json
@@ -24,6 +24,14 @@
     "aarch64_windows": {
       "url": "https://github.com/mozilla/sccache/releases/download/v${version}/sccache-v${version}-aarch64-pc-windows-msvc.tar.gz",
       "bin": "sccache-v${version}-aarch64-pc-windows-msvc/sccache.exe"
+    },
+    "riscv64_linux_musl": {
+      "url": "https://github.com/mozilla/sccache/releases/download/v${version}/sccache-v${version}-riscv64gc-unknown-linux-musl.tar.gz",
+      "bin": "sccache-v${version}-riscv64gc-unknown-linux-musl/sccache"
+    },
+    "s390x_linux_musl": {
+      "url": "https://github.com/mozilla/sccache/releases/download/v${version}/sccache-v${version}-s390x-unknown-linux-musl.tar.gz",
+      "bin": "sccache-v${version}-s390x-unknown-linux-musl/sccache"
     }
   },
   "license_markdown": "[Apache-2.0](https://github.com/mozilla/sccache/blob/main/LICENSE)",
@@ -57,6 +65,14 @@
     "aarch64_windows": {
       "etag": "0x8DE67ED6470B953",
       "checksum": "b416e81f946c607467c5383022842649569d73f468a8e42b4536998e3d784224"
+    },
+    "riscv64_linux_musl": {
+      "etag": "0x8DE67ED680C3E95",
+      "checksum": "a441c38cc6f316d86977082aaabe981aa0198fc3ab120459d9b2e76d8ff0243f"
+    },
+    "s390x_linux_musl": {
+      "etag": "0x8DE67ED69D8DD8A",
+      "checksum": "024a407ade66a39d04aaa1e55dcd5273bec093633ceb592af8e405128f80a6f4"
     }
   },
   "0.13": {
@@ -82,6 +98,14 @@
     "aarch64_windows": {
       "etag": "0x8DE52D745FEE398",
       "checksum": "a57ad29859610baedaa92683d342272424d6a43fda8a3295ee36c23030ecffd5"
+    },
+    "riscv64_linux_musl": {
+      "etag": "0x8DE52D749B8560B",
+      "checksum": "0194bd7ad66fcd77486370f62069336d44a2f08c61a8c8042cdf706f887ce413"
+    },
+    "s390x_linux_musl": {
+      "etag": "0x8DE52D74AB6CD28",
+      "checksum": "1bcb3333a762ce6870f7a0cec371d767990773fc9dfb1c1ee35e6996b22af3af"
     }
   },
   "0.12": {
@@ -111,6 +135,10 @@
     "aarch64_windows": {
       "etag": "0x8DE1028E6EF8402",
       "checksum": "5d99dfc3552907596de7e912432e49fd627eef0fb63b27b777c21db135bb1795"
+    },
+    "s390x_linux_musl": {
+      "etag": "0x8DE1028EA578862",
+      "checksum": "1df0c557e5a0e193a208d6c07af569fe79f09ed0c640e76057b91bf548bce704"
     }
   },
   "0.11": {
@@ -140,6 +168,10 @@
     "aarch64_windows": {
       "etag": "0x8DE0830F547F1AC",
       "checksum": "b3f6552a5ceefe4073e7a0cfc4f0b8dd514f5ae75988240637950c1d0450a747"
+    },
+    "s390x_linux_musl": {
+      "etag": "0x8DE0830F82B0916",
+      "checksum": "ef4fc6266e342fd7b9b576006a140a9e92be4ab6645b8fe4d972c5458fbb502f"
     }
   },
   "0.10": {

--- a/manifests/syft.json
+++ b/manifests/syft.json
@@ -21,6 +21,10 @@
       "url": "https://github.com/anchore/syft/releases/download/v${version}/syft_${version}_darwin_arm64.tar.gz",
       "bin": "syft"
     },
+    "aarch64_windows": {
+      "url": "https://github.com/anchore/syft/releases/download/v${version}/syft_${version}_windows_arm64.zip",
+      "bin": "syft.exe"
+    },
     "powerpc64le_linux_musl": {
       "url": "https://github.com/anchore/syft/releases/download/v${version}/syft_${version}_linux_ppc64le.tar.gz",
       "bin": "syft"
@@ -61,6 +65,10 @@
       "etag": "0x8DE7E0A7D4B9975",
       "checksum": "19c84dbb93207e51f3be4d74f4924a5dcb796d5aa00067ba4df0a92c54d72a38"
     },
+    "aarch64_windows": {
+      "etag": "0x8DE7E0A7DDB9E99",
+      "checksum": "bd0eddfaebb90528bbf37a7ceb660c87882fa7f7970634f5654cc2a4c5f8f582"
+    },
     "powerpc64le_linux_musl": {
       "etag": "0x8DE7E0A7D4BE736",
       "checksum": "14d2376273c92e140bff1a42bdf0ca4bfa4c430346808c1d0cd1e0a65c8443b9"
@@ -91,6 +99,10 @@
       "etag": "0x8DE6F163CEF4A53",
       "checksum": "b83cdcbd1b4c55505abd359c25c5903d94b99be47e6f98572bf96927b7b47e45"
     },
+    "aarch64_windows": {
+      "etag": "0x8DE6F163C5C6239",
+      "checksum": "8591d852e5ad2e5a78c0f009fcd15ca699ea1763d1f24d623035c557ba2be180"
+    },
     "powerpc64le_linux_musl": {
       "etag": "0x8DE6F163C83E205",
       "checksum": "04de86e1c31fc745d4f107f2c7f24806d6752887be2b264102ed0ac4b6e712c4"
@@ -120,6 +132,10 @@
     "aarch64_macos": {
       "etag": "0x8DE68CB5E70BAAB",
       "checksum": "eb5faccd882a1d45fb25a07848bef652e27ff141bc656dca83a250211c2036fc"
+    },
+    "aarch64_windows": {
+      "etag": "0x8DE68CB5E798A5E",
+      "checksum": "eac179f7e27cb3d0e4c897ad62603d54e08955fecc40fb349eb12a21553d7114"
     },
     "powerpc64le_linux_musl": {
       "etag": "0x8DE68CB5DCFB1BD",
@@ -154,6 +170,10 @@
       "etag": "0x8DE634FFC5CAA85",
       "checksum": "8047c772a7b901cc0864fe5c8aee8fd6ec56e70b796706c3150a50334eea26f0"
     },
+    "aarch64_windows": {
+      "etag": "0x8DE634FFC3503D3",
+      "checksum": "3977b77a9d09859d4dd9f3f991febf27f07f7926475a317b89c3b3d7928ffa2c"
+    },
     "powerpc64le_linux_musl": {
       "etag": "0x8DE634FFC1C676B",
       "checksum": "8297c3224d86c7aa5518c52f4b096c4ce135f3fade849fdb0ae6aacc6ce51bb7"
@@ -184,6 +204,10 @@
       "etag": "0x8DE5F799950D21F",
       "checksum": "2ef0308f238b5c762213774a81d1df5b132c78e3c33d5651e037cbe96dadcd16"
     },
+    "aarch64_windows": {
+      "etag": "0x8DE5F7999520941",
+      "checksum": "aa4952a90c5b02524a38cc9a0c57d49fc550e4352528282cb58a90264613fe20"
+    },
     "powerpc64le_linux_musl": {
       "etag": "0x8DE5F7999184E5B",
       "checksum": "b7a6be13a74d141d1d2702572adbebbb31f1dd2b82fa80b751e69316f4da6b4b"
@@ -213,6 +237,10 @@
     "aarch64_macos": {
       "etag": "0x8DE5D9450CC435D",
       "checksum": "ba3de65344e279adfe77948365c0ca4c523b51647b9017dd6ea5d66fa772219f"
+    },
+    "aarch64_windows": {
+      "etag": "0x8DE5D9450D38E2B",
+      "checksum": "9c5345bb1fd747d74fd934dd2c4bf1807a75dbefc851ef23aae69410cdb4e59e"
     },
     "powerpc64le_linux_musl": {
       "etag": "0x8DE5D9450CB59FB",
@@ -247,6 +275,10 @@
       "etag": "0x8DE5480286D6043",
       "checksum": "c0f6a4fc0563ef1dfe1acf9a4518db66cb37bbb1391889aba3be773dff3487dd"
     },
+    "aarch64_windows": {
+      "etag": "0x8DE5480281CDBBF",
+      "checksum": "e9a6c27b9b99f858840d7247595994b2859c5d9e87d27c20e32e7764df17a629"
+    },
     "powerpc64le_linux_musl": {
       "etag": "0x8DE548028451E07",
       "checksum": "33c56bdbef44a97abc2b49c4d40dc25d8f2053a9fc699796e8e93047f93e0b1c"
@@ -276,6 +308,10 @@
     "aarch64_macos": {
       "etag": "0x8DE4EB46B98766C",
       "checksum": "c7d6dc1bb17bddd90b1976b289c82b4c6a58b2cc01f4862e72c76982bc306e81"
+    },
+    "aarch64_windows": {
+      "etag": "0x8DE4EB46B74C2DD",
+      "checksum": "ce7129dbcc39809542c9bc5032b179131dfee72c68c5b3741e3270a3d9ed46e4"
     },
     "powerpc64le_linux_musl": {
       "etag": "0x8DE4EB46B43154C",
@@ -310,6 +346,10 @@
       "etag": "0x8DE419F300AA115",
       "checksum": "fe99f5d9d76c48752a53c3e5f3d4044652623daa623c0da4b1b501bf4fc6cde2"
     },
+    "aarch64_windows": {
+      "etag": "0x8DE419F303B3E5A",
+      "checksum": "eeab6648e552694672beed9ca8e9102413ca3d603a53dc7642a9406b1c3c9c7f"
+    },
     "powerpc64le_linux_musl": {
       "etag": "0x8DE419F2F3334FF",
       "checksum": "44954a1b23d83e37206c34bca6a0c72aebb5e3d0f883c9f2b51589563fce4bad"
@@ -343,6 +383,10 @@
       "etag": "0x8DE376E9E9AB756",
       "checksum": "3b53cdff2a1c66792329d91a914276e98efbe548901978fe42b991efc5df90cf"
     },
+    "aarch64_windows": {
+      "etag": "0x8DE376E9EC3BC09",
+      "checksum": "923120e16913d0f35d62ba628eefce1b4c3c25ea81dab3ee32ea3b87c1994e5e"
+    },
     "powerpc64le_linux_musl": {
       "etag": "0x8DE376E9DC04131",
       "checksum": "b03259cb24ece0e935bc63afd0e211edd3739ac3764dd11b80a85b68375bfa86"
@@ -372,6 +416,10 @@
     "aarch64_macos": {
       "etag": "0x8DE260288C75914",
       "checksum": "e2a02cf6786e420d8fa7d7907dac86f59ecc011c014b08ef521e8ed4f4ed2cda"
+    },
+    "aarch64_windows": {
+      "etag": "0x8DE260288FE7EB0",
+      "checksum": "6e26ab0b3085c8e94b9ba61964130ab00b0aba24ec437f067a2d5207a61a0dc5"
     },
     "powerpc64le_linux_musl": {
       "etag": "0x8DE260287FFE094",
@@ -406,6 +454,10 @@
       "etag": "0x8DE1B0687DD9059",
       "checksum": "b676cb2e112fcf5ec25638cca129f5de92f4786a6c4628cd3c307992f1a6a50d"
     },
+    "aarch64_windows": {
+      "etag": "0x8DE1B0687E4B439",
+      "checksum": "2f676e3ddc209b9a24610ff23b69402181e9d96f62fd60e54e8b489a01dbf993"
+    },
     "powerpc64le_linux_musl": {
       "etag": "0x8DE1B0686F4F95C",
       "checksum": "d1ca6ceaa20a63f7c4a7c344a17d88412cf951b3085b826d6b64b352cb5ed6d8"
@@ -438,6 +490,10 @@
     "aarch64_macos": {
       "etag": "0x8DE11A88B671B6D",
       "checksum": "49d1af3f041cfaf4a3c53d4e27e42ac589efeb9e96e515a8da2d438222afa2eb"
+    },
+    "aarch64_windows": {
+      "etag": "0x8DE11A88BBD8CD1",
+      "checksum": "496263f3e4e5f07435daf60250664ad7943beed282e6eb8af29a2f12bc1fde91"
     },
     "powerpc64le_linux_musl": {
       "etag": "0x8DE11A88ACEE1E1",
@@ -472,6 +528,10 @@
       "etag": "0x8DE0CB02213100C",
       "checksum": "17285aa74e1d698def8babc2dcab0f1b284113b77de6f56cf0b1123861e71b9c"
     },
+    "aarch64_windows": {
+      "etag": "0x8DE0CB022172A26",
+      "checksum": "f49c8cd8bf7d55692bed6d3ccd7a97f9a653d4b56e04d7cf92abae103ea4d7e2"
+    },
     "powerpc64le_linux_musl": {
       "etag": "0x8DE0CB02110A566",
       "checksum": "3a01cd8afcf0585cfae4e204d55895e1acfb93d07741837d873400862a009ca5"
@@ -501,6 +561,10 @@
     "aarch64_macos": {
       "etag": "0x8DE0C0188135AE2",
       "checksum": "a3d962d19bc206d9990b29311cfcd18572cf9be849748860c1f485397b3426c6"
+    },
+    "aarch64_windows": {
+      "etag": "0x8DE0C018861236D",
+      "checksum": "3ef6132a5f8ef04ab4a2673d91bc505d5e4701dc11d818671443e615df41d506"
     },
     "powerpc64le_linux_musl": {
       "etag": "0x8DE0C018743603A",

--- a/manifests/taplo.json
+++ b/manifests/taplo.json
@@ -21,6 +21,10 @@
       "url": "https://github.com/tamasfe/taplo/releases/download/${version}/taplo-darwin-aarch64.gz",
       "bin": "taplo"
     },
+    "aarch64_windows": {
+      "url": "https://github.com/tamasfe/taplo/releases/download/${version}/taplo-windows-aarch64.zip",
+      "bin": "taplo.exe"
+    },
     "riscv64_linux_gnu": {
       "url": "https://github.com/tamasfe/taplo/releases/download/${version}/taplo-linux-riscv64.gz",
       "bin": "taplo"
@@ -53,6 +57,10 @@
     "aarch64_macos": {
       "etag": "0x8DD99AB3700C1B5",
       "checksum": "713734314c3e71894b9e77513c5349835eefbd52908445a0d73b0c7dc469347d"
+    },
+    "aarch64_windows": {
+      "etag": "0x8DD99AB212032A1",
+      "checksum": "65a50c5d3b78f6014e6bc6d64eb6dc1d4992bc236589c9bb29e5609fc3454674"
     },
     "riscv64_linux_gnu": {
       "etag": "0x8DD99AAB4AAB107",

--- a/manifests/wasm-pack.json
+++ b/manifests/wasm-pack.json
@@ -16,6 +16,10 @@
     "aarch64_linux_musl": {
       "url": "https://github.com/drager/wasm-pack/releases/download/v${version}/wasm-pack-v${version}-aarch64-unknown-linux-musl.tar.gz",
       "bin": "wasm-pack-v${version}-aarch64-unknown-linux-musl/wasm-pack"
+    },
+    "aarch64_macos": {
+      "url": "https://github.com/drager/wasm-pack/releases/download/v${version}/wasm-pack-v${version}-aarch64-apple-darwin.tar.gz",
+      "bin": "wasm-pack-v${version}-aarch64-apple-darwin/wasm-pack"
     }
   },
   "license_markdown": "[MIT](https://github.com/drager/wasm-pack/blob/master/LICENSE-MIT) OR [Apache-2.0](https://github.com/drager/wasm-pack/blob/master/LICENSE-APACHE)",
@@ -41,6 +45,10 @@
     "aarch64_linux_musl": {
       "etag": "0x8DE580F1BE0E3B5",
       "checksum": "5941c7b05060440ff37ee50fe9009a408e63fa5ba607a3b0736f5a887ec5f2ca"
+    },
+    "aarch64_macos": {
+      "etag": "0x8DE580F1E459530",
+      "checksum": "9d0e70c6b229de18f0abfe910f2963e8f09ebae218250e9b09a1c3fdd955bef9"
     }
   },
   "0.13": {

--- a/tools/codegen/base/cargo-audit.json
+++ b/tools/codegen/base/cargo-audit.json
@@ -12,6 +12,7 @@
     "x86_64_windows": {
       "asset_name": "${package}-${rust_target}-v${version}.zip"
     },
-    "aarch64_linux_gnu": {}
+    "aarch64_linux_gnu": {},
+    "aarch64_macos": {}
   }
 }

--- a/tools/codegen/base/cargo-auditable.json
+++ b/tools/codegen/base/cargo-auditable.json
@@ -12,6 +12,11 @@
       "asset_name": "${package}-${rust_target}.zip",
       "bin": "${package}${exe}"
     },
-    "aarch64_macos": {}
+    "aarch64_linux_gnu": {},
+    "aarch64_macos": {},
+    "aarch64_windows": {
+      "asset_name": "${package}-${rust_target}.zip",
+      "bin": "${package}${exe}"
+    }
   }
 }

--- a/tools/codegen/base/cargo-cyclonedx.json
+++ b/tools/codegen/base/cargo-cyclonedx.json
@@ -24,6 +24,9 @@
       ],
       "bin": "${package}${exe}"
     },
+    "aarch64_linux_gnu": {
+      "asset_name": "${package}-${rust_target}.tar.xz"
+    },
     "aarch64_macos": {
       "asset_name": "${package}-${rust_target}.tar.xz"
     }

--- a/tools/codegen/base/cargo-insta.json
+++ b/tools/codegen/base/cargo-insta.json
@@ -9,10 +9,10 @@
   "platform": {
     "x86_64_linux_musl": {},
     "x86_64_macos": {},
-    "aarch64_macos": {},
     "x86_64_windows": {
       "asset_name": "${package}-${rust_target}.zip",
       "bin": "${package}.exe"
-    }
+    },
+    "aarch64_macos": {}
   }
 }

--- a/tools/codegen/base/cargo-machete.json
+++ b/tools/codegen/base/cargo-machete.json
@@ -8,6 +8,7 @@
     "x86_64_linux_musl": {},
     "x86_64_macos": {},
     "x86_64_windows": {},
+    "aarch64_linux_gnu": {},
     "aarch64_macos": {}
   }
 }

--- a/tools/codegen/base/cargo-nextest.json
+++ b/tools/codegen/base/cargo-nextest.json
@@ -13,6 +13,8 @@
     },
     "x86_64_windows": {},
     "aarch64_linux_gnu": {},
+    "aarch64_linux_musl": {},
+    "aarch64_windows": {},
     "riscv64_linux_gnu": {}
   }
 }

--- a/tools/codegen/base/coreutils.json
+++ b/tools/codegen/base/coreutils.json
@@ -16,6 +16,7 @@
     "aarch64_macos": {},
     "aarch64_windows": {
       "asset_name": "${package}-${version}-${rust_target}.zip"
-    }
+    },
+    "riscv64_linux_musl": {}
   }
 }

--- a/tools/codegen/base/dprint.json
+++ b/tools/codegen/base/dprint.json
@@ -10,6 +10,7 @@
     "x86_64_windows": {},
     "aarch64_linux_gnu": {},
     "aarch64_linux_musl": {},
-    "aarch64_macos": {}
+    "aarch64_macos": {},
+    "riscv64_linux_gnu": {}
   }
 }

--- a/tools/codegen/base/knope.json
+++ b/tools/codegen/base/knope.json
@@ -9,6 +9,7 @@
     "x86_64_linux_musl": {},
     "x86_64_macos": {},
     "x86_64_windows": {},
+    "aarch64_linux_musl": {},
     "aarch64_macos": {}
   }
 }

--- a/tools/codegen/base/sccache.json
+++ b/tools/codegen/base/sccache.json
@@ -10,6 +10,8 @@
     "x86_64_windows": {},
     "aarch64_linux_musl": {},
     "aarch64_macos": {},
-    "aarch64_windows": {}
+    "aarch64_windows": {},
+    "riscv64_linux_musl": {},
+    "s390x_linux_musl": {}
   }
 }

--- a/tools/codegen/base/syft.json
+++ b/tools/codegen/base/syft.json
@@ -19,6 +19,9 @@
     "aarch64_macos": {
       "asset_name": "${package}_${version}_darwin_arm64.tar.gz"
     },
+    "aarch64_windows": {
+      "asset_name": "${package}_${version}_windows_arm64.zip"
+    },
     "powerpc64le_linux_musl": {
       "asset_name": "${package}_${version}_linux_ppc64le.tar.gz"
     },

--- a/tools/codegen/base/taplo.json
+++ b/tools/codegen/base/taplo.json
@@ -17,6 +17,9 @@
     "aarch64_macos": {
       "asset_name": "${package}-darwin-${rust_target_arch}.gz"
     },
+    "aarch64_windows": {
+      "asset_name": "${package}-${rust_target_os}-${rust_target_arch}.zip"
+    },
     "riscv64_linux_gnu": {}
   }
 }

--- a/tools/codegen/base/wasm-pack.json
+++ b/tools/codegen/base/wasm-pack.json
@@ -8,6 +8,7 @@
     "x86_64_linux_musl": {},
     "x86_64_macos": {},
     "x86_64_windows": {},
-    "aarch64_linux_musl": {}
+    "aarch64_linux_musl": {},
+    "aarch64_macos": {}
   }
 }

--- a/tools/manifest-schema/src/lib.rs
+++ b/tools/manifest-schema/src/lib.rs
@@ -346,9 +346,8 @@ impl StringOrArray {
     }
 }
 
-/// GitHub Actions Runner supports x86_64/AArch64/Arm Linux, x86_64/AArch64 Windows,
-/// and x86_64/AArch64 macOS.
-/// <https://github.com/actions/runner/blob/v2.321.0/.github/workflows/build.yml#L21>
+/// GitHub Actions runner supports x86_64/AArch64/Arm Linux and x86_64/AArch64 Windows/macOS.
+/// <https://github.com/actions/runner/blob/v2.332.0/.github/workflows/build.yml#L24>
 /// <https://docs.github.com/en/actions/reference/runners/self-hosted-runners#supported-processor-architectures>
 /// And IBM provides runners for powerpc64le/s390x Linux.
 /// <https://github.com/IBM/actionspz>
@@ -359,13 +358,15 @@ impl StringOrArray {
 ///   (rustc enables statically linking for linux-musl by default, except for mips.)
 /// - Binaries compiled for x86_64 macOS will usually also work on AArch64 macOS.
 /// - Binaries compiled for x86_64 Windows will usually also work on AArch64 Windows 11+.
-/// - Ignore Arm for now, as we need to consider the version and whether hard-float is supported.
+/// - Ignore 32-bit Arm for now, as we need to consider the version and whether hard-float is supported.
 ///   <https://github.com/rust-lang/rustup/pull/593>
 ///   <https://github.com/cross-rs/cross/pull/1018>
+///   And support for 32-bit Arm will be removed in near future.
+///   <https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/#removal-of-operating-system-support-with-node24>
 ///   Does it seem only armv7l+ is supported?
 ///   <https://github.com/actions/runner/blob/v2.321.0/src/Misc/externals.sh#L178>
 ///   <https://github.com/actions/runner/issues/688>
-// TODO: support musl with dynamic linking like wasmtime 22.0.0+'s musl binaries: <https://github.com/bytecodealliance/wasmtime/releases/tag/v22.0.0>
+// TODO: support musl with dynamic linking like wasmtime and cyclonedx's musl binaries.
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum HostPlatform {


### PR DESCRIPTION
Changes:

- Support `cargo-auditable`, `cargo-cyclonedx`, `cargo-machete`, and `knope` on AArch64 Linux.

- Support `cargo-nextest` on AArch64 Linux (musl).

- Support `coreutils`, `dprint`, and `sccache` on riscv64 Linux.

- Support `sccache` on s390x Linux.

- Support installing native binary for `cargo-audit` and `wasm-pack` on AArch64 macOS. (Previously x86_64 macOS binary is used as fallback.)

- Support installing native binary for `cargo-auditable`, `cargo-nextest`, `syft`, and `taplo` on AArch64 Windows. (Previously x86_64 Windows binary is used as fallback.)