### PR TITLE
Install both uv, uvw, and uvx binaries when installing uv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Install `uv`, `uvw` (Windows-only), and `uvx` binaries when installing `uv`. Previously, only `uv` binary was installed. ([#1632](https://github.com/taiki-e/install-action/pull/1632))
+
 ## [2.69.14] - 2026-03-28
 
 - Update `just@latest` to 1.48.1.

--- a/main.sh
+++ b/main.sh
@@ -179,7 +179,7 @@ download_and_extract() {
     else
       case "${url}" in
         *.zip)
-          unzip -q tmp "${bin_in_archive#\./}"
+          unzip -q tmp
           for tmp in "${bin_in_archive[@]}"; do
             case "${tool}" in
               editorconfig-checker) mv -- "${tmp}" "${bin_dir}/${tool}${exe}" ;;

--- a/manifests/uv.json
+++ b/manifests/uv.json
@@ -1,41 +1,70 @@
 {
-  "rust_crate": null,
+  "rust_crate": "uv",
   "template": {
     "x86_64_linux_musl": {
       "url": "https://github.com/astral-sh/uv/releases/download/${version}/uv-x86_64-unknown-linux-musl.tar.gz",
-      "bin": "uv-x86_64-unknown-linux-musl/uv"
+      "bin": [
+        "uv-x86_64-unknown-linux-musl/uv",
+        "uv-x86_64-unknown-linux-musl/uvx"
+      ]
     },
     "x86_64_macos": {
       "url": "https://github.com/astral-sh/uv/releases/download/${version}/uv-x86_64-apple-darwin.tar.gz",
-      "bin": "uv-x86_64-apple-darwin/uv"
+      "bin": [
+        "uv-x86_64-apple-darwin/uv",
+        "uv-x86_64-apple-darwin/uvx"
+      ]
     },
     "x86_64_windows": {
       "url": "https://github.com/astral-sh/uv/releases/download/${version}/uv-x86_64-pc-windows-msvc.zip",
-      "bin": "uv.exe"
+      "bin": [
+        "uv.exe",
+        "uvw.exe",
+        "uvx.exe"
+      ]
     },
     "aarch64_linux_musl": {
       "url": "https://github.com/astral-sh/uv/releases/download/${version}/uv-aarch64-unknown-linux-musl.tar.gz",
-      "bin": "uv-aarch64-unknown-linux-musl/uv"
+      "bin": [
+        "uv-aarch64-unknown-linux-musl/uv",
+        "uv-aarch64-unknown-linux-musl/uvx"
+      ]
     },
     "aarch64_macos": {
       "url": "https://github.com/astral-sh/uv/releases/download/${version}/uv-aarch64-apple-darwin.tar.gz",
-      "bin": "uv-aarch64-apple-darwin/uv"
+      "bin": [
+        "uv-aarch64-apple-darwin/uv",
+        "uv-aarch64-apple-darwin/uvx"
+      ]
     },
     "aarch64_windows": {
       "url": "https://github.com/astral-sh/uv/releases/download/${version}/uv-aarch64-pc-windows-msvc.zip",
-      "bin": "uv.exe"
+      "bin": [
+        "uv.exe",
+        "uvw.exe",
+        "uvx.exe"
+      ]
     },
     "powerpc64le_linux_gnu": {
       "url": "https://github.com/astral-sh/uv/releases/download/${version}/uv-powerpc64le-unknown-linux-gnu.tar.gz",
-      "bin": "uv-powerpc64le-unknown-linux-gnu/uv"
+      "bin": [
+        "uv-powerpc64le-unknown-linux-gnu/uv",
+        "uv-powerpc64le-unknown-linux-gnu/uvx"
+      ]
     },
     "riscv64_linux_gnu": {
       "url": "https://github.com/astral-sh/uv/releases/download/${version}/uv-riscv64gc-unknown-linux-gnu.tar.gz",
-      "bin": "uv-riscv64gc-unknown-linux-gnu/uv"
+      "bin": [
+        "uv-riscv64gc-unknown-linux-gnu/uv",
+        "uv-riscv64gc-unknown-linux-gnu/uvx"
+      ]
     },
     "s390x_linux_gnu": {
       "url": "https://github.com/astral-sh/uv/releases/download/${version}/uv-s390x-unknown-linux-gnu.tar.gz",
-      "bin": "uv-s390x-unknown-linux-gnu/uv"
+      "bin": [
+        "uv-s390x-unknown-linux-gnu/uv",
+        "uv-s390x-unknown-linux-gnu/uvx"
+      ]
     }
   },
   "license_markdown": "[Apache-2.0](https://github.com/astral-sh/uv/blob/main/LICENSE-APACHE) OR [MIT](https://github.com/astral-sh/uv/blob/main/LICENSE-MIT)",

--- a/tools/codegen/base/uv.json
+++ b/tools/codegen/base/uv.json
@@ -2,6 +2,7 @@
   "repository": "https://github.com/astral-sh/uv",
   "license_markdown": "[Apache-2.0](https://github.com/astral-sh/uv/blob/main/LICENSE-APACHE) OR [MIT](https://github.com/astral-sh/uv/blob/main/LICENSE-MIT)",
   "tag_prefix": "",
+  "rust_crate": "${package}",
   "version_range": ">= 0.8.16",
   "signing": {
     "version_range": ">= 0.9.13",
@@ -11,42 +12,26 @@
       }
     }
   },
