### PR TITLE
Call main.sh from powershell on Windows to work around windows-11-arm runner bug

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,8 +45,25 @@ runs:
     - run: bash --noprofile --norc "${GITHUB_ACTION_PATH:?}/main.sh"
       shell: bash
       env:
+        # NB: Sync with non-Windows case.
         INPUT_TOOL: ${{ inputs.tool }}
         INPUT_CHECKSUM: ${{ inputs.checksum }}
         INPUT_FALLBACK: ${{ inputs.fallback }}
         DEFAULT_GITHUB_TOKEN: ${{ github.token }}
         ACTION_USER_AGENT: ${{ github.action_repository }} (${{ github.action_ref }})
+      if: runner.os != 'Windows'
+    # Workaround for https://github.com/actions/partner-runner-images/issues/169
+    # TODO: Is it necessary to retry for main.sh call? Or is this sufficient? https://github.com/taiki-e/install-action/pull/1647
+    - run: |
+        Set-StrictMode -Version Latest
+        $action_path = $env:GITHUB_ACTION_PATH
+        & bash --noprofile --norc "${action_path}/main.sh"
+      shell: powershell
+      env:
+        # NB: Sync with non-Windows case.
+        INPUT_TOOL: ${{ inputs.tool }}
+        INPUT_CHECKSUM: ${{ inputs.checksum }}
+        INPUT_FALLBACK: ${{ inputs.fallback }}
+        DEFAULT_GITHUB_TOKEN: ${{ github.token }}
+        ACTION_USER_AGENT: ${{ github.action_repository }} (${{ github.action_ref }})
+      if: runner.os == 'Windows'


### PR DESCRIPTION
Workaround for windows-11-arm runner bug: https://github.com/actions/partner-runner-images/issues/169.
Fixes #1645
Fixes #1562
Fixes #1472

The issue appears to be bash sometimes failing to start either due to how GHA launches bash or regardless of who to launch bash.

In the former case, just calling bash from powershell should be sufficient (as currently implemented in this PR); in the latter case, I think it would be sufficient to add a way to detect whether bash failed to start (such as creating and checking a temporary file) and then retry a few times.

I haven't encountered this issue in my repositories yet, so it's difficult for me to test whether the former approach is sufficient. (For now, I plan to continually rerun the tests using the windows-11-arm runner in this PR.)

I would appreciate it if anyone who has encountered this issue could help with testing.
cc @wmmc88 @nazar-pc @NobodyXu @deivid-rodriguez

