### PR TITLE
Revert "Update `cargo-binstall@latest` to 1.19.0"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,6 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
-- Update `cargo-binstall@latest` to 1.19.0.
-
 - Update `cargo-deb@latest` to 3.7.0.
 
 - Update `tombi@latest` to 0.10.2.

--- a/manifests/cargo-binstall.json
+++ b/manifests/cargo-binstall.json
@@ -21,32 +21,32 @@
     }
   },
   "latest": {
-    "version": "1.19.0"
+    "version": "1.18.1"
   },
-  "1.19.0": {
+  "1.18.1": {
     "x86_64_linux_musl": {
-      "etag": "0x8DEA8CE73C60C6A",
-      "hash": "a7a4271099ce891368bc544d3f89315f12547df653ba16de2030461e8867edd6"
+      "etag": "0x8DE9959D5E8FE78",
+      "hash": "cf2a4b54494ea8555d6349685e9a301efc1051d9fba6308c76914b2486f8700f"
     },
     "x86_64_macos": {
-      "etag": "0x8DEA8CE788A1BF8",
-      "hash": "289007dce39f181188b620c19783d3a0e8f37fb9e5d7c3ff1da9cfb9a2d8ecc3"
+      "etag": "0x8DE9959DBCBBA2C",
+      "hash": "e06370bec7143668653bb7c09d0b8b689fc703dd4fa58ec5847c4b571d8a490d"
     },
     "x86_64_windows": {
-      "etag": "0x8DEA8CE770C7D2D",
-      "hash": "1113c92eb53160c4e0c12dc803f582a266d26b26ca529520e104806cce8d0204"
+      "etag": "0x8DE9959D9E5BCF3",
+      "hash": "89706aa5215c164d8d091597a470fee72308ac87e8553af395ea77db844a888c"
     },
     "aarch64_linux_musl": {
-      "etag": "0x8DEA8CE816D40A0",
-      "hash": "57148539e6160789715745e6f50e0aac9193636df42bd9b4554cd9012195866c"
+      "etag": "0x8DE9959E60E685D",
+      "hash": "c55962a0115f9716b709216de7f8bdd59d6ba8738779e60b051b4593f677717a"
     },
     "aarch64_macos": {
-      "etag": "0x8DEA8CE874671AF",
-      "hash": "1208282e0719ae33fc1db20fe533a50827673d017fb85ed5dec0cb9b0c7ca569"
+      "etag": "0x8DE9959ED2C11A4",
+      "hash": "955abf167994c90f3547e233edace4c0f794465dd4aa408249b38999aa5ca3cf"
     },
     "aarch64_windows": {
-      "etag": "0x8DEA8CE8531F522",
-      "hash": "7ac3f11af34e014145999a970a32fb8b204c593f0b339d05015baa98cd9fb4ea"
+      "etag": "0x8DE9959EAAC5732",
+      "hash": "c6873e81457d9e44973a8e9a849795f2c83765fce0af8ad68b597b5b40dec418"
     }
   }
 }

--- a/tools/codegen/base/cargo-binstall.json
+++ b/tools/codegen/base/cargo-binstall.json
@@ -4,7 +4,7 @@
   "tag_prefix": "v",
   "rust_crate": "${package}",
   "asset_name": "${package}-${rust_target}.zip",
-  "version_range": "latest",
+  "version_range": "=1.18.1",
   "signing": {
     "kind": "minisign-binstall"
   },

--- a/tools/codegen/src/main.rs
+++ b/tools/codegen/src/main.rs
@@ -129,7 +129,9 @@ fn main() {
 
     let mut latest_only = false;
     if let Some(version_range) = &base_info.version_range {
-        if version_range == "latest" {
+        if version_range == "latest"
+            || version_range.starts_with('=') && !version_range.contains(',')
+        {
             latest_only = true;
         }
     }
@@ -171,13 +173,20 @@ fn main() {
 
     let version_req: semver::VersionReq = match version_req {
         _ if latest_only => {
-            // Exclude very recently released version from candidate for latest version.
-            let req =
-                format!("={}", releases.iter().find(|r| r.1.1.published_at <= before).unwrap().0.0)
-                    .parse()
-                    .unwrap();
-            eprintln!("update manifest for versions '{req}'");
-            req
+            let version_range = base_info.version_range.as_ref().unwrap();
+            if version_range == "latest" {
+                // Exclude very recently released version from candidate for latest version.
+                let req = format!(
+                    "={}",
+                    releases.iter().find(|r| r.1.1.published_at <= before).unwrap().0.0
+                )
+                .parse()
+                .unwrap();
+                eprintln!("update manifest for versions '{req}'");
+                req
+            } else {
+                version_range.parse().unwrap()
+            }
         }
         None => match base_info.version_range {
             Some(version_range) => version_range.parse().unwrap(),


### PR DESCRIPTION
This reverts unreleased commit https://github.com/taiki-e/install-action/commit/4976db38623e99a8f71d5bb48a3ff2071a6a3ccd (taiki-e/install-action#1777).

Since 1.19.0, cargo-binstall fails to install prebuilt binary on Windows.

before taiki-e/install-action#1777: 2m19s https://github.com/taiki-e/install-action/actions/runs/25299305975/job/74163342253
after taiki-e/install-action#1777: 24m12s https://github.com/taiki-e/install-action/actions/runs/25306107410/job/74182317433
after revert: 2m18s https://github.com/taiki-e/install-action/actions/runs/25315683032/job/74212565628?pr=1778

```
info: install-action does not support cargo-watch,watchexec-cli; fallback to cargo-binstall
info: cargo-binstall already installed at /c/Users/runneradmin/.cargo/bin/cargo-binstall.exe
 INFO resolve: Resolving package: 'cargo-watch'
 WARN resolve: Timeout reached while checking fetcher invalid url: deadline has elapsed
 WARN resolve: Timeout reached while checking fetcher invalid url: deadline has elapsed
 WARN resolve: Timeout reached while checking fetcher invalid url: deadline has elapsed
 WARN resolve: Timeout reached while checking fetcher invalid url: deadline has elapsed
 WARN resolve: Timeout reached while checking fetcher invalid url: deadline has elapsed
 WARN resolve: Timeout reached while checking fetcher invalid url: deadline has elapsed
 WARN resolve: Timeout reached while checking fetcher invalid url: deadline has elapsed
 WARN resolve: Timeout reached while checking fetcher invalid url: deadline has elapsed
 WARN resolve: Timeout reached while checking fetcher invalid url: deadline has elapsed
 WARN resolve: Timeout reached while checking fetcher QuickInstall: deadline has elapsed
 WARN resolve: Timeout reached while checking fetcher QuickInstall: deadline has elapsed
 WARN resolve: Timeout reached while checking fetcher QuickInstall: deadline has elapsed
 WARN resolve: Timeout reached while checking fetcher QuickInstall: deadline has elapsed
 WARN resolve: Timeout reached while checking fetcher QuickInstall: deadline has elapsed
 WARN resolve: Timeout reached while checking fetcher QuickInstall: deadline has elapsed
 WARN resolve: Timeout reached while checking fetcher QuickInstall: deadline has elapsed
 WARN resolve: Timeout reached while checking fetcher QuickInstall: deadline has elapsed
 WARN resolve: Timeout reached while checking fetcher QuickInstall: deadline has elapsed
ERROR Fatal error:
  × For crate cargo-watch: Fallback to cargo-install is disabled
  ╰─▶ Fallback to cargo-install is disabled
```