### PR TITLE
Fix oxfmt installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Fix an issue where `oxfmt` was　accidentally installed as `oxfmt-{target}{exe}`. ([#1969](https://github.com/taiki-e/install-action/pull/1969))
+
 ## [2.86.0] - 2026-08-15
 
 - Support `oxfmt`. ([#1967](https://github.com/taiki-e/install-action/pull/1967), thanks @rami3l)

--- a/main.sh
+++ b/main.sh
@@ -95,8 +95,8 @@ download_and_extract() {
   case "${tool}" in
     # xbuild's binary name is "x", as opposed to the usual crate name
     xbuild) installed_bin=("${bin_dir}/x${exe}") ;;
-    # editorconfig-checker's binary name is renamed below
-    editorconfig-checker) installed_bin=("${bin_dir}/${tool}${exe}") ;;
+    # Their binary names are renamed below.
+    editorconfig-checker | oxfmt) installed_bin=("${bin_dir}/${tool}${exe}") ;;
     *)
       for tmp in "${bin_in_archive[@]}"; do
         installed_bin+=("${bin_dir}/$(basename -- "${tmp}")")
@@ -205,7 +205,7 @@ download_and_extract() {
       esac
       for tmp in "${bin_in_archive[@]}"; do
         case "${tool}" in
-          editorconfig-checker) mv -- "${tmp}" "${bin_dir}/${tool}${exe}" ;;
+          editorconfig-checker | oxfmt) mv -- "${tmp}" "${bin_dir}/${tool}${exe}" ;;
           *) mv -- "${tmp}" "${bin_dir}/" ;;
         esac
       done
@@ -215,7 +215,7 @@ download_and_extract() {
           unzip -q tmp
           for tmp in "${bin_in_archive[@]}"; do
             case "${tool}" in
-              editorconfig-checker) mv -- "${tmp}" "${bin_dir}/${tool}${exe}" ;;
+              editorconfig-checker | oxfmt) mv -- "${tmp}" "${bin_dir}/${tool}${exe}" ;;
               *) mv -- "${tmp}" "${bin_dir}/" ;;
             esac
           done


### PR DESCRIPTION
https://github.com/taiki-e/install-action/pull/1967#issuecomment-5303469886

Before:
```
  info: installing oxfmt@latest
  info: downloading https://github.com/oxc-project/oxc/releases/download/apps_v1.78.0/oxfmt-x86_64-unknown-linux-musl.tar.gz
  info: verifying sha256 checksum for oxfmt-x86_64-unknown-linux-musl.tar.gz
  info: oxfmt-x86_64-unknown-linux-musl installed at /home/runner/.install-action/bin/oxfmt-x86_64-unknown-linux-musl
  + oxfmt-x86_64-unknown-linux-musl --version
  Version: 0.63.0
```

After:
```
  info: installing oxfmt@latest
  info: downloading https://github.com/oxc-project/oxc/releases/download/apps_v1.78.0/oxfmt-x86_64-unknown-linux-musl.tar.gz
  info: verifying sha256 checksum for oxfmt-x86_64-unknown-linux-musl.tar.gz
  info: oxfmt installed at /home/runner/.install-action/bin/oxfmt
  + oxfmt --version
  Version: 0.63.0
```