### PR TITLE
Update `convco` to 0.7.0

### DIFF
--- a/manifests/convco.json
+++ b/manifests/convco.json
@@ -1,45 +1,65 @@
 {
   "rust_crate": "convco",
-  "template": {
+  "template": null,
+  "latest": {
+    "version": "0.7.0"
+  },
+  "0.7": {
+    "version": "0.7.0"
+  },
+  "0.7.0": {
     "x86_64_linux_musl": {
-      "url": "https://github.com/convco/convco/releases/download/v${version}/convco-ubuntu.zip",
-      "bin": "convco"
+      "url": "https://github.com/convco/convco/releases/download/v0.7.0/convco-v0.7.0-x86_64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DEDD2ACCEC0640",
+      "hash": "37a21cb2e88e418f35068db77b3255f88a153ddcea42395dc91004ee1460c2db",
+      "bin": "convco-v0.7.0-x86_64-unknown-linux-musl/convco"
     },
     "x86_64_windows": {
-      "url": "https://github.com/convco/convco/releases/download/v${version}/convco-windows.zip",
-      "bin": "convco.exe"
+      "url": "https://github.com/convco/convco/releases/download/v0.7.0/convco-v0.7.0-x86_64-pc-windows-msvc.tar.gz",
+      "etag": "0x8DEDD2ACC7BE938",
+      "hash": "22429240e0c41d7d151fe9d8c2e26ab1cf87b50a31ab3ecebc4689d48f159213",
+      "bin": "convco-v0.7.0-x86_64-pc-windows-msvc/convco.exe"
     },
     "aarch64_linux_musl": {
-      "url": "https://github.com/convco/convco/releases/download/v${version}/convco-ubuntu-aarch64.zip",
-      "bin": "convco"
+      "url": "https://github.com/convco/convco/releases/download/v0.7.0/convco-v0.7.0-aarch64-unknown-linux-musl.tar.gz",
+      "etag": "0x8DEDD2ACC04EF54",
+      "hash": "b2356c8a5d3c383948f6eeb3017dea68d7140bc26a9f306d79d9a9591125dd8c",
+      "bin": "convco-v0.7.0-aarch64-unknown-linux-musl/convco"
     },
     "aarch64_macos": {
-      "url": "https://github.com/convco/convco/releases/download/v${version}/convco-macos.zip",
-      "bin": "convco"
+      "url": "https://github.com/convco/convco/releases/download/v0.7.0/convco-v0.7.0-aarch64-apple-darwin.tar.gz",
+      "etag": "0x8DEDD2ACC097E12",
+      "hash": "eabfac4390a4ab8e254b429384d3595b7e4917bcb6b5371a96844e80e74b89d7",
+      "bin": "convco-v0.7.0-aarch64-apple-darwin/convco"
     }
-  },
-  "latest": {
-    "version": "0.6.4"
   },
   "0.6": {
     "version": "0.6.4"
   },
   "0.6.4": {
     "x86_64_linux_musl": {
+      "url": "https://github.com/convco/convco/releases/download/v0.6.4/convco-ubuntu.zip",
       "etag": "0x8DEB96EA68FD07C",
-      "hash": "d6e43a1975949ef05d31bb1ac64fdd7c2dbc18b0b65df075c16dc296b8153be7"
+      "hash": "d6e43a1975949ef05d31bb1ac64fdd7c2dbc18b0b65df075c16dc296b8153be7",
+      "bin": "convco"
     },
     "x86_64_windows": {
+      "url": "https://github.com/convco/convco/releases/download/v0.6.4/convco-windows.zip",
       "etag": "0x8DEB96EA51CABCF",
-      "hash": "268f1c80abcb2cdc31174984a0a824f06705b5f62485e780f04008c5765219bd"
+      "hash": "268f1c80abcb2cdc31174984a0a824f06705b5f62485e780f04008c5765219bd",
+      "bin": "convco.exe"
     },
     "aarch64_linux_musl": {
+      "url": "https://github.com/convco/convco/releases/download/v0.6.4/convco-ubuntu-aarch64.zip",
       "etag": "0x8DEB96EA5E3148D",
-      "hash": "1e626914c90cf60314a8ef50d97566ebabb0ad5daf405fa7e4ca3193df1c73c3"
+      "hash": "1e626914c90cf60314a8ef50d97566ebabb0ad5daf405fa7e4ca3193df1c73c3",
+      "bin": "convco"
     },
     "aarch64_macos": {
+      "url": "https://github.com/convco/convco/releases/download/v0.6.4/convco-macos.zip",
       "etag": "0x8DEB96EA769D246",
-      "hash": "88901e63aa26b601b6726bff8e05cab89d16ebcb772f719bad431a40b12caa54"
+      "hash": "88901e63aa26b601b6726bff8e05cab89d16ebcb772f719bad431a40b12caa54",
+      "bin": "convco"
     }
   }
 }

--- a/tools/codegen/base/convco.json
+++ b/tools/codegen/base/convco.json
@@ -3,23 +3,23 @@
   "license_markdown": "[MIT](https://github.com/convco/convco/blob/main/LICENSE)",
   "tag_prefix": "v",
   "rust_crate": "${package}",
-  "version_range": ">= 0.6.4",
+  "version_range": ">= 0.7.0",
   "platform": {
     "x86_64_linux_musl": {
-      "asset_name": "${package}-ubuntu.zip",
-      "bin": "${package}"
+      "asset_name": "${package}-v${version}-x86_64-unknown-linux-musl.tar.gz",
+      "bin": "${package}-v${version}-x86_64-unknown-linux-musl/${package}"
     },
     "x86_64_windows": {
-      "asset_name": "${package}-windows.zip",
-      "bin": "${package}.exe"
+      "asset_name": "${package}-v${version}-x86_64-pc-windows-msvc.tar.gz",
+      "bin": "${package}-v${version}-x86_64-pc-windows-msvc/${package}.exe"
     },
     "aarch64_linux_musl": {
-      "asset_name": "${package}-ubuntu-aarch64.zip",
-      "bin": "${package}"
+      "asset_name": "${package}-v${version}-aarch64-unknown-linux-musl.tar.gz",
+      "bin": "${package}-v${version}-aarch64-unknown-linux-musl/${package}"
     },
     "aarch64_macos": {
-      "asset_name": "${package}-macos.zip",
-      "bin": "${package}"
+      "asset_name": "${package}-v${version}-aarch64-apple-darwin.tar.gz",
+      "bin": "${package}-v${version}-aarch64-apple-darwin/${package}"
     }
   }
 }


### PR DESCRIPTION
Hi,

Convco 0.7.0 was released this week, with a new naming scheme for the release binaries, and a new file layout for each (binary in versioned dir).

Here's the updated manifest.

Cheers