+  "asset_name": "${package}-${rust_target}.tar.gz",
+  "bin": [
+    "${package}-${rust_target}/${package}${exe}",
+    "${package}-${rust_target}/${package}x${exe}"
+  ],
   "platform": {
-    "x86_64_linux_musl": {
-      "asset_name": "${package}-x86_64-unknown-linux-musl.tar.gz",
-      "bin": "${package}-x86_64-unknown-linux-musl/${package}${exe}"
-    },
-    "x86_64_macos": {
-      "asset_name": "${package}-x86_64-apple-darwin.tar.gz",
-      "bin": "${package}-x86_64-apple-darwin/${package}${exe}"
-    },
+    "x86_64_linux_musl": {},
+    "x86_64_macos": {},
     "x86_64_windows": {
-      "asset_name": "${package}-x86_64-pc-windows-msvc.zip",
-      "bin": "${package}${exe}"
+      "asset_name": "${package}-${rust_target}.zip",
+      "bin": ["${package}${exe}", "${package}w${exe}", "${package}x${exe}"]
     },
-    "aarch64_linux_musl": {
-      "asset_name": "${package}-aarch64-unknown-linux-musl.tar.gz",
-      "bin": "${package}-aarch64-unknown-linux-musl/${package}${exe}"
-    },
-    "aarch64_macos": {
-      "asset_name": "${package}-aarch64-apple-darwin.tar.gz",
-      "bin": "${package}-aarch64-apple-darwin/${package}${exe}"
-    },
+    "aarch64_linux_musl": {},
+    "aarch64_macos": {},
     "aarch64_windows": {
-      "asset_name": "${package}-aarch64-pc-windows-msvc.zip",
-      "bin": "${package}${exe}"
+      "asset_name": "${package}-${rust_target}.zip",
+      "bin": ["${package}${exe}", "${package}w${exe}", "${package}x${exe}"]
     },
-    "powerpc64le_linux_gnu": {
-      "asset_name": "${package}-powerpc64le-unknown-linux-gnu.tar.gz",
-      "bin": "${package}-powerpc64le-unknown-linux-gnu/${package}${exe}"
-    },
-    "riscv64_linux_gnu": {
-      "asset_name": "${package}-riscv64gc-unknown-linux-gnu.tar.gz",
-      "bin": "${package}-riscv64gc-unknown-linux-gnu/${package}${exe}"
-    },
-    "s390x_linux_gnu": {
-      "asset_name": "${package}-s390x-unknown-linux-gnu.tar.gz",
-      "bin": "${package}-s390x-unknown-linux-gnu/${package}${exe}"
-    }
+    "powerpc64le_linux_gnu": {},
+    "riscv64_linux_gnu": {},
+    "s390x_linux_gnu": {}
   }
 }


### PR DESCRIPTION
 Install `uv`, `uvw` (Windows-only), and `uvx` binaries when installing `uv`. Previously, only `uv` binary was installed.